### PR TITLE
Use system sqlite3 library on linux and mac

### DIFF
--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -45,6 +45,7 @@ if (APPLE)
                    -lbz2 \
                    -lFLAC \
                    -lvorbis \
+                   -lsqlite3 \
                    -lz \
                    -lpng16 \
                    -lvorbisfile \
@@ -92,6 +93,7 @@ else()
                    -lvorbisfile \
                    -logg \
                    -lwebp \
+                   -lsqlite3 \
                    -lfreetype \
                    -lcurl \
                    -ldl \
@@ -160,7 +162,6 @@ file(GLOB SOURCE_FILES
     "${SK_SRC}/coresdk/*.cpp"
     "${SK_SRC}/backend/*.cpp"
     "${SK_EXT}/civetweb/src/civetweb.c"
-    "${SK_EXT}/sqlite/sqlite3.c"
     "${SK_EXT}/hash-library/*.cpp"
     "${SK_EXT}/easyloggingpp/*.cc"
 )
@@ -188,7 +189,6 @@ include_directories("${SK_EXT}/civetweb/include")
 include_directories("${SK_EXT}/easyloggingpp")
 include_directories("${SK_EXT}/hash-library")
 include_directories("${SK_EXT}/json")
-include_directories("${SK_EXT}/sqlite")
 include_directories("${SK_EXT}/catch")
 
 # MAC OS AND WINDOWS DIRECTORY INCLUDES
@@ -209,7 +209,6 @@ if (MSYS)
     include_directories(/${MINGW_PATH_PART}/include)
     include_directories(/${MINGW_PATH_PART}/include/libpng16)
     include_directories("${SK_LIB}/win_inc")
-    include_directories("${SK_EXT}/sqlite")
 endif()
 
 # MACRO DEFINITIONS #

--- a/tools/scripts/cmake/libsplashkit/CMakeLists.txt
+++ b/tools/scripts/cmake/libsplashkit/CMakeLists.txt
@@ -83,6 +83,7 @@ elseif (APPLE)
                    -lSDL2_gfx \
                    -lSDL2_image \
                    -lSDL2_net \
+                   -lsqlite3 \
                    -lpthread \
                    -lpng16 \
                    -lz \
@@ -115,6 +116,7 @@ else()
                    -lmikmod \
                    -logg \
                    -lwebp \
+                   -lsqlite3 \
                    -lfreetype \
                    -lcurl \
                    -ldl")


### PR DESCRIPTION
The bundled sqlite3 library in [splashkit/splashkit-external was removed](https://github.com/splashkit/splashkit-external/commit/aceb9c2d765ed1c36839626be087e7475f1e407e) however the linux and mac OS CMake scripts still depended on it which resulted in linker errors when attempting to compile splashkit.

This PR changes the CMake scripts to link against the system wide installed sqlite3 libraries instead. After this change, splashkit is able to successfully compile on linux. I'm unable to test the changes for MacOS.