### PR TITLE
Fix/data analytics redesign

### DIFF
--- a/coresdk/src/coresdk/data_frame.cpp
+++ b/coresdk/src/coresdk/data_frame.cpp
@@ -1,0 +1,152 @@
+#include <iostream>
+#include <stdexcept>
+
+#include "data_frame.h"
+
+namespace splashkit_lib
+{
+    struct _data_frame_data
+    {
+        std::vector<std::vector<data_element>> data;    // Data frame data, data[i][j] = col i row j
+        std::vector<std::string> col_names;             // Name of each of the columns in the data frame
+    };
+
+    data_frame create_data_frame()
+    {
+        data_frame df = new _data_frame_data();
+        return df;
+    }
+
+    int num_rows(data_frame &df)
+    {
+        if (num_cols(df) == 0)
+            return 0;
+        return df->data[0].size();
+    }
+
+    int num_cols(data_frame &df)
+    {
+        return df->col_names.size();
+    }
+
+    void display(data_frame &df)
+    {
+        // Display column names
+        for (std::string col_name : df->col_names)
+            std::cout << col_name << '\t';
+        std::cout << std::endl;
+
+        // Display data
+        for (int row = 0; row < num_rows(df); row++)
+            display_row(df, row);
+    }
+
+    std::vector<data_element> get_col(data_frame &df, int idx)
+    {
+        return df->data[idx];
+    }
+
+    std::vector<data_element> get_row(data_frame &df, int idx)
+    {
+        std::vector<data_element> row;
+        for (int col = 0; col < num_cols(df); col++)
+            row.push_back(df->data[col][idx]);
+        return row;
+    }
+
+    data_element get_cell(data_frame &df, int row, int col)
+    {
+        return df->data[col][row];
+    }
+
+    void append_col(data_frame &df, std::vector<data_element> &data, std::string col_name)
+    {
+        insert_col(df, num_cols(df), data, col_name);
+    }
+
+    void append_row(data_frame &df, std::vector<data_element> &data)
+    {
+        insert_row(df, num_rows(df), data);
+    }
+
+    void insert_col(data_frame &df, int idx, std::vector<data_element> &data, std::string col_name)
+    {
+        // Validate column length
+        if (num_cols(df) != 0 && data.size() != num_rows(df))
+            throw std::runtime_error("Number of rows in the inserted column (" + std::to_string(data.size()) + ") does not match the number of rows in the data frame (" + std::to_string(num_rows(df)) + ")");
+
+        // Validate same type within column
+        for (int row = 1; row < data.size(); row++)
+            if (data[row].index() != data[row-1].index())
+                throw std::runtime_error("Not all data elements in the inserted column are the same type");
+
+        // Insert
+        df->col_names.insert(df->col_names.begin() + idx, col_name);
+        df->data.insert(df->data.begin() + idx, data);
+    }
+
+    void insert_row(data_frame &df, int idx, std::vector<data_element> &data)
+    {
+        // Validate row length
+        if (data.size() != num_cols(df))
+            throw std::runtime_error("Number of columns in the inserted row (" + std::to_string(data.size()) + ") does not match the number of columns in the data frame (" + std::to_string(num_cols(df)) + ")");
+
+        // Validate elements match column types
+        if (num_rows(df) != 0)
+            for (int col = 0; col < num_cols(df); col++)
+                if (data[col].index() != df->data[col][0].index())
+                    throw std::runtime_error("Not all data elements in the inserted row match the type of their respective column");
+
+        // Insert
+        for (int col = 0; col < num_cols(df); col++)
+            df->data[col].insert(df->data[col].begin() + idx, data[col]);
+    }
+
+    std::vector<data_element> delete_col(data_frame &df, int idx)
+    {
+        std::vector<data_element> col = get_col(df, idx);
+        df->data.erase(df->data.begin() + idx);
+        return col;
+    }
+
+    std::vector<data_element> delete_row(data_frame &df, int idx)
+    {
+        std::vector<data_element> row = get_row(df, idx);
+        for (int col = 0; col < num_cols(df); col++)
+            df->data[col].erase(df->data[col].begin() + idx);
+        return row;
+    }
+
+    /**
+     * Allows data elements to be printed
+     *
+     * @param stream            Output stream to print to
+     * @param data              data element to print
+     * @return std::ostream&    Output stream to print to
+     */
+    std::ostream &operator << (std::ostream &stream, data_element &data)
+    {
+        std::visit([&stream](auto&& d) { stream << d; }, data);
+        return stream;
+    }
+
+    void display_row(data_frame &df, int idx)
+    {
+        for (data_element cell : get_row(df, idx))
+            std::cout << cell << '\t';
+        std::cout << std::endl;
+    }
+
+    void display_col(data_frame &df, int idx)
+    {
+        for (data_element cell : get_col(df, idx))
+            std::cout << cell << '\n';
+    }
+
+    data_frame read_csv(std::string filepath, char sep, char line_break, bool header)
+    {
+        // TODO
+        data_frame df = new _data_frame_data();
+        return df;
+    }
+}

