### PR TITLE
added circle-triangle intersection functions

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -111,50 +111,75 @@ namespace splashkit_lib
     bool circle_triangle_intersect(const circle &c, const triangle &tri)
     {
         point_2d p;
-        return circle_triangle_intersect_closest_point(c, tri, p);
+        return circle_triangle_intersect(c, tri, p);
     }
 
-    bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p)
+    bool circle_triangle_intersect(const circle &c, const triangle &tri, point_2d &p)
     {
-            // Check if the sphere center is inside the triangle
-            if (point_in_triangle(c.center, tri))
-            {
-                p = c.center;
-                return true;
-            }
+        // Check if the sphere center is inside the triangle
+        if (point_in_triangle(c.center, tri))
+        {
+            p = c.center;
+            return true;
+        }
 
-            line line_1 = line_from(tri.points[0], tri.points[1]);
-            line line_2 = line_from(tri.points[1], tri.points[2]);
-            line line_3 = line_from(tri.points[2], tri.points[0]);
+        int idx;
+        // Find the closest point on the triangle to the sphere center
+        p = closest_point_on_lines(c.center, lines_from(tri), idx);
 
-            point_2d pt_line_1 = closest_point_on_line_from_circle(c, line_1);
-            point_2d pt_line_2 = closest_point_on_line_from_circle(c, line_2);
-            point_2d pt_line_3 = closest_point_on_line_from_circle(c, line_3);
-            
-            float dist_1 = point_point_distance(c.center, pt_line_1);
-            float dist_2 = point_point_distance(c.center, pt_line_2);
-            float dist_3 = point_point_distance(c.center, pt_line_3);
-
-            // Find the closest point on the triangle to the sphere center
-            float min_dist = dist_1;
-            p = pt_line_1;
-            if (dist_2 < min_dist)
-            {
-                min_dist = dist_2;
-                p = pt_line_2;
-            }
-            if (dist_3 < min_dist)
-            {
-                min_dist = dist_3;
-                p = pt_line_3;
-            }
-      
-            vector_2d v = vector_point_to_point(p, c.center);
-
-            // Circle and triangle intersect if the squared distance from circle
-            // center to point p is less than the squared circle radius
-            return dot_product(v, v) <= c.radius * c.radius;
+        // Circle and triangle intersect if the squared distance from circle
+        // center to point p is less than the squared circle radius
+        return vector_magnitude_sqared(vector_point_to_point(c.center, p)) < c.radius * c.radius;
     }
+
+    point_2d closest_point_on_triangle_from_circle(const circle &c, const triangle &tri)
+    {
+        point_2d p;
+        circle_triangle_intersect(c, tri, p);
+        return p;
+    }
+
+    // bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p)
+    // {
+    //         // Check if the sphere center is inside the triangle
+    //         if (point_in_triangle(c.center, tri))
+    //         {
+    //             p = c.center;
+    //             return true;
+    //         }
+
+    //         line line_1 = line_from(tri.points[0], tri.points[1]);
+    //         line line_2 = line_from(tri.points[1], tri.points[2]);
+    //         line line_3 = line_from(tri.points[2], tri.points[0]);
+
+    //         point_2d pt_line_1 = closest_point_on_line_from_circle(c, line_1);
+    //         point_2d pt_line_2 = closest_point_on_line_from_circle(c, line_2);
+    //         point_2d pt_line_3 = closest_point_on_line_from_circle(c, line_3);
+            
+    //         float dist_1 = point_point_distance(c.center, pt_line_1);
+    //         float dist_2 = point_point_distance(c.center, pt_line_2);
+    //         float dist_3 = point_point_distance(c.center, pt_line_3);
+
+    //         // Find the closest point on the triangle to the sphere center
+    //         float min_dist = dist_1;
+    //         p = pt_line_1;
+    //         if (dist_2 < min_dist)
+    //         {
+    //             min_dist = dist_2;
+    //             p = pt_line_2;
+    //         }
+    //         if (dist_3 < min_dist)
+    //         {
+    //             min_dist = dist_3;
+    //             p = pt_line_3;
+    //         }
+      
+    //         vector_2d v = vector_point_to_point(p, c.center);
+
+    //         // Circle and triangle intersect if the squared distance from circle
+    //         // center to point p is less than the squared circle radius
+    //         return dot_product(v, v) <= c.radius * c.radius;
+    // }
 
     float circle_radius(const circle c)
     {

--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -139,48 +139,6 @@ namespace splashkit_lib
         return p;
     }
 
