### PR TITLE
Fix erroneous flipping of renderers

### DIFF
--- a/coresdk/src/backend/graphics_driver.cpp
+++ b/coresdk/src/backend/graphics_driver.cpp
@@ -369,15 +369,7 @@ namespace splashkit_lib
     {
         SDL_Rect rect = {x, y, w, h};
 
-        int *raw_pixels = (int*)malloc( sizeof(int) * static_cast<unsigned long>(w * h) );
-        SDL_RenderReadPixels(renderer, &rect, SDL_PIXELFORMAT_RGBA8888, raw_pixels, w * 4);
-
-        for (int row = 0; row < h; row++)
-        {
-            // Copy a row from the paw pixels to the dest pixels
-            memcpy(&pixels[row * w], &raw_pixels[row *  w], sizeof(int) * static_cast<unsigned long>(w));
-        }
-        free(raw_pixels);
+        SDL_RenderReadPixels(renderer, &rect, SDL_PIXELFORMAT_RGBA8888, pixels, w * 4);
     }
 
     void _sk_bitmap_be_texture_to_pixels(sk_bitmap_be *bitmap_be, int *pixels, int sz, int w, int h)

--- a/coresdk/src/backend/graphics_driver.cpp
+++ b/coresdk/src/backend/graphics_driver.cpp
@@ -375,11 +375,7 @@ namespace splashkit_lib
         for (int row = 0; row < h; row++)
         {
             // Copy a row from the paw pixels to the dest pixels
-#ifdef WINDOWS
-            memcpy(&pixels[(h - row - 1) * w], &raw_pixels[row *  w], sizeof(int) * static_cast<unsigned long>(w));
-#else
             memcpy(&pixels[row * w], &raw_pixels[row *  w], sizeof(int) * static_cast<unsigned long>(w));
-#endif
         }
         free(raw_pixels);
     }
@@ -1280,12 +1276,7 @@ namespace splashkit_lib
         sk_color result = {0,0,0,0};
         unsigned int clr = 0;
         
-#ifdef WINDOWS
-        // Texture is inverted so flip y
-        SDL_Rect rect = {x, surface->height - y - 1, 1, 1};	
-#else
         SDL_Rect rect = {x, y, 1, 1};
-#endif
 
         if ( ! surface || ! surface->_data ) return result;
 


### PR DESCRIPTION
# Description

There were occasions when saving bitmaps, and restoring bitmaps (when all windows are destroyed then recreated) would cause them to be flipped vertically.

An `sk_drawing_surface` can have its internal bitmap stored either in textures or a surface, depending on if its 'drawable'. The code that handled reading from textures/renderers had a special case for Windows, that flipped the texture (or the coordinates being read) vertically. This was likely a workaround for a bug that used to be in SDL, but was [fixed](https://github.com/libsdl-org/SDL/issues/2182) a while ago, so this PR simply removes those special cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected) - if any people using SplashKit relied on the textures being flipped (or worked around it), they will experience different behavior.

## How Has This Been Tested?

Tested using the following sample, on Windows:
```c++
open_window("Test", 256, 256);
bitmap bmp = create_bitmap("test bitmap",256,256);

clear_bitmap(bmp, COLOR_WHITE);

// draw a square in the corner
draw_rectangle_on_bitmap(bmp, COLOR_RED, {0,0,32,32});

// write out some pixels read from the bitmap in lines
draw_pixel_on_bitmap(bmp, COLOR_BLACK, {199,0});
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 0,0), {200,0}); // expected: red
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,0), {201,0}); // expected: red
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,1), {202,0}); // expected: white

draw_pixel_on_bitmap(bmp, COLOR_BLACK, {199,1});
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 0,1), {200,1}); // expected: red
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,1), {201,1}); // expected: white
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,1), {202,1}); // expected: white

draw_pixel_on_bitmap(bmp, COLOR_BLACK, {199,2});
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 0,255), {200,2}); // expected: white
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,255), {201,2}); // expected: white
draw_pixel_on_bitmap(bmp, get_pixel(bmp, 1,254), {202,2}); // expected: white

// without commit, the saved bitmap is flipped vertically
save_bitmap(bmp, "is_it_flipped");

// the bitmap drawn here is the correct way around
draw_bitmap(bmp,0,0);
refresh_screen();
delay(2000);

close_window("Test");
//------------------------------------
open_window("Test", 256, 256);

// The bitmap drawn here is now vertically flipped before the commit
draw_bitmap(bmp,0,0);
refresh_screen();
delay(2000);

close_window("Test");
```

Without the commits, the `get_pixel`s are all white (reading is flipped vertically), the `save_bitmap` saves a flipped bitmap, and the bitmap `bmp` is flipped once the window is closed then re-opened. All works correctly with the commits.

## Testing Checklist

- [x] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
