### PR TITLE
Altered the move_sprite_to method to correctly move a sprite which ha…

### DIFF
--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1023,8 +1023,8 @@ namespace splashkit_lib
 
         if (s->position_at_anchor_point)
         {
-            s->position.x += s->anchor_point.x;
-            s->position.y += s->anchor_point.y;
+            s->position.x -= s->anchor_point.x;
+            s->position.y -= s->anchor_point.y;
         }
     }
 


### PR DESCRIPTION
The move_sprite_to method produces incorrect behavior when a sprite has the Boolean field position_at_anchor_point set to true.

For example, take a 10x10 sprite which is positioned at world coordinates {10,10}. Its anchor is then {5,5} in sprite coordinates and {15,15} in world coordinates. Now when move_sprite_to(sprite, 20.0, 20.0) is called the sprite’s updated position is {25,25} with an anchor position of {30,30}.

With my alteration to the method, the sprite position would be {15,15} with an anchor position of {20,20}. This seems more natural as the sprite’s position is now being set by its anchor position, as intended by the position_at_anchor_point Boolean being true.