-    // bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p)
-    // {
-    //         // Check if the sphere center is inside the triangle
-    //         if (point_in_triangle(c.center, tri))
-    //         {
-    //             p = c.center;
-    //             return true;
-    //         }
-
-    //         line line_1 = line_from(tri.points[0], tri.points[1]);
-    //         line line_2 = line_from(tri.points[1], tri.points[2]);
-    //         line line_3 = line_from(tri.points[2], tri.points[0]);
-
-    //         point_2d pt_line_1 = closest_point_on_line_from_circle(c, line_1);
-    //         point_2d pt_line_2 = closest_point_on_line_from_circle(c, line_2);
-    //         point_2d pt_line_3 = closest_point_on_line_from_circle(c, line_3);
-            
-    //         float dist_1 = point_point_distance(c.center, pt_line_1);
-    //         float dist_2 = point_point_distance(c.center, pt_line_2);
-    //         float dist_3 = point_point_distance(c.center, pt_line_3);
-
-    //         // Find the closest point on the triangle to the sphere center
-    //         float min_dist = dist_1;
-    //         p = pt_line_1;
-    //         if (dist_2 < min_dist)
-    //         {
-    //             min_dist = dist_2;
-    //             p = pt_line_2;
-    //         }
-    //         if (dist_3 < min_dist)
-    //         {
-    //             min_dist = dist_3;
-    //             p = pt_line_3;
-    //         }
-      
-    //         vector_2d v = vector_point_to_point(p, c.center);
-
-    //         // Circle and triangle intersect if the squared distance from circle
-    //         // center to point p is less than the squared circle radius
-    //         return dot_product(v, v) <= c.radius * c.radius;
-    // }
-
     float circle_radius(const circle c)
     {
         return c.radius;

--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -129,7 +129,7 @@ namespace splashkit_lib
 
         // Circle and triangle intersect if the squared distance from circle
         // center to point p is less than the squared circle radius
-        return vector_magnitude_sqared(vector_point_to_point(c.center, p)) < c.radius * c.radius;
+        return vector_magnitude_squared(vector_point_to_point(c.center, p)) < c.radius * c.radius;
     }
 
     point_2d closest_point_on_triangle_from_circle(const circle &c, const triangle &tri)

--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -108,6 +108,53 @@ namespace splashkit_lib
         return point_point_distance(point_at(c1_x, c1_y), point_at(c2_x, c2_y)) < c1_radius + c2_radius;
     }
 
+    bool circle_triangle_intersect(const circle &c, const triangle &tri)
+    {
+        point_2d p;
+        return circle_triangle_intersect_closest_point(c, tri, p);
+    }
+
+    bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p)
+    {
+            // Check if the sphere center is inside the triangle
+            if (point_in_triangle(c.center, tri))
+            {
+                p = c.center;
+                return true;
+            }
+
+            line line_1 = line_from(tri.points[0], tri.points[1]);
+            line line_2 = line_from(tri.points[1], tri.points[2]);
+            line line_3 = line_from(tri.points[2], tri.points[0]);
+
+            point_2d pt_line_1 = closest_point_on_line_from_circle(c, line_1);
+            point_2d pt_line_2 = closest_point_on_line_from_circle(c, line_2);
+            point_2d pt_line_3 = closest_point_on_line_from_circle(c, line_3);
+            
+            float dist_1 = point_point_distance(c.center, pt_line_1);
+            float dist_2 = point_point_distance(c.center, pt_line_2);
+            float dist_3 = point_point_distance(c.center, pt_line_3);
+
+            // Find the closest point on the triangle to the sphere center
+            float min_dist = dist_1;
+            p = pt_line_1;
+            if (dist_2 < min_dist)
+            {
+                min_dist = dist_2;
+                p = pt_line_2;
+            }
+            if (dist_3 < min_dist)
+            {
+                min_dist = dist_3;
+                p = pt_line_3;
+            }
+      
+            vector_2d v = vector_point_to_point(p, c.center);
+
+            // Circle and triangle intersect if the squared distance from circle
+            // center to point p is less than the squared circle radius
+            return dot_product(v, v) <= c.radius * c.radius;
+    }
 
     float circle_radius(const circle c)
     {

--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -59,6 +59,28 @@ namespace splashkit_lib
     bool circles_intersect(double c1_x, double c1_y, double c1_radius, double c2_x, double c2_y, double c2_radius);
 
     /**
+     * Detects if a circle intersects with a triangle.
+     * 
+     * @param c The circle to test
+     * @param tri The triangle to test
+     * @returns True if the circle and triangle intersect
+     */
+    bool circle_triangle_intersect(const circle &c, const triangle &tri);
+
+    /**
+     * Detects if a circle intersects with a triangle. The closest point on the
+     * triangle to the circle is returned, even if the circle and triangle do not
+     * intersect. If the centre of the circle is inside the triangle,
+     * the point returned is the centre of the circle.
+     * 
+     * @param c The circle to test
+     * @param tri The triangle to test
+     * @param p The point to set to the closest point on the triangle to the circle
+     * @returns True if the circle and triangle intersect
+     */
+    bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p);
+
+    /**
      *  Returns the center point of the circle.
      *
      * @param c   The circle to get the center point

--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -78,7 +78,19 @@ namespace splashkit_lib
      * @param p The point to set to the closest point on the triangle to the circle
      * @returns True if the circle and triangle intersect
      */
