### PR TITLE
Add check for both sprites in AABB collision kind for Sprite-Sprite collision function

### DIFF
--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -336,7 +336,8 @@ namespace splashkit_lib
         {
             return false;
         }
-        else if (sprite_collision_kind(s1) == AABB_COLLISIONS && sprite_collision_kind(s2) == AABB_COLLISIONS)
+        
+        if (sprite_collision_kind(s1) == AABB_COLLISIONS && sprite_collision_kind(s2) == AABB_COLLISIONS)
         {
             return true;
         }

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -336,6 +336,10 @@ namespace splashkit_lib
         {
             return false;
         }
+        else if (sprite_collision_kind(s1) == AABB_COLLISIONS && sprite_collision_kind(s2) == AABB_COLLISIONS)
+        {
+            return true;
+        }
         
         if (sprite_collision_kind(s1) == AABB_COLLISIONS)
         {


### PR DESCRIPTION
Previous version does not check in sprite-sprite collision function, if both sprites are in AABB collision kind, only one at a time which S1 takes precedence first. Swingame source also lacks this check.

This adds an IF statement between checking for collision rectangle overlap and first AABB check. Immediately returns TRUE since after the first IF statement, they have to be intersecting collision rectangles already.

Discrepancy was noted by me approximately in May, when trying an external (to Splashkit library) "Collide" function in C#.