### PR TITLE
fix typo documentation

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -144,7 +144,7 @@ namespace splashkit_lib
     {
         vector_2d pm_c = vector_point_to_point(from_pt, c.center);
 
-        double sqr_len = vector_magnitude_sqared(pm_c);
+        double sqr_len = vector_magnitude_squared(pm_c);
         double r_sqr = c.radius * c.radius;
 
         // Quick check for P inside the circle, return False if so

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -132,14 +132,14 @@ namespace splashkit_lib
         return { -v.y / magnitude, v.x / magnitude };
     }
 
-    double vector_magnitude_sqared(const vector_2d &v)
+    double vector_magnitude_squared(const vector_2d &v)
     {
         return (v.x * v.x) + (v.y * v.y);
     }
 
     double vector_magnitude(const vector_2d &v)
     {
-        return sqrt(vector_magnitude_sqared(v));
+        return sqrt(vector_magnitude_squared(v));
     }
 
     vector_2d vector_limit(const vector_2d &v, double limit)

--- a/coresdk/src/coresdk/vector_2d.h
+++ b/coresdk/src/coresdk/vector_2d.h
@@ -166,7 +166,7 @@ namespace splashkit_lib
      * @param  v The vector
      * @return   Its squared magnitude
      */
-    double vector_magnitude_sqared(const vector_2d &v);
+    double vector_magnitude_squared(const vector_2d &v);
 
     /**
      * Returns the magnitude (or "length") of the vector.


### PR DESCRIPTION
# Description

Fix typo in the splashkit website documentation.

## Type of change

- [x] Documentation (update or new)

## How Has This Been Tested?

I find where the typo located and then manage to change from "sqared" to "squared".

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
