### PR TITLE
feat(gpio): add spi protocol functions

### DIFF
--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -95,7 +95,18 @@ namespace splashkit_lib
                 check_pi();
                 set_PWM_dutycycle(pi, pin, dutycycle);
         }
-
+        int sk_spi_open(int channel, int speed, int spi_flags)
+        {
+                return spi_open(pi, channel, speed, spi_flags);
+        }
+        int sk_spi_close(int handle)
+        {
+                return spi_close(pi, handle);
+        }
+        int sk_spi_transfer(int handle, char *sendBuf, char *recvBuf, int count)
+        {
+                return spi_xfer(pi, handle, sendBuf, recvBuf, count);
+        }	
         // Cleanup the GPIO library
         void sk_gpio_cleanup()
         {

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -18,6 +18,9 @@ namespace splashkit_lib
     void sk_set_pwm_range(int pin, int range);
     void sk_set_pwm_frequency(int pin, int frequency);
     void sk_set_pwm_dutycycle(int pin, int dutycycle);
+	int sk_spi_open(int channel, int speed, int spi_flags);
+    int sk_spi_close(int handle);
+    int sk_spi_transfer(int handle, char *sendBuf, char *recvBuf, int count);
     void sk_gpio_cleanup();
 }
 #endif

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -209,6 +209,35 @@ namespace splashkit_lib
         cout << "Unable to set pwm dutycycle - GPIO not supported on this platform" << endl;
 #endif
     }
+	
+	int raspi_spi_open(int channel, int speed, int spi_flags)
+    {
+#ifdef RASPBERRY_PI
+        int handle = -1;
+	handle = sk_spi_open(channel, speed, spi_flags);
+        return handle;
+#else
+        cout << "Unable to open SPI interface - GPIO not supported on this platform" << endl;
+#endif
+    }
+
+    int raspi_spi_close(int handle)
+    {
+#ifdef RASPBERRY_PI
+        return sk_spi_close(handle);
+#else
+        cout << "Unable to close SPI interface - GPIO not supported on this platform" << endl;
+#endif
+    }
+
+    int raspi_spi_transfer(int handle, char *sendBuf, char *recvBuf, int count)
+    {
+#ifdef RASPBERRY_PI
+        return sk_spi_transfer(handle, sendBuf, recvBuf, count);
+#else
+        cout << "Unable to transfer through SPI - GPIO not supported on this platform" << endl;
+#endif
+    }
 
     // Cleanup GPIO resources
     void raspi_cleanup()

--- a/coresdk/src/coresdk/raspi_gpio.h
+++ b/coresdk/src/coresdk/raspi_gpio.h
@@ -122,11 +122,11 @@ namespace splashkit_lib
     int raspi_spi_open(int channel, int speed, int spi_flags);
 
     /**
-     * @brief Opens SPI communication on selected channel.
+     * @brief Closes SPI communication on selected channel.
      *
      * This function closes SPI communication on a particular channel.
      *
-     * @param handle  A reference to the specific SPI communication to close.
+     * @param handle  A reference to the specific SPI connection to close.
      * @returns       A value indicating success or failure.
      */
     int raspi_spi_close(int handle);

--- a/coresdk/src/coresdk/raspi_gpio.h
+++ b/coresdk/src/coresdk/raspi_gpio.h
@@ -109,6 +109,41 @@ namespace splashkit_lib
      */
     pin_values raspi_read(pins pin);
 
