### PR TITLE
Extend any_key_pressed() to handle multiple held keys

### DIFF
--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -22,7 +22,6 @@ namespace splashkit_lib
     static map<key_code, bool> _keys_down;
     static map<key_code, bool> _keys_just_typed; // i.e. those that have just gone down
     static map<key_code, bool> _keys_released; // i.e. those that have just gone up
-    static bool _key_pressed = false;
 
     static vector<key_callback *> _on_key_down;
     static vector<key_callback *> _on_key_up;
@@ -70,7 +69,6 @@ namespace splashkit_lib
 
     void _keyboard_start_process_events()
     {
-        _key_pressed = false;
         _keys_just_typed.clear();
         _keys_released.clear();
     }
@@ -79,7 +77,7 @@ namespace splashkit_lib
     {
         key_code keycode = static_cast<key_code>(code);
         _keys_released[keycode] = true;
-        _keys_down[keycode] = false;
+        _keys_down.erase(keycode);
         _raise_key_event(_on_key_up, keycode);
     }
 
@@ -112,7 +110,14 @@ namespace splashkit_lib
     
     bool any_key_pressed()
     {
-        return _key_pressed;
+        if (_keys_down.size() > 0)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
     }
     
     string key_name(key_code key)

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -1,141 +1,132 @@
 //
-//  test_input.cpp
+//  keyboard_input.cpp
 //  splashkit
 //
-//  Created by Andrew Cain on 15/08/2016.
+//  Created by Andrew Cain on 16/08/2016.
 //  Copyright © 2016 Andrew Cain. All rights reserved.
 //
 
-#include "graphics.h"
-#include "input.h"
-#include "text.h"
+#include "keyboard_input.h"
 
-using namespace splashkit_lib;
-using namespace std;
+#include "input_driver.h"
+#include "utility_functions.h"
 
-static string _key_typed = "", _key_down = "", _key_up = "";
+#include <vector>
+#include <map>
 
-void _on_key_typed(int code)
+using std::vector;
+using std::map;
+
+namespace splashkit_lib
 {
-    _key_typed = key_name( static_cast<key_code>(code));
-}
+    static map<key_code, bool> _keys_down;
+    static map<key_code, bool> _keys_just_typed; // i.e. those that have just gone down
+    static map<key_code, bool> _keys_released; // i.e. those that have just gone up
 
-void _on_key_down(int code)
-{
-    _key_down = key_name( static_cast<key_code>(code) );
-}
+    static vector<key_callback *> _on_key_down;
+    static vector<key_callback *> _on_key_up;
+    static vector<key_callback *> _on_key_typed;
 