-    bool circle_triangle_intersect_closest_point(const circle &c, const triangle &tri, point_2d &p);
+    bool circle_triangle_intersect(const circle &c, const triangle &tri, point_2d &p);
+
+    /**
+     * Calculates the closest point on a triangle to a circle. If the circle and
+     * triangle do not intersect, the closest point on the triangle to the circle
+     * is returned. If the circle and triangle do intersect, the center of the
+     * circle is returned.
+     *
+     * @param c   The circle to test
+     * @param tri The triangle to test
+     * @returns   The closest point on the triangle to the circle
+     */
+    point_2d closest_point_on_triangle_from_circle(const circle &c, const triangle &tri);
 
     /**
      *  Returns the center point of the circle.

--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -69,9 +69,9 @@ namespace splashkit_lib
 
     /**
      * Detects if a circle intersects with a triangle. The closest point on the
-     * triangle to the circle is returned, even if the circle and triangle do not
+     * triangle to the circle is assigned to p, even if the circle and triangle do not
      * intersect. If the centre of the circle is inside the triangle,
-     * the point returned is the centre of the circle.
+     * the point assigned to p is the centre of the circle.
      * 
      * @param c The circle to test
      * @param tri The triangle to test

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -151,16 +151,16 @@ void test_triangle()
 
         point_2d p1, p2, p3, p4;
 
-        if (circle_triangle_intersect_closest_point(c1, t1, p1))
+        if (circle_triangle_intersect(c1, t1, p1))
             fill_triangle(COLOR_TAN, t1);
 
-        if (circle_triangle_intersect_closest_point(c1, t2, p2))
+        if (circle_triangle_intersect(c1, t2, p2))
             fill_triangle(COLOR_TAN, t2);
 
-        if (circle_triangle_intersect_closest_point(c1, t3, p3))
+        if (circle_triangle_intersect(c1, t3, p3))
             fill_triangle(COLOR_TAN, t3);
 
-        if (circle_triangle_intersect_closest_point(c1, t4, p4))
+        if (circle_triangle_intersect(c1, t4, p4))
             fill_triangle(COLOR_TAN, t4);
 
         draw_triangle(COLOR_RED, t1);

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -127,8 +127,62 @@ void test_rectangle()
     close_window(w1);
 }
 
+void test_triangle()
+{
+    auto t1 = triangle_from(110, 110, 120, 150, 170, 190);
+    auto t2 = triangle_from(200, 200, 200, 500, 500, 500);
+    auto t3 = triangle_from(300, 20, 280, 240, 550, 60);
+    auto t4 = triangle_from(150, 700, 265, 600, 510, 610);
+    auto c1 = circle_at(300, 300, 50);
+
+    window w1 = open_window("Triangle Tests", 600, 800);
+    while ( !window_close_requested(w1) ) {
+        process_events();
+        
+        if (key_down(UP_KEY))
+            c1.radius += 0.05;
+
+        if (key_down(DOWN_KEY))
+            c1.radius -= 0.05;
+
+        clear_screen(COLOR_WHEAT);
+
+        c1.center = mouse_position();
+
+        point_2d p1, p2, p3, p4;
+
+        if (circle_triangle_intersect_closest_point(c1, t1, p1))
+            fill_triangle(COLOR_TAN, t1);
+
+        if (circle_triangle_intersect_closest_point(c1, t2, p2))
+            fill_triangle(COLOR_TAN, t2);
+
+        if (circle_triangle_intersect_closest_point(c1, t3, p3))
+            fill_triangle(COLOR_TAN, t3);
+
+        if (circle_triangle_intersect_closest_point(c1, t4, p4))
+            fill_triangle(COLOR_TAN, t4);
+
+        draw_triangle(COLOR_RED, t1);
+        draw_triangle(COLOR_RED, t2);
+        draw_triangle(COLOR_RED, t3);
+        draw_triangle(COLOR_RED, t4);
+
+        draw_circle(COLOR_RED, p1.x, p1.y, 5);
+        draw_circle(COLOR_RED, p2.x, p2.y, 5);
+        draw_circle(COLOR_RED, p3.x, p3.y, 5);
+        draw_circle(COLOR_RED, p4.x, p4.y, 5);
+
+        draw_circle(COLOR_RED, c1);
+
+        refresh_screen();
+    }
+    close_window(w1);
+}
+
 void run_geometry_test()
 {
     test_rectangle();
     test_points();
+    test_triangle();
 }


### PR DESCRIPTION
# Description

There is no triangle-circle intersection test currently available in SplashKit, despite
being a useful test for game development.
I created two functions which will be expand the utility of the SplashKit library.
The first detects whether or not a circle and triangle are intersecting and returns
the Boolean result
The second has the functionality of the first but also supplies the closest point on the
triangle to the circle's center. This is achieved by passing a point_2d reference to the
function. Passing a value by reference to receive output may be complicated to
beginner programmers. Fortunately, the first function operates in a standard manner
and will be easily understandable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

I created a graphical test of my functions in the test_geometry.cpp file.
Four static triangles are present on the screen. A circle follows the mouse
cursor across the screen. The circle's size can be increased and decreased by
pressing the up and down arrow keys. If a triangle is intersecting with the
circle, it will change colour. The point_2d returned by my function is displayed
as a smaller circle on the surface of each triangle.

## Testing Checklist

- [x] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