+	/**
+     * @brief Opens SPI communication on selected channel.
+     *
+     * This function opens SPI communication on a particular channel.
+     *
+     * @param channel    The SPI channel to use.
+     * @param speed      The speed of data transfer (in baud).
+     * @param spi_flags  Optional flags for the SPI modes and settings.
+     * @returns          The handle referencing this particular connection.
+     */
+    int raspi_spi_open(int channel, int speed, int spi_flags);
+
+    /**
+     * @brief Closes SPI communication on selected channel.
+     *
+     * This function reads the value from the specified pin.
+     *
+     * @param handle  A reference to the specific SPI communication to close.
+     * @returns       A value indicating success or failure.
+     */
+    int raspi_spi_close(int handle);
+
+    /**
+     * @brief Transfers data on specified SPI connection
+     *
+     * This function transfers data through SPI, it sends data from sendBuf and receives it into recvBuf.
+     *
+     * @param handle,  The reference for a specific SPI connection.
+     * @param sendBuf  The memory buffer for sending data.
+     * @param recvBuf  The memory buffer for receiving data.
+     * @param count    The number of bytes to be transferred.
+     * @returns        The number of bytes that have actually been transfered.
+     */
+    int raspi_spi_transfer(int handle, char *sendBuf, char *recvBuf, int count);
+	
     /**
      * @brief Cleans up and releases any resources used by the GPIO library.
      *

--- a/coresdk/src/coresdk/raspi_gpio.h
+++ b/coresdk/src/coresdk/raspi_gpio.h
@@ -122,9 +122,9 @@ namespace splashkit_lib
     int raspi_spi_open(int channel, int speed, int spi_flags);
 
     /**
-     * @brief Closes SPI communication on selected channel.
+     * @brief Opens SPI communication on selected channel.
      *
-     * This function reads the value from the specified pin.
+     * This function closes SPI communication on a particular channel.
      *
      * @param handle  A reference to the specific SPI communication to close.
      * @returns       A value indicating success or failure.

--- a/coresdk/src/test/test_main.cpp
+++ b/coresdk/src/test/test_main.cpp
@@ -59,6 +59,7 @@ void setup_tests()
     add_test("UDP Networking Test", run_udp_networking_test);
     add_test("TCP Networking Test", run_tcp_networking_test);
     add_test("GPIO Tests", run_gpio_tests);
+	add_test("GPIO Tests - SPI", run_spi_tests);
     add_test("UI Tests", run_ui_test);
    
 }

--- a/coresdk/src/test/test_main.cpp
+++ b/coresdk/src/test/test_main.cpp
@@ -59,7 +59,7 @@ void setup_tests()
     add_test("UDP Networking Test", run_udp_networking_test);
     add_test("TCP Networking Test", run_tcp_networking_test);
     add_test("GPIO Tests", run_gpio_tests);
-	add_test("GPIO Tests - SPI", run_spi_tests);
+    add_test("GPIO Tests - SPI", run_spi_tests);
     add_test("UI Tests", run_ui_test);
    
 }

--- a/coresdk/src/test/test_main.h
+++ b/coresdk/src/test/test_main.h
@@ -33,6 +33,7 @@ void run_restful_web_service();
 void run_udp_networking_test();
 void run_tcp_networking_test();
 void run_gpio_tests();
+void run_gpio_spi_tests();
 void run_terminal_test();
 void run_logging_test();
 void run_ui_test();

--- a/coresdk/src/test/test_raspi_spi.cpp
+++ b/coresdk/src/test/test_raspi_spi.cpp
@@ -1,0 +1,55 @@
+//
+//  test_raspi_spi.cpp
+//  splashkit
+//
+//  Created by Jonathan Tynan https://github.com/Liquidscroll
+//
+
+#include <iostream>
+#include "raspi_gpio.h"
+using namespace std;
+using namespace splashkit_lib;
+
+
+void run_gpio_spi_tests()
+{
+
+
+    cout << "Initializing GPIO" << endl;
+    raspi_init();
+
+    cout << "Attempting to open SPI..." << endl;
+    int handle = raspi_spi_open(0, 1000000, 0);
+    if(handle >= 0)
+    {
+        cout << "SPI Connection Opened" << endl;
+    }
+    else
+    {
+        cout << "SPI failed to open." << endl;
+        return;
+    }
+
+    char buffer[3];
+
+    cout << "Attempting transfer..." << endl;
+    int bytes_trans = raspi_spi_transfer(handle, buffer, buffer, 3);
+    if(bytes_trans != 3)
+    {
+        cout << "Transfer error, wrong number of bytes transferred." << endl;     
+    }
+
+    cout << "Attempting to close SPI..." << endl;
+    int close_result = raspi_spi_close(handle);
+    if(close_result < 0)
+    {
+        cout << "SPI failed to close." << endl;
+    }
+    else
+    {
+        cout << "SPI closed successfully" << endl;
+    }
+
+    // Clean up the GPIO
+    raspi_cleanup();
+}


### PR DESCRIPTION
# Description

This PR adds functions to open and close a connection through SPI, as well as transfer data between devices. This is a common communication protocol and allows us to connect with a wide variety of sensors. Included is a simple test to open a connection, transfer data, and then close.

For more information see tutorial 5 in [this pull request](https://github.com/thoth-tech/SplashKit-Tutorial/pull/45).

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Included is a test for the basic functionality of the functions, furthermore they have been actively used to produce the tutorial mentioned above. Specifically, they have been used to communicate with the MCP3008 ADC to read a joysticks position. See linked tutorial for more information.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
