### PR TITLE
feat: add dataframe null type compatibility to existing methods

### DIFF
--- a/coresdk/src/coresdk/dataframe.cpp
+++ b/coresdk/src/coresdk/dataframe.cpp
@@ -29,13 +29,7 @@ namespace splashkit_lib
         return &_dataframe_null_data::get_instance();
     }
 
-    /**
-     * Returns the data type of a data element
-     *
-     * @param elem                  The data element
-     * @return data_element_type    The data type of the data element
-     */
-    data_element_type data_element_to_data_element_type(data_element &elem)
+    data_element_type dataframe_get_element_type(data_element &elem)
     {
         return (data_element_type) elem.index();
     }
@@ -161,7 +155,7 @@ namespace splashkit_lib
         // Set column type and validate data only has one type (or null)
         for (int row = 0; row < data.size(); row++)
         {
-            data_element_type row_type = data_element_to_data_element_type(data[row]);
+            data_element_type row_type = dataframe_get_element_type(data[row]);
             if (row_type == DATA_ELEMENT_NULL)
                 continue;
             else if (col_type == DATA_ELEMENT_NULL)
@@ -185,7 +179,7 @@ namespace splashkit_lib
         // Validate elements match column types
         if (dataframe_num_rows(df) != 0)
             for (int col = 0; col < dataframe_num_cols(df); col++)
-                if (!std::holds_alternative<dataframe_null>(data[col]) && df->col_types[col] != data_element_to_data_element_type(data[col]))
+                if (!std::holds_alternative<dataframe_null>(data[col]) && df->col_types[col] != dataframe_get_element_type(data[col]))
                     throw std::invalid_argument("Not all data elements in the inserted row match the type of their respective column");
 
         // Insert

--- a/coresdk/src/coresdk/dataframe.cpp
+++ b/coresdk/src/coresdk/dataframe.cpp
@@ -45,14 +45,7 @@ namespace splashkit_lib
         std::vector<std::vector<data_element>> data;    // Dataframe data, data[i][j] = col i row j
         std::vector<std::string> col_names;             // Name of each of the columns in the dataframe
         std::vector<data_element_type> col_types;       // Data type in each column (index of the type in the data_element variant)
-        const static std::string type_names[];          // String representations of each data type
     };