--- a/coresdk/src/coresdk/data_frame.cpp
+++ b/coresdk/src/coresdk/data_frame.cpp
@@ -29,18 +29,6 @@ namespace splashkit_lib
         return df->col_names.size();
     }
 
-    void display(data_frame &df)
-    {
-        // Display column names
-        for (std::string col_name : df->col_names)
-            std::cout << col_name << '\t';
-        std::cout << std::endl;
-
-        // Display data
-        for (int row = 0; row < num_rows(df); row++)
-            display_row(df, row);
-    }
-
     std::vector<data_element> get_col(data_frame &df, int idx)
     {
         return df->data[idx];
@@ -128,6 +116,18 @@ namespace splashkit_lib
     {
         std::visit([&stream](auto&& d) { stream << d; }, data);
         return stream;
+    }
+
+    void display(data_frame &df)
+    {
+        // Display column names
+        for (std::string col_name : df->col_names)
+            std::cout << col_name << '\t';
+        std::cout << std::endl;
+
+        // Display data
+        for (int row = 0; row < num_rows(df); row++)
+            display_row(df, row);
     }
 
     void display_row(data_frame &df, int idx)

--- a/coresdk/src/coresdk/data_frame.cpp
+++ b/coresdk/src/coresdk/data_frame.cpp
@@ -31,11 +31,13 @@ namespace splashkit_lib
 
     std::vector<data_element> get_col(data_frame &df, int idx)
     {
+        validate_col(df, idx);
         return df->data[idx];
     }
 
     std::vector<data_element> get_row(data_frame &df, int idx)
     {
+        validate_row(df, idx);
         std::vector<data_element> row;
         for (int col = 0; col < num_cols(df); col++)
             row.push_back(df->data[col][idx]);
@@ -44,6 +46,8 @@ namespace splashkit_lib
 
     data_element get_cell(data_frame &df, int row, int col)
     {
+        validate_row(df, row);
+        validate_col(df, col);
         return df->data[col][row];
     }
 
@@ -61,12 +65,12 @@ namespace splashkit_lib
     {
         // Validate column length
         if (num_cols(df) != 0 && data.size() != num_rows(df))
-            throw std::runtime_error("Number of rows in the inserted column (" + std::to_string(data.size()) + ") does not match the number of rows in the data frame (" + std::to_string(num_rows(df)) + ")");
+            throw std::invalid_argument("Number of rows in the inserted column (" + std::to_string(data.size()) + ") does not match the number of rows in the data frame (" + std::to_string(num_rows(df)) + ")");
 
         // Validate same type within column
         for (int row = 1; row < data.size(); row++)
             if (data[row].index() != data[row-1].index())
-                throw std::runtime_error("Not all data elements in the inserted column are the same type");
+                throw std::invalid_argument("Not all data elements in the inserted column are the same type");
 
         // Insert
         df->col_names.insert(df->col_names.begin() + idx, col_name);
@@ -77,13 +81,13 @@ namespace splashkit_lib
     {
         // Validate row length
         if (data.size() != num_cols(df))
-            throw std::runtime_error("Number of columns in the inserted row (" + std::to_string(data.size()) + ") does not match the number of columns in the data frame (" + std::to_string(num_cols(df)) + ")");
+            throw std::invalid_argument("Number of columns in the inserted row (" + std::to_string(data.size()) + ") does not match the number of columns in the data frame (" + std::to_string(num_cols(df)) + ")");
 
         // Validate elements match column types
         if (num_rows(df) != 0)
             for (int col = 0; col < num_cols(df); col++)
                 if (data[col].index() != df->data[col][0].index())
-                    throw std::runtime_error("Not all data elements in the inserted row match the type of their respective column");
+                    throw std::invalid_argument("Not all data elements in the inserted row match the type of their respective column");
 
         // Insert
         for (int col = 0; col < num_cols(df); col++)
@@ -105,15 +109,9 @@ namespace splashkit_lib
         return row;
     }
 
-    /**
-     * Allows data elements to be printed
-     *
-     * @param stream            Output stream to print to
-     * @param data              data element to print
-     * @return std::ostream&    Output stream to print to
-     */
     std::ostream &operator << (std::ostream &stream, data_element &data)
     {
+        // Print underlying value of a data_element
         std::visit([&stream](auto&& d) { stream << d; }, data);
         return stream;
     }
@@ -148,5 +146,17 @@ namespace splashkit_lib
         // TODO
         data_frame df = new _data_frame_data();
         return df;
+    }
+
+    void validate_col(data_frame &df, int idx)
+    {
+        if (idx < 0 || idx >= num_cols(df))
+            throw std::out_of_range("column " + std::to_string(idx) + " is out of range");
+    }
+
+    void validate_row(data_frame &df, int idx)
+    {
+        if (idx < 0 || idx >= num_rows(df))
+            throw std::out_of_range("row " + std::to_string(idx) + " is out of range");
     }
 }

--- a/coresdk/src/coresdk/data_frame.h
+++ b/coresdk/src/coresdk/data_frame.h
@@ -128,6 +128,15 @@ namespace splashkit_lib
     std::vector<data_element> delete_row(data_frame &df, int idx);
 
     /**
+     * Allows data elements to be printed
+     *
+     * @param stream            Output stream to print to
+     * @param data              data element to print
+     * @return std::ostream&    Output stream to print to
+     */
+    std::ostream &operator << (std::ostream &stream, data_element &data);
+
+    /**
      * Displays the contents of a data frame in the console.
      *
      * @param df    The data frame to display.
@@ -160,6 +169,22 @@ namespace splashkit_lib
      * @return data_frame   The new data frame containing the file's data.
      */
     data_frame read_csv(std::string filepath, char sep = ',', char line_break = '\n', bool header = true);
+
+    /**
+     * Raises an out_of_range exception if an invalid column index is requested.
+     *
+     * @param df    The data frame
+     * @param idx   Index of the column
+     */
+    void validate_col(data_frame &df, int idx);
+
+    /**
+     * Raises an out_of_range exception if an invalid row index is requested.
+     *
+     * @param df    The data frame
+     * @param idx   Index of the row
+     */
+    void validate_row(data_frame &df, int idx);
 }
 
 #endif

