### PR TITLE
new: add get_system_font() - searches for common system fonts

### DIFF
--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -209,51 +209,37 @@ namespace splashkit_lib
 
     font get_system_font()
     {
-        // record if we've tried to find a system font
-        static bool system_font_attempted_load = false;
-        // the system font we found (if successfull)
-        static font system_font = nullptr;
-
         // attempt to find a common font that looks nice.
         // This way most computers will have nice text at least
-        if (!system_font_attempted_load)
+        static const std::string common_fonts[] = {
+            "meiryo.ttc", // should be on Windows 7 and up - looks good in English, and supports a variety of languages
+            "NotoSansCJK-Regular.ttc", // some Linux options - supports a variety of languages
+            "NotoSansJP-Regular", // some Linux options
+            "NotoSans-Regular", // some Linux options
+            "LiberationSans-Regular", // some Linux options
+            "DejaVuSans", // some Linux options
+            "Arial", // all-rounder, should be on Windows and Mac
+        };
+
+        for (auto& font_name : common_fonts)
         {
-            system_font_attempted_load = true;
+            // check if the font exists first, to avoid warnings from load_font later
+            if (
+                !file_exists(sk_find_system_font_path(font_name)) &&
+                !file_exists(path_to_resource(font_name, FONT_RESOURCE)) &&
+                !file_exists(path_to_resource(font_name + ".ttf", FONT_RESOURCE))
+            )
+                continue;
 
-            static const std::string common_fonts[] = {
-                "meiryo.ttc", // should be on Windows 7 and up - looks good in English, and supports a variety of languages
-                "NotoSansCJK-Regular.ttc", // some Linux options - supports a variety of languages
-                "NotoSansJP-Regular", // some Linux options
-                "NotoSans-Regular", // some Linux options
-                "LiberationSans-Regular", // some Linux options
-                "DejaVuSans", // some Linux options
-                "Arial", // all-rounder, should be on Windows and Mac
-            };
-
-            for (auto& font_name : common_fonts)
-            {
-                // check if the font exists first, to avoid warnings from load_font later
-                if (
-                    !file_exists(sk_find_system_font_path(font_name)) &&
-                    !file_exists(path_to_resource(font_name, FONT_RESOURCE)) &&
-                    !file_exists(path_to_resource(font_name + ".ttf", FONT_RESOURCE))
-                )
-                    continue;
-
-                // try loading the font - if it fails, we'll try the next
-                font result = load_font("__system_font__", font_name);
-                if (result)
-                {
-                    system_font = result;
-                    break;
-                }
-            }
-
-            if (system_font == nullptr)
-                LOG(WARNING) << "Failed to find valid system font file";
+            // try loading the font - if it fails, we'll try the next
+            font result = load_font("__system_font__", font_name);
+            if (result)
+                return result;
         }
 
-        return system_font;
+        LOG(WARNING) << "Failed to find valid system font file";
+
+        return nullptr;
     }
 
     void draw_text(const string &text, const color &clr, font fnt, int font_size, double x, double y, const drawing_options &opts)

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -261,6 +261,9 @@ namespace splashkit_lib
                 if (try_load_system_font(path_to_resource(font_name + ".ttf", FONT_RESOURCE)))
                     break;
             }
+
+            if (system_font == nullptr)
+                LOG(WARNING) << "Failed to find valid system font file";
         }
 
         return system_font;

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -207,6 +207,59 @@ namespace splashkit_lib
         return result;
     }
 