-
-    /**
-     * String representation of each possible data_element type (indexed by the data_element variant order)
-     * See data_element type definition for how to extend to new data types
-     */
-    const std::string _dataframe_data::type_names[] = {"string", "int", "float", "bool", "char", "null"};
 
     dataframe create_dataframe()
     {
@@ -74,7 +67,9 @@ namespace splashkit_lib
 
     std::string dataframe_get_col_type(dataframe &df, int idx)
     {
-        return _dataframe_data::type_names[df->col_types[idx]];
+        // See data_element type definition for how to extend to new data types
+        static std::string type_names[] = {"string", "int", "float", "bool", "char", "null"};
+        return type_names[df->col_types[idx]];
     }
 
     std::vector<std::string> dataframe_get_col_types(dataframe &df)

--- a/coresdk/src/coresdk/dataframe.cpp
+++ b/coresdk/src/coresdk/dataframe.cpp
@@ -4,7 +4,7 @@
 #include "dataframe.h"
 
 namespace splashkit_lib
-{   
+{
     struct _dataframe_null_data
     {
         public:
@@ -161,10 +161,11 @@ namespace splashkit_lib
 
     std::ostream &operator << (std::ostream &stream, dataframe_null &elem)
     {
+        // Print a null data element
         stream << "null";
         return stream;
     }
-    
+
     std::ostream &operator << (std::ostream &stream, data_element &data)
     {
         // Print underlying value of a data_element

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -8,10 +8,28 @@
 
 namespace splashkit_lib
 {
+    /**
+     * A dataframe_null is a null element that can be represent a
+     * missing value in a dataframe
+     *
+     * @attribute class dataframe_null
+     */
     typedef struct _dataframe_null_data *dataframe_null;
 
+    /**
+     * Allows null data elements to be printed
+     *
+     * @param stream            Output stream to print to
+     * @param data              Null data element to print
+     * @return std::ostream&    Output stream to print to
+     */
     std::ostream &operator << (std::ostream &stream, dataframe_null &elem);
 
+    /**
+     * Returns an instance of a null element for a dataframe
+     *
+     * @return dataframe_null   Instance of a null element
+     */
     dataframe_null dataframe_get_null();
 
     /**

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -64,7 +64,7 @@ namespace splashkit_lib
      * 1. Add the type to the end of the data_element type definition below
      * 2. Add the type to the data_element_type enumeration with an integer value
      *    that matches the index of the type in the data_element type definition
-     * 3. Add a string description of the type to the _dataframe_data::type_names
+     * 3. Add a string description of the type to the dataframe_get_col_type
      *    definition in dataframe.cpp at the same index of the type in the
      *    data_element type definition
      * 4. Add an element of the created data type, the enumeration, and the

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -41,9 +41,9 @@ namespace splashkit_lib
      * @constant DATA_ELEMENT_STRING    string data element
      * @constant DATA_ELEMENT_INT       integer data element
      * @constant DATA_ELEMENT_FLOAT     float data element
-     * @constant BOOL                   boolean data element
-     * @constant CHAR                   character data element
-     * @constant BOOL                   dataframe_null data element
+     * @constant DATA_ELEMENT_BOOL      boolean data element
+     * @constant DATA_ELEMENT_CHAR      character data element
+     * @constant DATA_ELEMENT_NULL      dataframe_null data element
      */
     enum data_element_type
     {

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -33,9 +33,43 @@ namespace splashkit_lib
     dataframe_null dataframe_get_null();
 
     /**
+     * This enumeration contains a list of all of the different types of
+     * elements that can be held in a data_element variant and their indexes
+     * in the variant.
+     * See data_element type definition for how to extend to new data types
+     *
+     * @constant DATA_ELEMENT_STRING    string data element
+     * @constant DATA_ELEMENT_INT       integer data element
+     * @constant DATA_ELEMENT_FLOAT     float data element
+     * @constant BOOL                   boolean data element
+     * @constant CHAR                   character data element
+     * @constant BOOL                   dataframe_null data element
+     */
+    enum data_element_type
+    {
+        DATA_ELEMENT_STRING = 0,
+        DATA_ELEMENT_INT    = 1,
+        DATA_ELEMENT_FLOAT  = 2,
+        DATA_ELEMENT_BOOL   = 3,
+        DATA_ELEMENT_CHAR   = 4,
+        DATA_ELEMENT_NULL   = 5
+    };
+
+    /**
      * A data element is an element that can be stored in the cell of a
      * dataframe. Its type must be one of the variant types listed in the
      * signature below.
+     *
+     * How to extend compatibility to more data types
+     * 1. Add the type to the end of the data_element type definition below
+     * 2. Add the type to the data_element_type enumeration with an integer value
+     *    that matches the index of the type in the data_element type definition
+     * 3. Add a string description of the type to the _dataframe_data::type_names
+     *    definition in dataframe.cpp at the same index of the type in the
+     *    data_element type definition
+     * 4. Add an element of the created data type, the enumeration, and the
+     *    string description to the "Data element types and variant indexes"
+     *    section of unit_test_dataframe.cpp
      */
     typedef std::variant<std::string,int,float,bool,char,dataframe_null> data_element;
 
@@ -70,6 +104,40 @@ namespace splashkit_lib
      * @return int  Number of columns in the dataframe
      */
     int dataframe_num_cols(dataframe &df);
+
+    /**
+     * Returns the type of elements in a dataframe column
+     *
+     * @param df            The dataframe
+     * @param idx           Index of the column to return the type of
+     * @return std::string  Type of the elements in the column
+     */
+    std::string dataframe_get_col_type(dataframe &df, int idx);
+
+    /**
+     * Returns the type of elements in each column of a dataframe
+     *
+     * @param df                            The dataframe
+     * @return std::vector<std::string>     Type of the elements in each column
+     */
+    std::vector<std::string> dataframe_get_col_types(dataframe &df);
+
+    /**
+     * Returns the name of a dataframe column
+     *
+     * @param df            The dataframe
+     * @param idx           Index of the column to return the name of
+     * @return std::string  Name of the column
+     */
+    std::string dataframe_get_col_name(dataframe &df, int idx);
+
+    /**
+     * Returns the name of each column in the dataframe
+     *
+     * @param df                            The dataframe
+     * @return std::vector<std::string>     Name of each column
+     */
+    std::vector<std::string> dataframe_get_col_names(dataframe &df);
 
     /**
      * Returns a column from a dataframe.

--- a/coresdk/src/coresdk/dataframe.h
+++ b/coresdk/src/coresdk/dataframe.h
@@ -74,6 +74,14 @@ namespace splashkit_lib
     typedef std::variant<std::string,int,float,bool,char,dataframe_null> data_element;
 
     /**
+     * Returns the data type of a data element
+     *
+     * @param elem                  The data element
+     * @return data_element_type    The data type of the data element
+     */
+    data_element_type dataframe_get_element_type(data_element &elem);
+
+    /**
      * Dataframes contain a table of information about a data set. Data
      * from csv or text files can be loaded into a dataframe to perform
      * data analysis with.

--- a/coresdk/src/test/test_dataframe.cpp
+++ b/coresdk/src/test/test_dataframe.cpp
@@ -11,23 +11,72 @@ void run_dataframe_test()
     dataframe df = create_dataframe();
 
     // Add column
+    cout << "Append integer column {3, 4, 7} called 'MyInts' to dataframe" << endl;
     vector<data_element> col1 = {3, 4, 7};
     dataframe_append_col(df, col1, "MyInts");
+    dataframe_display(df);
 
     // Insert column at start
-    vector<data_element> col2 = {'A', 'B', 'C'};
+    cout << "\nInsert character column with a null element {A, null, C} called 'MyChars' at front of dataframe" << endl;
+    vector<data_element> col2 = {'A', DATAFRAME_NULL, 'C'};
     dataframe_insert_col(df, 0, col2, "MyChars");
+    dataframe_display(df);
+
+    // Update column
+    cout << "\nUpdate integer column 'MyInts' with {9, 8, 7} and rename to 'MyInts2' in dataframe" << endl;
+    vector<data_element> col3 = {9, 8, 7};
+    dataframe_update_col(df, 1, col3, "MyInts2");
+    dataframe_display(df);
 
     // Add row
+    cout << "\nAppend row {Z, 99} to dataframe" << endl;
     vector<data_element> row1 = {'Z', 99};
     dataframe_append_row(df, row1);
+    dataframe_display(df);
 
     // Extract element and parse to correct type
     data_element elem = dataframe_get_cell(df, 0, 0);
     char parsed_elem = get<char>(elem);
+    cout << "\nExtract element in the first row and column in dataframe" << endl;
+    cout << parsed_elem << endl;
 
-    // Display
+    // Extract row
+    cout << "\nExtract second column in dataframe" << endl;
+    dataframe_display_col(df, 1);
+
+    // Extract column
+    cout << "\nExtract third row in dataframe" << endl;
+    dataframe_display_row(df, 2);
+
+    // Count rows
+    cout << "\nGet number of columns in dataframe" << endl;
+    cout << dataframe_num_cols(df) << endl;
+
+    // Count columns
+    cout << "\nGet number of rows in dataframe" << endl;
+    cout << dataframe_num_rows(df) << endl;
+
+    // Column types
+    cout << "\nGet column types in dataframe" << endl;
+    for (string col_type : dataframe_get_col_types(df))
+        cout << col_type << " ";
+    cout << endl;
+
+    // Column names
+    cout << "\nGet column names in dataframe" << endl;
+    for (string col_name : dataframe_get_col_names(df))
+        cout << col_name << " ";
+    cout << endl;
+
+    // Delete rows
+    cout << "\nDelete second row in dataframe" << endl;
+    dataframe_delete_row(df, 1);
     dataframe_display(df);
 
-    cout << "Run './skunit_tests' to view unit tests" << endl;
+    // Delete column
+    cout << "\nDelete first column in dataframe" << endl;
+    dataframe_delete_col(df, 0);
+    dataframe_display(df);
+
+    cout << "\nRun './skunit_tests' to view unit tests" << endl;
 }

--- a/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
@@ -312,6 +312,32 @@ TEST_CASE( "Dataframe", "[dataframe]" )
         }
     }
 
+    SECTION( "Deleting rows" )
+    {
+        dataframe df = create_demo_dataframe();
+
+        SECTION( "Deleting valid rows" )
+        {
+            // Delete row
+            dataframe_delete_row(df, 1);
+            REQUIRE( dataframe_num_rows(df) == 2 );
+
+            // Check neighbouring row values
+            vector<data_element> extract_row = dataframe_get_row(df, 1);
+            REQUIRE( get<int>(extract_row[0]) == 8 );
+            REQUIRE( get<char>(extract_row[1]) == 'C' );
+            extract_row = dataframe_get_row(df, 0);
+            REQUIRE( get<int>(extract_row[0]) == 9 );
+            REQUIRE( get<char>(extract_row[1]) == 'A' );
+        }
+
+        SECTION( "Deleting invalid row indexes")
+        {
+            REQUIRE_THROWS_AS( dataframe_delete_row(df, -1), std::out_of_range );
+            REQUIRE_THROWS_AS( dataframe_delete_row(df, 4), std::out_of_range );
+        }
+    }
+
     SECTION( "Updating columns" )
     {
         dataframe df = create_demo_dataframe();

--- a/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_dataframe.cpp
@@ -396,7 +396,7 @@ TEST_CASE( "Dataframe", "[dataframe]" )
         for (int i = 0; i < elems.size(); i++)
         {
             // Validate element types
-            REQUIRE( elems[i].index() == types[i] );
+            REQUIRE( dataframe_get_element_type(elems[i]) == types[i] );
 
             // Validate names
             vector<data_element> demo_col = {elems[i]};


### PR DESCRIPTION
Changes made:
- **Added** compatibility with null types in existing methods
- **Added** dataframe column types
- **Added** unit tests for column types, null compatability and deleting columns/rows in skunit_tests
- **Added** demo with most dataframe methods in sktest
- **Added** documentation where it was missing
- **Removed** extra whitespace where present