-void _on_key_up(int code)
-{
-    _key_up = key_name( static_cast<key_code>(code) );
-}
-
-void run_input_test()
-{
-    register_callback_on_key_typed(&_on_key_typed);
-    register_callback_on_key_down(&_on_key_down);
-    register_callback_on_key_up(&_on_key_up);
-    
-    rectangle rect = { 230.0f, 50.0f, 200.0f, 30.0f };
-    
-    window w1 = open_window("Test Input", 600, 600);
-    window w2 = open_window("Test Input Window 2", 600, 600);
-    
-    load_font("hara", "hara.ttf");
-    load_font("kochi", "kochi-gothic-subst");
-    
-    start_reading_text(rect);
-    
-    set_current_window(w2);
-    
-    start_reading_text(rect, "スプラッシュ・キット");
-    
-    color back = COLOR_WHEAT;
-    
-    while ( (not quit_requested()) && ( reading_text(w1) || reading_text(w2) ) )
+    void register_callback_on_key_down(key_callback *callback)
     {
-        process_events();
-        
-        set_current_window(w1);
-        
-        if ( not text_entry_cancelled(w1) )
-            clear_screen(COLOR_WHITE);
-        else
-            clear_screen(COLOR_PERU);
-        
-        draw_text("Enter english string: ", COLOR_NAVY, "hara", 18, 30, 50);
-        draw_collected_text(COLOR_BLACK, font_named("hara"), 18, option_defaults());
-        
-        if ( not reading_text(w1) )
-        {
-            draw_text(string("Read: "), COLOR_BLUE, "hara", 18, 30, 80);
-            draw_text(text_input(w1), COLOR_BLUE, "hara", 18, 30, 110);
-        }
-        
-        string location = "Mouse location: ";
-        location += to_string(mouse_x()) + ":" + to_string(mouse_y());
-        
-        string left_clicked = "Left click status: ";
-        left_clicked += to_string(mouse_clicked(LEFT_BUTTON)) + " up: " + to_string(mouse_up(LEFT_BUTTON)) + " down: " + to_string(mouse_down(LEFT_BUTTON));
-        
-        string right_clicked = "Right click status: ";
-        right_clicked += to_string(mouse_clicked(RIGHT_BUTTON)) + " up: " + to_string(mouse_up(RIGHT_BUTTON)) + " down: " + to_string(mouse_down(RIGHT_BUTTON));
-        
-        string key_details = "T key is ";
-        if ( key_down(T_KEY) ) key_details += "down";
-        if ( key_up(T_KEY) ) key_details += "up";
-        if ( key_released(T_KEY) ) key_details += " - released";
-        if ( key_typed(T_KEY) ) key_details += " - typed";
+        _on_key_down.push_back(callback);
+    }
 
-        if ( key_typed(F_KEY) ) window_toggle_fullscreen(window_with_focus());
-        if ( key_typed(B_KEY) ) window_toggle_border(window_with_focus());
+    void register_callback_on_key_up(key_callback *callback)
+    {
+        _on_key_up.push_back(callback);
+    }
 
-        draw_text(location, COLOR_PLUM, "hara", 14, 18, 200);
-        draw_text(left_clicked, COLOR_PLUM, "hara", 14, 18, 220);
-        draw_text(right_clicked, COLOR_PLUM, "hara", 14, 18, 240);
-        draw_text(key_details, COLOR_PLUM, "hara", 14, 18, 280);
-        draw_text(_key_down, COLOR_PLUM, "hara", 14, 18, 300);
-        draw_text(_key_up, COLOR_PLUM, "hara", 14, 18, 320);
-        draw_text(_key_typed, COLOR_PLUM, "hara", 14, 18, 340);
-        
-        set_current_window(w2);
-        
-        if ( key_typed(C_KEY) )
+    void register_callback_on_key_typed(key_callback *callback)
+    {
+        _on_key_typed.push_back(callback);
+    }
+
+    void deregister_callback_on_key_down(key_callback *callback)
+    {
+        _on_key_down.erase(std::remove(_on_key_down.begin(), _on_key_down.end(), callback), _on_key_down.end());
+    }
+
+    void deregister_callback_on_key_up(key_callback *callback)
+    {
+        _on_key_up.erase(std::remove(_on_key_up.begin(), _on_key_up.end(), callback), _on_key_up.end());
+    }
+
+    void deregister_callback_on_key_typed(key_callback *callback)
+    {
+        _on_key_typed.erase(std::remove(_on_key_typed.begin(), _on_key_typed.end(), callback), _on_key_typed.end());
+    }
+
+    void _raise_key_event(vector<key_callback *> &list, key_code code)
+    {
+        for(auto callback: list )
         {
-            back = random_rgb_color(255);
+            try {
+                callback(code);
+            } catch (...) {}
         }
-        
-        clear_screen(back);
-        draw_text("Enter Japanese string: ", COLOR_NAVY, "hara", 18, 30, 50);
-        draw_collected_text(COLOR_BLACK, font_named("kochi"), 18, option_defaults());
-        
-        if ( not reading_text(w2) )
+    }
+
+    void _keyboard_start_process_events()
+    {
+        _keys_just_typed.clear();
+        _keys_released.clear();
+    }
+
+    void _handle_key_up_callback(key_code code)
+    {
+        key_code keycode = static_cast<key_code>(code);
+        _keys_released[keycode] = true;
+        _keys_down.erase(keycode);
+        _raise_key_event(_on_key_up, keycode);
+    }
+
+    void _handle_key_down_callback(key_code code)
+    {
+        key_code keycode = static_cast<key_code>(code);
+        if(not key_down(keycode))
         {
-            draw_text(string("Read: "), COLOR_BLUE, "hara", 18, 30, 80);
-            draw_text(text_input(w2), COLOR_BLUE, "kochi", 18, 30, 110);
+            _keys_down[keycode] = true;
+            _keys_just_typed[keycode] = true;
+            _raise_key_event(_on_key_typed, keycode);
         }
-        
-        // Get location of mouse in W2
-        location = "Mouse location: ";
-        location += to_string(mouse_x()) + ":" + to_string(mouse_y());
-        
-        draw_text(location, COLOR_PLUM, "hara", 14, 18, 200);
-        draw_text(left_clicked, COLOR_PLUM, "hara", 14, 18, 220);
-        draw_text(right_clicked, COLOR_PLUM, "hara", 14, 18, 240);
-        draw_text(key_details, COLOR_PLUM, "hara", 14, 18, 280);
-        draw_text(_key_down, COLOR_PLUM, "hara", 14, 18, 300);
-        draw_text(_key_up, COLOR_PLUM, "hara", 14, 18, 320);
-        draw_text(_key_typed, COLOR_PLUM, "hara", 14, 18, 340);
-        
-        refresh_screen();
+        _raise_key_event(_on_key_down, keycode);
+    }
+
+    bool key_down(key_code key)
+    {
+        return _keys_down.count(key) > 0 and _keys_down[key];
+    }
+
+    bool key_typed(key_code key)
+    {
+        return _keys_just_typed.count(key) > 0 and _keys_just_typed[key] ;
     }
     
-    close_window("Test Input");
-    close_window("Test Input Window 2");
+    bool key_released(key_code key)
+    {
+        return _keys_released.count(key) > 0 and _keys_released[key] ;
+    }
     
-    deregister_callback_on_key_typed(&_on_key_typed);
-    deregister_callback_on_key_down(&_on_key_down);
-    deregister_callback_on_key_up(&_on_key_up);
+    bool any_key_pressed()
+    {
+        if (_keys_down.size() > 0)
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
     
-    free_all_fonts();
+    string key_name(key_code key)
+    {
+        return sk_key_name(key);
+    }
+    
+    bool key_up(key_code key)
+    {
+        return not key_down(key);
+    }
 }

--- a/coresdk/src/test/test_input.cpp
+++ b/coresdk/src/test/test_input.cpp
@@ -15,7 +15,6 @@ using namespace std;
 
 static string _key_typed = "", _key_down = "", _key_up = "";
 
-
 void _on_key_typed(int code)
 {
     _key_typed = key_name( static_cast<key_code>(code));


### PR DESCRIPTION
# Description
Extended any_keys_pressed so that  holding down multiple keys and then releasing one will make any_key_pressed return true. Rather than trying to track this with a boolean any_keys_pressed() now reads the size of the keys down map. Also amended how  _keys_down map works. Previously a new key-value pair would be created when a key was pressed. When the key is released the boolean is set to false, but it does not appear that these false keys were ever actually used for anything. This would give an erroneous value for size as it it would return the number of unique keys that had ever been pressed since the program began running. Now the key is erased from the map when the keyboard key is released. The any_keys_pressed()  now just tests whether the size of_keys_down is non-zero, and returns a boolean.

## Type of change
Extension to existing  function.
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Tested with skunit_tests, all of which pass. Tested with sktest, now works as expected. Holding a single key returns true, holding multiple keys  and releasing one will still return true. Releasing all keys returns false. Manually checked that _keys_down.size() returns the expected values representative of the keys which are held down.  Removed this check from the test code.

## Testing Checklist
- [X] Tested with sktest
- [X] Tested with skunit_tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
