### PR TITLE
Fix bugs in closest_point_on_lines

### DIFF
--- a/coresdk/src/coresdk/line_geometry.cpp
+++ b/coresdk/src/coresdk/line_geometry.cpp
@@ -109,8 +109,11 @@ namespace splashkit_lib
     point_2d closest_point_on_lines(const point_2d from_pt, const vector<line> &lines, int &line_idx)
     {
         line_idx = -1;
-        float min_dist = -1, dst;
         point_2d result = point_at_origin();
+
+        if (lines.size() < 1) return result;
+
+        float min_dist = std::numeric_limits<float>::max(), dst;
         point_2d pt;
 
         for (int i = 0; i < lines.size(); i++)
@@ -125,7 +128,7 @@ namespace splashkit_lib
                 result = pt;
             }
         }
-        return pt;
+        return result;
     }
 
     vector<line> lines_from(const triangle &t)

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -127,8 +127,40 @@ void test_rectangle()
     close_window(w1);
 }
 
+void test_closest_point_on_lines()
+{
+    line l1 = line_from(10, 0, 10, 10);
+    line l2 = line_from(20, 0, 20, 10);
+    line l3 = line_from(30, 0, 30, 10);
+
+    point_2d pt = point_at(0, 5);
+
+    int line_idx = 0;
+    point_2d closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
+
+    cout << "Closes point should be 10,5 on line 0" << endl;
+    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+
+    pt = point_at(35, 8);
+    closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
+
+    cout << "Closes point should be 30,8 on line 2" << endl;
+    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+
+    pt = point_at(21, 3);
+    closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
+    cout << "Closest point should be 20,3 on line 1" << endl;
+    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+
+    // no lines
+    closest = closest_point_on_lines(pt, {}, line_idx);
+    cout << "Closest point should be 0,0 on line -1" << endl;
+    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+}
+
 void run_geometry_test()
 {
     test_rectangle();
     test_points();
+    test_closest_point_on_lines();
 }

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -127,40 +127,68 @@ void test_rectangle()
     close_window(w1);
 }
 
-void test_closest_point_on_lines()
+void test_lines()
 {
-    line l1 = line_from(10, 0, 10, 10);
-    line l2 = line_from(20, 0, 20, 10);
-    line l3 = line_from(30, 0, 30, 10);
-
-    point_2d pt = point_at(0, 5);
+    std::vector<line> lines;
+    lines.push_back(line_from(110, 100, 110, 150));
+    lines.push_back(line_from(120, 100, 120, 150));
+    lines.push_back(line_from(130, 100, 130, 150));
 
     int line_idx = 0;
-    point_2d closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
 
-    cout << "Closes point should be 10,5 on line 0" << endl;
-    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+    point_2d pt = point_at(100, 105);
+    point_2d closest = closest_point_on_lines(pt, lines, line_idx);
+    cout << "Closest point should be (110,105 on line 0): " << point_to_string(closest) << " on line " << line_idx << endl;
 
-    pt = point_at(35, 8);
-    closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
+    pt = point_at(135, 108);
+    closest = closest_point_on_lines(pt, lines, line_idx);
+    cout << "Closest point should be (130,108 on line 2): " << point_to_string(closest) << " on line " << line_idx << endl;
 
-    cout << "Closes point should be 30,8 on line 2" << endl;
-    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
-
-    pt = point_at(21, 3);
-    closest = closest_point_on_lines(pt, {l1, l2, l3}, line_idx);
-    cout << "Closest point should be 20,3 on line 1" << endl;
-    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+    pt = point_at(121, 103);
+    closest = closest_point_on_lines(pt, lines, line_idx);
+    cout << "Closest point (should be 120,103 on line 1): " << point_to_string(closest) << " on line " << line_idx << endl;
 
     // no lines
     closest = closest_point_on_lines(pt, {}, line_idx);
-    cout << "Closest point should be 0,0 on line -1" << endl;
-    cout << "Closest point is " << point_to_string(closest) << " on line " << line_idx << endl;
+    cout << "Closest point (should be 0,0 on line -1): " << point_to_string(closest) << " on line " << line_idx << endl;
+
+    circle c1 = circle_at(300, 300, 2);
+
+    lines.push_back(line_from(200, 200, 400, 400));
+    lines.push_back(line_from(200, 400, 400, 200));
+    lines.push_back(line_from(15, 15, 400, 30));
+    lines.push_back(line_from(100, 500, 500, 400));
+    lines.push_back(line_from(550, 700, 550, 790));
+    lines.push_back(line_from(30, 550, 230, 650));
+
+    window w1 = open_window("Line Tests", 600, 800);
+    while ( !window_close_requested(w1) ) {
+        process_events();
+
+        clear_screen(COLOR_WHEAT);
+
+        c1.center = mouse_position();
+
+        point_2d p1 = closest_point_on_lines(c1.center, lines, line_idx);
+
+        for (int i = 0; i < lines.size(); i++)
+        {
+            if (i == line_idx)
+                draw_line(COLOR_RED, lines[i]);
+            else
+                draw_line(COLOR_BLACK, lines[i]);
+        }
+        draw_circle(COLOR_RED, p1.x, p1.y, 5);
+        fill_circle(COLOR_RED, c1);
+
+        refresh_screen();
+    }
+    close_window(w1);
 }
 
 void run_geometry_test()
 {
     test_rectangle();
     test_points();
-    test_closest_point_on_lines();
+    test_lines();
 }


### PR DESCRIPTION
# Description

I attempted to use the closest_point_on_lines function in my circle_triangle_intersects function and found that it behaved strangely. Further investigation revealed two major bugs. First, despite `result` being initialised, it is never returned. Second, `min_dist` is initialised as `-1`, which means that the comparison `min_dist > dst` will always resolve to `false` as `dst` must be a positive number returned from `point_point_distance`. The special case when `lines.size() == 0` is handled correctly by returning `0,0` with `line_idx=0`, however I felt that an early return for this case would make the function easier to understand.

It is possible that the incorrect behavior of this function has lead to workarounds being used in projects. Therefore, I believe that this is a breaking change. Despite this, I believe that the functionality must be rectified for the sake of correctness.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

I added tests to sktest which show the function working in real-time. They indicate the position of the closest point, as well as which individual line contains the closest point. I also added a few numerical tests which print their results to the console.

## Testing Checklist

- [x] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from peers on the Pull Request