--- a/coresdk/src/coresdk/data_frame.h
+++ b/coresdk/src/coresdk/data_frame.h
@@ -1,0 +1,72 @@
+#ifndef data_frame_h
+#define data_frame_h
+
+#include <vector>
+#include <variant>
+
+namespace splashkit_lib
+{
+    /**
+     * A data element is an element that can be stored in the cell of a
+     * data frame. Its type must be one of the variant types listed in the
+     * signature below.
+     */
+    typedef std::variant<std::string,int,float,bool,char> data_element;
+
+    /**
+     * Data frames contain a table of information about a data set. Data
+     * from csv or text files can be loaded into a data frame to perform
+     * data analysis with.
+     *
+     * @attribute class data_frame
+     */
+    typedef struct _data_frame_data *data_frame;
+
+    data_frame create_data_frame();
+
+    int num_rows(data_frame &df);
+
+    int num_cols(data_frame &df);
+
+    std::vector<data_element> get_col(data_frame &df, int idx);
+
+    std::vector<data_element> get_row(data_frame &df, int idx);
+
+    data_element get_cell(data_frame &df, int row, int col);
+
+    void append_col(data_frame &df, std::vector<data_element> &data, std::string col_name);
+
+    void append_row(data_frame &df, std::vector<data_element> &data);
+
+    void insert_col(data_frame &df, int idx, std::vector<data_element> &data, std::string col_name);
+
+    void insert_row(data_frame &df, int idx, std::vector<data_element> &data);
+
+    std::vector<data_element> delete_col(data_frame &df, int idx);
+
+    std::vector<data_element> delete_row(data_frame &df, int idx);
+
+    /**
+     * Displays the contents of a data frame in the console.
+     *
+     * @param df    The data frame to display.
+     */
+    void display(data_frame &df);
+
+    void display_row(data_frame &df, int idx);
+
+    void display_col(data_frame &df, int idx);
+
+    /**
+     * Reads the content of a csv or text file and stores it in a data frame.
+     *
+     * @param filepath      The path to the csv or text file.
+     * @param sep           The character used to separate elements in the file, by default ','.
+     * @param line_break    The character used to separate rows in the file, by default '\\n'.
+     * @param header        Whether or not row 0 in the file containers the column names.
+     * @return data_frame   The new data frame containing the file's data.
+     */
+    data_frame read_csv(std::string filepath, char sep = ',', char line_break = '\n', bool header = true);
+}
+
+#endif

