### PR TITLE
Fix uri splitting when a / isn't before args

### DIFF
--- a/coresdk/src/coresdk/web_server.cpp
+++ b/coresdk/src/coresdk/web_server.cpp
@@ -292,11 +292,14 @@ namespace splashkit_lib
 
     vector<string> split_uri_stubs(const string &uri)
     {
-        stringstream ss(uri);
+        stringstream stubs;
         string stub;
         vector<string> result;
 
-        while (getline(ss, stub, '/'))
+        // Ensure args are removed if there isn't a / before the ?
+        stubs = (stringstream) uri.substr(0, uri.find('?'));
+
+        while (getline(stubs, stub, '/'))
         {
             result.push_back(stub);
         }

--- a/coresdk/src/test/unit_tests/unit_test_web_server.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_web_server.cpp
@@ -1,0 +1,47 @@
+/*  Copyright (C) 2024 Hayley Hughes
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include <vector>
+
+#include "catch.hpp"
+
+#include "web_server.h"
+
+using namespace splashkit_lib;
+
+TEST_CASE("split uri stubs", "[web_server]")
+{
+    vector<string> empty;
+
+    SECTION("can parse uri without path")
+    {
+       CHECK(split_uri_stubs("")  == empty);
+       CHECK(split_uri_stubs("/") == (vector<string>) {""});
+    }
+
+    SECTION("can parse uri with path")
+    {
+       CHECK(split_uri_stubs("/one")      == (vector<string>) {"one"});
+       CHECK(split_uri_stubs("/one/two/") == (vector<string>) {"one", "two"});
+    }
+
+    SECTION("can parse uri with arguments")
+    {
+       CHECK(split_uri_stubs("?foo=bar")      == empty);
+       CHECK(split_uri_stubs("/one/?foo=bar") == (vector<string>) {"one"});
+       CHECK(split_uri_stubs("/one?foo=bar")  == (vector<string>) {"one"});
+    }
+}
+


### PR DESCRIPTION
Fixes [#129](https://github.com/splashkit/splashkit-core/issues/129)

Tested using the included unit tests.