+    font get_system_font()
+    {
+        // record if we've tried to find a system font
+        bool system_font_attempted_load = false;
+        // the system font we found (if successfull)
+        static font system_font = nullptr;
+
+        // attempt to find a common font that looks nice.
+        // This way most computers will have nice text at least
+        if (!system_font_attempted_load)
+        {
+            system_font_attempted_load = true;
+
+            std::vector<std::string> commonFonts = {
+                "meiryo.ttc", // should be on Windows 7 and up - looks good in English, and supports a variety of languages
+                "NotoSansCJK-Regular.ttc", // some Linux options - supports a variety of languages
+                "NotoSansJP-Regular", // some Linux options
+                "NotoSans-Regular", // some Linux options
+                "LiberationSans-Regular", // some Linux options
+                "DejaVuSans", // some Linux options
+                "Arial", // all-rounder, should be on Windows and Mac
+            };
+
+            // try loading each font manually - this avoid unecessary warnings, and we expect failure to happen on some systems
+            for (auto& fontName : commonFonts)
+            {
+                // Try the system font paths, and also the local font resource folder
+                std::string file_path = sk_find_system_font_path(fontName);
+                std::string file_path2 = path_to_resource(fontName, FONT_RESOURCE);
+                std::string file_path3 = path_to_resource(fontName + ".ttf", FONT_RESOURCE);
+
+                if (
+                    !file_exists(file_path) &&
+                    !file_exists(file_path2) &&
+                    !file_exists(file_path3)
+                )
+                    continue;
+
+                font result = sk_load_font(file_path.c_str(), 64);
+                if (!sk_contains_valid_font(result))
+                {
+                    delete result;
+                    continue;
+                }
+
+                system_font = result;
+                break;
+            }
+        }
+
+        return system_font;
+    }
+
     void draw_text(const string &text, const color &clr, font fnt, int font_size, double x, double y, const drawing_options &opts)
     {
         if ( fnt != nullptr and INVALID_PTR(fnt, FONT_PTR) )

--- a/coresdk/src/coresdk/text.cpp
+++ b/coresdk/src/coresdk/text.cpp
@@ -230,36 +230,23 @@ namespace splashkit_lib
                 "Arial", // all-rounder, should be on Windows and Mac
             };
 
-            // utility function to keep loading logic tidy
-            const auto try_load_system_font = [](const std::string& path) -> font
-            {
-                if (file_exists(path))
-                {
-                    font result = sk_load_font(path.c_str(), 64);
-
-                    if (!sk_contains_valid_font(result))
-                    {
-                        delete result;
-                        return nullptr;
-                    }
-
-                    system_font = result;
-                    return result;
-                }
-
-                return nullptr;
-            };
-
-            // try loading each font manually - this avoid unecessary warnings, and we expect failure to happen on some systems
             for (auto& font_name : common_fonts)
             {
-                // Try the system font paths, and also the local font resource folder
-                if (try_load_system_font(sk_find_system_font_path(font_name)))
+                // check if the font exists first, to avoid warnings from load_font later
+                if (
+                    !file_exists(sk_find_system_font_path(font_name)) &&
+                    !file_exists(path_to_resource(font_name, FONT_RESOURCE)) &&
+                    !file_exists(path_to_resource(font_name + ".ttf", FONT_RESOURCE))
+                )
+                    continue;
+
+                // try loading the font - if it fails, we'll try the next
+                font result = load_font("__system_font__", font_name);
+                if (result)
+                {
+                    system_font = result;
                     break;
-                if (try_load_system_font(path_to_resource(font_name, FONT_RESOURCE)))
-                    break;
-                if (try_load_system_font(path_to_resource(font_name + ".ttf", FONT_RESOURCE)))
-                    break;
+                }
             }
 
             if (system_font == nullptr)

--- a/coresdk/src/coresdk/text.h
+++ b/coresdk/src/coresdk/text.h
@@ -91,6 +91,15 @@ namespace splashkit_lib
     font load_font(const string &name, const string &filename);
 
     /**
+     * @brief Searches for and (if found) returns a default system font. Otherwise defaults to the in-built font.
+     *
+     * Searches for and (if found) returns a default system font. Otherwise defaults to the in-built font.
+     *
+     * @returns Returns the `font` found, or the in-built font if not
+     */
+    font get_system_font();
+
+    /**
      * @brief Frees a loaded font.
      *
      * @param fnt           The font to be freed.


### PR DESCRIPTION
# Description

This PR just adds a new function to SplashKit, `get_system_font()`, that can be used to quickly get a nice font. It searches for common fonts across different platforms, and just returns the first one it finds, caching this result so it doesn't have to search upon subsequent calls.

## Type of change

_Please delete options that are not relevant._

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (update or new)

## How Has This Been Tested?

This has been tested on Windows only, and it can be confirmed that the `meiryo.ttc` font present on my computer is correctly found. Other font names have been verified by checking online, but no verification on a live system has happened - I'd be really grateful if someone set up for this was able to test it across Linux and Mac 😃 

## Testing Checklist

- [x] Tested with sktest (no effect)
- [x] Tested with skunit_tests (no effect)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