--- a/coresdk/src/coresdk/data_frame.h
+++ b/coresdk/src/coresdk/data_frame.h
@@ -22,28 +22,109 @@ namespace splashkit_lib
      */
     typedef struct _data_frame_data *data_frame;
 
+    /**
+     * Creates a new data frame object
+     *
+     * @return data_frame   The new data frame object
+     */
     data_frame create_data_frame();
 
+    /**
+     * Returns the number of rows in a data frame.
+     *
+     * @param df    The data frame
+     * @return int  Number of rows in the data frame
+     */
     int num_rows(data_frame &df);
 
+    /**
+     * Returns the number of columns in a data frame.
+     *
+     * @param df    The data frame
+     * @return int  Number of columns in the data frame
+     */
     int num_cols(data_frame &df);
 
+    /**
+     * Returns a column from a data frame.
+     *
+     * @param df                            The data frame
+     * @param idx                           Index of the column to return
+     * @return std::vector<data_element>    A column from the data frame
+     */
     std::vector<data_element> get_col(data_frame &df, int idx);
 
+    /**
+     * Returns a row from a data frame.
+     *
+     * @param df                            The data frame
+     * @param idx                           Index of the row to return
+     * @return std::vector<data_element>    A row from the data frame
+     */
     std::vector<data_element> get_row(data_frame &df, int idx);
 
+    /**
+     * Returns a single element from a data frame.
+     *
+     * @param df                The data frame
+     * @param row               The row number of the element
+     * @param col               The column number of the element
+     * @return data_element     An element from the data frame
+     */
     data_element get_cell(data_frame &df, int row, int col);
 
+    /**
+     * Adds a column to the end of a data frame.
+     *
+     * @param df        The data frame
+     * @param data      The column data to add
+     * @param col_name  The name of the column
+     */
     void append_col(data_frame &df, std::vector<data_element> &data, std::string col_name);
 
+    /**
+     * Adds a row to the end of a data frame.
+     *
+     * @param df    The data frame
+     * @param data  The row data to add
+     */
     void append_row(data_frame &df, std::vector<data_element> &data);
 
+    /**
+     * Inserts a column into a data frame at a specified index.
+     *
+     * @param df        The data frame
+     * @param idx       Index in which the column should be inserted
+     * @param data      The column data to insert
+     * @param col_name  The name of the column
+     */
     void insert_col(data_frame &df, int idx, std::vector<data_element> &data, std::string col_name);
 
+    /**
+     * Inserts a row into a data frame at a specified index.
+     *
+     * @param df    The data frame
+     * @param idx   Index in which the row should be inserted
+     * @param data  The row data to insert
+     */
     void insert_row(data_frame &df, int idx, std::vector<data_element> &data);
 
+    /**
+     * Drops a column from a data frame at a specified index and returns that column.
+     *
+     * @param df                            The data frame
+     * @param idx                           Index of the column to remove
+     * @return std::vector<data_element>    The dropped column
+     */
     std::vector<data_element> delete_col(data_frame &df, int idx);
 
