### PR TITLE
feat: add update column to dataframe

### DIFF
--- a/coresdk/src/coresdk/dataframe.cpp
+++ b/coresdk/src/coresdk/dataframe.cpp
@@ -29,15 +29,39 @@ namespace splashkit_lib
         return df->col_names.size();
     }
 
+    /**
+     * Raises an out_of_range exception if an invalid column index is requested.
+     *
+     * @param df    The dataframe
+     * @param idx   Index of the column
+     */
+    inline void dataframe_validate_col_idx(dataframe &df, int idx)
+    {
+        if (idx < 0 || idx >= dataframe_num_cols(df))
+            throw std::out_of_range("column " + std::to_string(idx) + " is out of range");
+    }
+
+    /**
+     * Raises an out_of_range exception if an invalid row index is requested.
+     *
+     * @param df    The dataframe
+     * @param idx   Index of the row
+     */
+    inline void dataframe_validate_row_idx(dataframe &df, int idx)
+    {
+        if (idx < 0 || idx >= dataframe_num_rows(df))
+            throw std::out_of_range("row " + std::to_string(idx) + " is out of range");
+    }
+
     std::vector<data_element> dataframe_get_col(dataframe &df, int idx)
     {
-        dataframe_validate_col(df, idx);
+        dataframe_validate_col_idx(df, idx);
         return df->data[idx];
     }
 
     std::vector<data_element> dataframe_get_row(dataframe &df, int idx)
     {
-        dataframe_validate_row(df, idx);
+        dataframe_validate_row_idx(df, idx);
         std::vector<data_element> row;
         for (int col = 0; col < dataframe_num_cols(df); col++)
             row.push_back(df->data[col][idx]);
@@ -46,8 +70,8 @@ namespace splashkit_lib
 
     data_element dataframe_get_cell(dataframe &df, int row, int col)
     {
-        dataframe_validate_row(df, row);
-        dataframe_validate_col(df, col);
+        dataframe_validate_row_idx(df, row);
+        dataframe_validate_col_idx(df, col);
         return df->data[col][row];
     }
 
@@ -111,7 +135,7 @@ namespace splashkit_lib
 
     void dataframe_update_col(dataframe &df, int idx, std::vector<data_element> &data, std::string col_name)
     {
-        dataframe_validate_col(df, idx);
+        dataframe_validate_col_idx(df, idx);
         dataframe_insert_col(df, idx, data, col_name); // Insert first to validate new column before old column is deleted
         dataframe_delete_col(df, idx+1);
     }
@@ -153,17 +177,5 @@ namespace splashkit_lib
         // TODO
         dataframe df = new _dataframe_data();
         return df;
-    }
-
-    void dataframe_validate_col(dataframe &df, int idx)
-    {
-        if (idx < 0 || idx >= dataframe_num_cols(df))
-            throw std::out_of_range("column " + std::to_string(idx) + " is out of range");
-    }
-
-    void dataframe_validate_row(dataframe &df, int idx)
-    {
-        if (idx < 0 || idx >= dataframe_num_rows(df))
-            throw std::out_of_range("row " + std::to_string(idx) + " is out of range");
     }
 }

--- a/coresdk/src/coresdk/dataframe.cpp
+++ b/coresdk/src/coresdk/dataframe.cpp
@@ -109,6 +109,13 @@ namespace splashkit_lib
         return row;
     }
 
+    void dataframe_update_col(dataframe &df, int idx, std::vector<data_element> &data, std::string col_name)
+    {
+        dataframe_validate_col(df, idx);
+        dataframe_insert_col(df, idx, data, col_name); // Insert first to validate new column before old column is deleted
+        dataframe_delete_col(df, idx+1);
+    }
+
     std::ostream &operator << (std::ostream &stream, data_element &data)
     {
         // Print underlying value of a data_element

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -179,22 +179,6 @@ namespace splashkit_lib
      * @return dataframe   The new dataframe containing the file's data.
      */
     dataframe dataframe_read_csv(std::string filepath, char sep = ',', char line_break = '\n', bool header = true);
-
-    /**
-     * Raises an out_of_range exception if an invalid column index is requested.
-     *
-     * @param df    The dataframe
-     * @param idx   Index of the column
-     */
-    void dataframe_validate_col(dataframe &df, int idx);
-
-    /**
-     * Raises an out_of_range exception if an invalid row index is requested.
-     *
-     * @param df    The dataframe
-     * @param idx   Index of the row
-     */
-    void dataframe_validate_row(dataframe &df, int idx);
 }
 
 #endif

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -128,6 +128,16 @@ namespace splashkit_lib
     std::vector<data_element> dataframe_delete_row(dataframe &df, int idx);
 
     /**
+     * Updates the data in a column.
+     *
+     * @param df        The dataframe
+     * @param idx       Index in which the column should be updated
+     * @param data      The new column data that is replacing the old data
+     * @param col_name  The new name of the column
+     */
+    void dataframe_update_col(dataframe &df, int idx, std::vector<data_element> &data, std::string col_name);
+
+    /**
      * Allows data elements to be printed
      *
      * @param stream            Output stream to print to

--- a/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
@@ -232,4 +232,34 @@ TEST_CASE( "Dataframe", "[dataframe]" )
             REQUIRE_THROWS_AS( dataframe_insert_row(df, 0, demo_row), std::invalid_argument );
         }
     }
+
+    SECTION( "Updating columns" )
+    {
+        dataframe df = create_demo_dataframe();
+
+        SECTION( "Updating with valid column data" )
+        {
+            vector<data_element> demo_col = {9, 8, 7};
+            dataframe_update_col(df, 2, demo_col, "Col X");
+            vector<data_element> extract_col = dataframe_get_col(df, 2);
+            REQUIRE( get<int>(extract_col[0]) == 9 );
+            REQUIRE( get<int>(extract_col[1]) == 8 );
+            extract_col = dataframe_get_col(df, 3);
+            REQUIRE( get<float>(extract_col[0]) == 1.1f );
+            REQUIRE( get<float>(extract_col[1]) == 2.2f );
+        }
+
+        SECTION( "Updating at invalid column indexes" )
+        {
+            vector<data_element> demo_col = {9, 8, 7};
+            REQUIRE_THROWS_AS( dataframe_update_col(df, -1, demo_col, "Col X"), std::out_of_range );
+            REQUIRE_THROWS_AS( dataframe_update_col(df, 5, demo_col, "Col X"), std::out_of_range );
+        }
+
+        SECTION( "Updating column with incorrect column types")
+        {
+            vector<data_element> demo_col = {9, 8, '7'};
+            REQUIRE_THROWS_AS( dataframe_update_col(df, 2, demo_col, "Col X"), std::invalid_argument );
+        }
+    }
 }


### PR DESCRIPTION
Changes to allow updating column values and changes to remove non-public methods from the dataframe header

Changes made:

- **Renamed** "dataframe_validate_col" and "dataframe_validate_row" to "dataframe_validate_col_idx" and "dataframe_validate_row_idx"
  - to better describe that the requested index is being validated and not the cell data
- **Moved** "dataframe_validate_col_idx" and "dataframe_validate_row_idx" out of the header files and into cpp files
  - these methods are not part of the public API
- **Added** "dataframe_update_col" method to allow modifying the data in a column
  - to simplify from needing delete and insert a column to achieve this
- **Test** cases added for "dataframe_update_col" method
  - to validate that the method achieve user expectations