### PR TITLE
Update keyboard_input.cpp

### DIFF
--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -70,7 +70,6 @@ namespace splashkit_lib
 
     void _keyboard_start_process_events()
     {
-        _key_pressed = false;
         _keys_just_typed.clear();
         _keys_released.clear();
     }
@@ -80,6 +79,7 @@ namespace splashkit_lib
         key_code keycode = static_cast<key_code>(code);
         _keys_released[keycode] = true;
         _keys_down[keycode] = false;
+        _key_pressed = false;
         _raise_key_event(_on_key_up, keycode);
     }
 
@@ -92,6 +92,7 @@ namespace splashkit_lib
             _keys_just_typed[keycode] = true;
             _raise_key_event(_on_key_typed, keycode);
         }
+        _key_pressed = true;
         _raise_key_event(_on_key_down, keycode);
     }
 


### PR DESCRIPTION
# Description

I have changed how the any_key_pressed() function works so that it will actually test for keys pressed. Bool is set to true when a key_down event occurs and is back to false when a key is released. splashkit doens't have a great way of keeping track of how many keys have been pressed, so with the way that the function works currently holding down two keys and then releasing one of them will toggle "_any_keys_pressed" back to false. Also had to remove the flag from getting reset in _keyboard_start_process_events() otherwise the bool would be reset at every tick of the program.

Fixes # (issue)
Bug where any_key_pressed() function would always return false regardless of keyboard input.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Tested with sktest & unit tests. All tests pass, keys are detected as expected.  Due to the aforementioned issues with key tracking releasing a single key when multiple keys are held down will toggle this boolean back to false.

## Testing Checklist

- [X] Tested with sktest
- [X] Tested with skunit_tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