+    /**
+     * Drops a row from a data frame at a specified index and returns that row.
+     *
+     * @param df                            The data frame
+     * @param idx                           Index of the row to remove
+     * @return std::vector<data_element>    The dropped row
+     */
     std::vector<data_element> delete_row(data_frame &df, int idx);
 
     /**
@@ -53,8 +134,20 @@ namespace splashkit_lib
      */
     void display(data_frame &df);
 
+    /**
+     * Displays the contents of a single row in a data frame
+     *
+     * @param df    The data frame
+     * @param idx   Index of the row to display
+     */
     void display_row(data_frame &df, int idx);
 
+    /**
+     * Displays the contents of a single column in a data frame
+     *
+     * @param df    The data frame
+     * @param idx   Index of the column to display
+     */
     void display_col(data_frame &df, int idx);
 
     /**

--- a/coresdk/src/test/test_data_frame.cpp
+++ b/coresdk/src/test/test_data_frame.cpp
@@ -28,4 +28,6 @@ void run_data_frame_test()
 
     // Display
     display(df);
+
+    cout << "Run './skunit_tests' to view unit tests" << endl;
 }

--- a/coresdk/src/test/test_data_frame.cpp
+++ b/coresdk/src/test/test_data_frame.cpp
@@ -1,0 +1,31 @@
+#include <string>
+#include <iostream>
+
+#include "data_frame.h"
+
+using namespace splashkit_lib;
+using std::cout, std::endl, std::vector, std::string, std::get;
+
+void run_data_frame_test()
+{
+    data_frame df = create_data_frame();
+
+    // Add column
+    vector<data_element> col1 = {3, 4, 7};
+    append_col(df, col1, "MyInts");
+
+    // Insert column at start
+    vector<data_element> col2 = {'A', 'B', 'C'};
+    insert_col(df, 0, col2, "MyChars");
+
+    // Add row
+    vector<data_element> row1 = {'Z', 99};
+    append_row(df, row1);
+
+    // Extract element and parse to correct type
+    data_element elem = get_cell(df, 0, 0);
+    char parsed_elem = get<char>(elem);
+
+    // Display
+    display(df);
+}

--- a/coresdk/src/test/test_main.cpp
+++ b/coresdk/src/test/test_main.cpp
@@ -34,6 +34,7 @@ void setup_tests()
     add_test("Bundles", run_bundle_test);
     add_test("Camera", run_camera_test);
     add_test("Database", run_database_tests);
+    add_test("DataFrame", run_data_frame_test);
     add_test("Geometry", run_geometry_test);
     add_test("Graphics", run_graphics_test);
     add_test("Input", run_input_test);

--- a/coresdk/src/test/test_main.h
+++ b/coresdk/src/test/test_main.h
@@ -35,5 +35,6 @@ void run_tcp_networking_test();
 void run_twitter_test();
 void run_terminal_test();
 void run_logging_test();
+void run_data_frame_test();
 
 #endif /* test_main_h */

