### PR TITLE
Fix/fix gpio cleanup and add pi init

### DIFF
--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -96,11 +96,11 @@ namespace splashkit_lib
                 set_PWM_dutycycle(pi, pin, dutycycle);
         }
 
-		void sk_clear_gpio_bank()
-		{
-				check_pi();
-				clear_bank_1(pi, 0x0FFFFFFC);
-		}
+        void sk_clear_gpio_bank()
+        {
+                check_pi();
+                clear_bank_1(pi, 0x0FFFFFFC);
+        }
 
         // Cleanup the GPIO library
         void sk_gpio_cleanup()

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -16,7 +16,7 @@ using namespace std;
 // Use https://abyz.me.uk/rpi/pigpio/pdif2.html for reference
 namespace splashkit_lib
 {
-        int pi;
+        int pi = -1;
 
         // Check if pigpio_init() has been called before any other GPIO functions
         bool check_pi()
@@ -96,12 +96,17 @@ namespace splashkit_lib
                 set_PWM_dutycycle(pi, pin, dutycycle);
         }
 
+		void sk_clear_gpio_bank()
+		{
+				check_pi();
+				clear_bank_1(pi, 0x0FFFFFFC);
+		}
+
         // Cleanup the GPIO library
         void sk_gpio_cleanup()
         {
 
-                check_pi();
-
+                check_pi();	
                 pigpio_stop(pi);
         }
 }

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -18,6 +18,7 @@ namespace splashkit_lib
     void sk_set_pwm_range(int pin, int range);
     void sk_set_pwm_frequency(int pin, int frequency);
     void sk_set_pwm_dutycycle(int pin, int dutycycle);
+	void sk_clear_gpio_bank();
     void sk_gpio_cleanup();
 }
 #endif

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -18,7 +18,7 @@ namespace splashkit_lib
     void sk_set_pwm_range(int pin, int range);
     void sk_set_pwm_frequency(int pin, int frequency);
     void sk_set_pwm_dutycycle(int pin, int dutycycle);
-	void sk_clear_gpio_bank();
+    void sk_clear_gpio_bank();
     void sk_gpio_cleanup();
 }
 #endif

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -214,7 +214,7 @@ namespace splashkit_lib
     void raspi_cleanup()
     {
 #ifdef RASPBERRY_PI
-		cout << "Cleaning GPIO pins" << endl;
+        cout << "Cleaning GPIO pins" << endl;
         sk_clear_gpio_bank();
         sk_gpio_cleanup();
 #else

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -214,16 +214,8 @@ namespace splashkit_lib
     void raspi_cleanup()
     {
 #ifdef RASPBERRY_PI
-        cout << "Cleaning GPIO pins" << endl;
-        for (int i = 1; i <= 40; i++)
-        {
-            int bcmPin = boardToBCM(static_cast<pins>(i));
-            if (bcmPin > 0)
-            {
-                raspi_set_mode(static_cast<pins>(bcmPin), GPIO_INPUT);
-                raspi_write(static_cast<pins>(bcmPin), GPIO_LOW);
-            }
-        }
+		cout << "Cleaning GPIO pins" << endl;
+        sk_clear_gpio_bank();
         sk_gpio_cleanup();
 #else
         cout << "Unable to set cleanup - GPIO not supported on this platform" << endl;


### PR DESCRIPTION
# Description

Pull request duplicated from: https://github.com/thoth-tech/splashkit-core/pull/44 to fix merge conflicts and change development over to the t1-2024 branch.

Change the variable `pi` to be explicitly initialised to a negative number, so as to prevent any situations in which it is initialised to a positive number and thus ensure `check_pi()` reflects the status of the Raspberry Pi board at all times. As suggested by  @hugglesfox

In the `raspi_cleanup()` function the pin is converted to its BCM representation and this is passed to the `raspi_set_mode()` and `raspi_write()` functions. These functions will convert the pin as well so this results in the pins being converted twice and some of the pins erroneously being converted to an invalid (HIGH/GND) pin. For example, Pin 3 will convert to BCM Pin 2 (a GPIO pin) and this is then passed to the function which converts it again to -1 which indicates that this is a HIGH pin.

Instead of this we use pigpiod `clear_bank_1` function to with a bitmask for all user GPIO pins (pins 2-28). This eliminates the conversion of pins during cleanup and the associated for loop. - suggested by @hugglesfox

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Reinstalled skm with this change, then ran `sktest` and `skunit_tests` all tests ran correctly and GPIO cleanup did not attempt to clean invalid pins. Then built a simple circuit to blink an led and successfully tested again.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from @hugglesfox on the Pull Request