--- a/coresdk/src/test/unit_tests/unit_test_data_frame.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_data_frame.cpp
@@ -1,0 +1,235 @@
+#include "catch.hpp"
+#include "data_frame.h"
+#include <stdexcept>
+
+using namespace splashkit_lib;
+using std::vector, std::string, std::get;
+
+data_frame create_demo_data_frame()
+{
+    data_frame df = create_data_frame();
+    vector<data_element> demo_col1 = {9, 4, 8};
+    vector<data_element> demo_col2 = {'A', 'B', 'C'};
+    vector<data_element> demo_col3 = {true, false, true};
+    vector<data_element> demo_col4 = {1.1f, 2.2f, 3.3f};
+    vector<data_element> demo_col5 = {"Aa", "Bb", "Cc"};
+    append_col(df, demo_col1, "Col 1");
+    append_col(df, demo_col2, "Col 2");
+    append_col(df, demo_col3, "Col 3");
+    append_col(df, demo_col4, "Col 4");
+    append_col(df, demo_col5, "Col 5");
+    return df;
+}
+
+TEST_CASE( "Data Frame", "[data_frame]" )
+{
+    SECTION( "Creating a data frame" )
+    {
+        data_frame df = create_data_frame();
+        REQUIRE( num_rows(df) == 0 );
+        REQUIRE( num_cols(df) == 0 );
+    }
+
+    SECTION( "Getting number of rows" )
+    {
+        data_frame df = create_demo_data_frame();
+        REQUIRE( num_rows(df) == 3 );
+    }
+
+    SECTION( "Getting number of columns" )
+    {
+        data_frame df = create_demo_data_frame();
+        REQUIRE( num_cols(df) == 5 );
+    }
+
+    SECTION( "Getting columns" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Getting valid columns")
+        {
+            vector<data_element> demo_col = get_col(df, 0);
+            REQUIRE( get<int>(demo_col[0]) == 9 );
+            REQUIRE( get<int>(demo_col[2]) == 8 );
+
+            demo_col = get_col(df, 4);
+            REQUIRE( get<string>(demo_col[0]) == "Aa" );
+            REQUIRE( get<string>(demo_col[1]) == "Bb" );
+        }
+
+        SECTION( "Getting invalid column indexes")
+        {
+            REQUIRE_THROWS_AS( get_col(df, -1), std::out_of_range );
+            REQUIRE_THROWS_AS( get_col(df, 5), std::out_of_range );
+        }
+    }
+
+    SECTION( "Getting rows" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Getting valid rows")
+        {
+            vector<data_element> demo_row = get_row(df, 0);
+            REQUIRE( get<char>(demo_row[1]) == 'A' );
+            REQUIRE( get<float>(demo_row[3]) == 1.1f );
+
+            demo_row = get_row(df, 2);
+            REQUIRE( get<char>(demo_row[1]) == 'C' );
+            REQUIRE( get<float>(demo_row[3]) == 3.3f );
+        }
+
+        SECTION( "Getting invalid row indexes")
+        {
+            REQUIRE_THROWS_AS( get_row(df, -1), std::out_of_range );
+            REQUIRE_THROWS_AS( get_row(df, 3), std::out_of_range );
+        }
+    }
+
+    SECTION( "Getting cells" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Getting valid cells" )
+        {
+            REQUIRE( get<string>(get_cell(df, 1, 4)) == "Bb");
+            REQUIRE( get<int>(get_cell(df, 2, 0)) == 8);
+        }
+
+        SECTION( "Getting invalid cell indexes" )
+        {
+            REQUIRE_THROWS_AS( get_cell(df, -1, 1), std::out_of_range );
+            REQUIRE_THROWS_AS( get_cell(df, 1, -1), std::out_of_range );
+            REQUIRE_THROWS_AS( get_cell(df, 1, 5), std::out_of_range );
+            REQUIRE_THROWS_AS( get_cell(df, 3, 1), std::out_of_range );
+        }
+    }
+
+    SECTION( "Appending columns" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Appending valid columns")
+        {
+            vector<data_element> demo_col = {-1, -2, -3};
+            append_col(df, demo_col, "Col 6");
+            vector<data_element> extract_col = get_col(df, 5);
+            REQUIRE( get<int>(extract_col[0]) == -1 );
+            REQUIRE( get<int>(extract_col[2]) == -3 );
+
+            demo_col = {'Z', 'Y', 'X'};
+            append_col(df, demo_col, "Col 7");
+            extract_col = get_col(df, 6);
+            REQUIRE( get<char>(extract_col[0]) == 'Z');
+            REQUIRE( get<char>(extract_col[2]) == 'X');
+        }
+
+        SECTION( "Appending incorrect length column" )
+        {
+            vector<data_element> demo_col = {1, 2};
+            REQUIRE_THROWS_AS( append_col(df, demo_col, "Col 6"), std::invalid_argument );
+        }
+
+        SECTION( "Appending column with variable types" )
+        {
+            vector<data_element> demo_col = {1, '2', 3};
+            REQUIRE_THROWS_AS( append_col(df, demo_col, "Col 6"), std::invalid_argument );
+        }
+    }
+
+    SECTION( "Appending rows" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Appending valid rows" )
+        {
+            vector<data_element> demo_row = {-1, 'Z', false, -1.1f, "Zz"};
+            append_row(df, demo_row);
+            vector<data_element> extract_row = get_row(df, 3);
+            REQUIRE( get<int>(extract_row[0]) == -1 );
+            REQUIRE( get<float>(extract_row[3]) == -1.1f );
+
+            demo_row = {-2, 'Y', true, -2.2f, "Yy"};
+            append_row(df, demo_row);
+            extract_row = get_row(df, 4);
+            REQUIRE( get<char>(extract_row[1]) == 'Y');
+            REQUIRE( get<string>(extract_row[4]) == "Yy");
+        }
+
+        SECTION( "Appending incorrect length row")
+        {
+            vector<data_element> demo_row = {-1, 'Z'};
+            REQUIRE_THROWS_AS( append_row(df, demo_row), std::invalid_argument );
+        }
+
+        SECTION( "Appending row with incorrect column types" )
+        {
+            vector<data_element> demo_row = {-1, 'Z', false, -1.1f, -1};
+            REQUIRE_THROWS_AS( append_row(df, demo_row), std::invalid_argument );
+        }
+    }
+
+    SECTION( "Inserting columns" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Inserting valid columns" )
+        {
+            vector<data_element> demo_col = {'Z', 'Y', 'X'};
+            insert_col(df, 2, demo_col, "Col A");
+            vector<data_element> extract_col = get_col(df, 2);
+            REQUIRE( get<char>(extract_col[0]) == 'Z' );
+            REQUIRE( get<char>(extract_col[2]) == 'X' );
+            extract_col = get_col(df, 5);
+            REQUIRE( get<string>(extract_col[0]) == "Aa" );
+            REQUIRE( get<string>(extract_col[2]) == "Cc" );
+            extract_col = get_col(df, 1);
+            REQUIRE( get<char>(extract_col[0]) == 'A' );
+            REQUIRE( get<char>(extract_col[2]) == 'C' );
+        }
+
+        SECTION( "Inserting incorrect length column")
+        {
+            vector<data_element> demo_col = {'Z', 'Y'};
+            REQUIRE_THROWS_AS( insert_col(df, 1, demo_col, "Col A"), std::invalid_argument );
+        }
+
+        SECTION( "Inserting column with variable types" )
+        {
+            vector<data_element> demo_col = {'Z', 'Y', 1};
+            REQUIRE_THROWS_AS( insert_col(df, 1, demo_col, "Col A"), std::invalid_argument );
+        }
+    }
+
+    SECTION( "Inserting rows" )
+    {
+        data_frame df = create_demo_data_frame();
+
+        SECTION( "Inserting valid rows" )
+        {
+            vector<data_element> demo_row = {-1, 'Z', false, -1.1f, "Zz"};
+            insert_row(df, 1, demo_row);
+            vector<data_element> extract_row = get_row(df, 1);
+            REQUIRE( get<int>(extract_row[0]) == -1 );
+            REQUIRE( get<char>(extract_row[1]) == 'Z' );
+            extract_row = get_row(df, 3);
+            REQUIRE( get<int>(extract_row[0]) == 8 );
+            REQUIRE( get<char>(extract_row[1]) == 'C' );
+            extract_row = get_row(df, 0);
+            REQUIRE( get<int>(extract_row[0]) == 9 );
+            REQUIRE( get<char>(extract_row[1]) == 'A' );
+        }
+
+        SECTION( "Inserting incorrect length row" )
+        {
+            vector<data_element> demo_row = {-1, 'Z'};
+            REQUIRE_THROWS_AS( insert_row(df, 0, demo_row), std::invalid_argument );
+        }
+
+        SECTION( "Inserting row with incorrect column types" )
+        {
+            vector<data_element> demo_row = {-1, 'Z', false, -1.1f, -1};
+            REQUIRE_THROWS_AS( insert_row(df, 0, demo_row), std::invalid_argument );
+        }
+    }
+}


### PR DESCRIPTION
This feature adds a data frame to splashkit that can be extended and modified for future data frame development.

The current features available include:
- Create a data frame
- Variable column data types
- Insert, append and delete rows and columns
- Retrieve rows, columns and cells
- Display data frame to console

Testing
- Demo and usage examples located at `splashkit-core/coresdk/src/test/test_data_frame.cpp`
- Unit tests located at `splashkit-core/coresdk/src/test/unit_tests/unit_test_data_frame.cpp`