### PR TITLE
Add bitmap, sound effect and music unit tests

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -6,40 +6,66 @@
 
 #include "types.h"
 #include "graphics.h"
+#include "resources.h"
 
 using namespace splashkit_lib;
 
-TEST_CASE("bitmap can be created and freed", "[bitmap]")
+TEST_CASE("bitmaps can be created and freed", "[bitmap]")
 {
-    SECTION("can detect non-existant bitamp has not been loaded")
+    SECTION("can detect non-existent bitmap")
     {
+        REQUIRE(has_bitmap("non_existent") == false);
         bitmap no_bmp = load_bitmap("non_existent", "non_existent.jpg");
+        REQUIRE(no_bmp == nullptr);
         REQUIRE(has_bitmap("non_existent") == false);
     }
-    SECTION("can load and create bitmap")
+    SECTION("can load and free bitmap")
     {
-        bitmap bmp = load_bitmap("cottage", "cottage_door_and_window_199195.jpg");
-        REQUIRE(has_bitmap("cottage") == true);
-        REQUIRE(bitmap_valid(bmp) == true);
-        REQUIRE(bitmap_width(bmp) == 500);
-        REQUIRE(bitmap_height(bmp) == 333);
+        bitmap bmp;
+        SECTION("can load bitmap")
+        {
+            REQUIRE(has_bitmap("cottage") == false);
+            bmp = load_bitmap("cottage", "cottage_door_and_window_199195.jpg");
+            REQUIRE(bmp != nullptr);
+            REQUIRE(has_bitmap("cottage") == true);
+            REQUIRE(bitmap_valid(bmp) == true);
+            REQUIRE(bitmap_width(bmp) == 500);
+            REQUIRE(bitmap_height(bmp) == 333);
+            REQUIRE(bitmap_name(bmp) == "cottage");
+            REQUIRE(bitmap_filename(bmp) == path_to_resource("cottage_door_and_window_199195.jpg", IMAGE_RESOURCE));
+            REQUIRE(bitmap_named("cottage") == bmp);
+        }
         SECTION("can free bitmap")
         {
             free_bitmap(bmp);
             REQUIRE(has_bitmap("cottage") == false);
         }
     }
-    SECTION("can free all bitmaps")
+    SECTION("can load and free multiple bitmaps")
     {
-        bitmap bmp2, bmp3;
+        bitmap bmp, bmp2;
         SECTION("can load and create two bitmaps")
         {
-            bmp2 = load_bitmap("player", "player.png");
+            REQUIRE(has_bitmap("player") == false);
+            bmp = load_bitmap("player", "player.png");
+            REQUIRE(bmp != nullptr);
             REQUIRE(has_bitmap("player") == true);
-            REQUIRE(bitmap_valid(bmp2) == true);
-            bmp3 = load_bitmap("ufo", "ufo.png");
+            REQUIRE(bitmap_valid(bmp) == true);
+            REQUIRE(bitmap_width(bmp) == 300);
+            REQUIRE(bitmap_height(bmp) == 42);
+            REQUIRE(bitmap_name(bmp) == "player");
+            REQUIRE(bitmap_filename(bmp) == path_to_resource("player.png", IMAGE_RESOURCE));
+            REQUIRE(bitmap_named("player") == bmp);
+            REQUIRE(has_bitmap("ufo") == false);
+            bmp2 = load_bitmap("ufo", "ufo.png");
+            REQUIRE(bmp2 != nullptr);
             REQUIRE(has_bitmap("ufo") == true);
-            REQUIRE(bitmap_valid(bmp3) == true);
+            REQUIRE(bitmap_valid(bmp2) == true);
+            REQUIRE(bitmap_width(bmp2) == 35);
+            REQUIRE(bitmap_height(bmp2) == 33);
+            REQUIRE(bitmap_name(bmp2) == "ufo");
+            REQUIRE(bitmap_filename(bmp2) == path_to_resource("ufo.png", IMAGE_RESOURCE));
+            REQUIRE(bitmap_named("ufo") == bmp2);
         }
         SECTION("can free all bitmaps")
         {

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -22,56 +22,61 @@ TEST_CASE("bitmaps can be created and freed", "[bitmap]")
     SECTION("can load and free bitmap")
     {
         bitmap bmp;
+        string filename = "cottage_door_and_window_199195.jpg", name = "cottage";
+        int width = 500, height = 333;
         SECTION("can load bitmap")
         {
-            REQUIRE(has_bitmap("cottage") == false);
-            bmp = load_bitmap("cottage", "cottage_door_and_window_199195.jpg");
+            REQUIRE(has_bitmap(name) == false);
+            bmp = load_bitmap(name, filename);
             REQUIRE(bmp != nullptr);
-            REQUIRE(has_bitmap("cottage") == true);
+            REQUIRE(has_bitmap(name) == true);
             REQUIRE(bitmap_valid(bmp) == true);
-            REQUIRE(bitmap_width(bmp) == 500);
-            REQUIRE(bitmap_height(bmp) == 333);
-            REQUIRE(bitmap_name(bmp) == "cottage");
-            REQUIRE(bitmap_filename(bmp) == path_to_resource("cottage_door_and_window_199195.jpg", IMAGE_RESOURCE));
-            REQUIRE(bitmap_named("cottage") == bmp);
+            REQUIRE(bitmap_width(bmp) == width);
+            REQUIRE(bitmap_height(bmp) == height);
+            REQUIRE(bitmap_name(bmp) == name);
+            REQUIRE(bitmap_filename(bmp) == path_to_resource(filename, IMAGE_RESOURCE));
+            REQUIRE(bitmap_named(name) == bmp);
         }
         SECTION("can free bitmap")
         {
             free_bitmap(bmp);
-            REQUIRE(has_bitmap("cottage") == false);
+            REQUIRE(has_bitmap(name) == false);
         }
     }
     SECTION("can load and free multiple bitmaps")
     {
-        bitmap bmp, bmp2;
+        bitmap bmp1, bmp2;
+        string filename1 = "player.png", name1 = "player", filename2 = "ufo.png", name2 = "ufo";
+        int width1 = 300, height1 = 42, width2 = 35, height2 = 33;
         SECTION("can load and create two bitmaps")
         {
-            REQUIRE(has_bitmap("player") == false);
-            bmp = load_bitmap("player", "player.png");
-            REQUIRE(bmp != nullptr);
-            REQUIRE(has_bitmap("player") == true);
-            REQUIRE(bitmap_valid(bmp) == true);
-            REQUIRE(bitmap_width(bmp) == 300);
-            REQUIRE(bitmap_height(bmp) == 42);
-            REQUIRE(bitmap_name(bmp) == "player");
-            REQUIRE(bitmap_filename(bmp) == path_to_resource("player.png", IMAGE_RESOURCE));
-            REQUIRE(bitmap_named("player") == bmp);
-            REQUIRE(has_bitmap("ufo") == false);
-            bmp2 = load_bitmap("ufo", "ufo.png");
+            REQUIRE(has_bitmap(name1) == false);
+            bmp1 = load_bitmap(name1, filename1);
+            REQUIRE(bmp1 != nullptr);
+            REQUIRE(has_bitmap(name1) == true);
+            REQUIRE(bitmap_valid(bmp1) == true);
+            REQUIRE(bitmap_width(bmp1) == 300);
+            REQUIRE(bitmap_height(bmp1) == 42);
+            REQUIRE(bitmap_name(bmp1) == name1);
+            REQUIRE(bitmap_filename(bmp1) == path_to_resource(filename1, IMAGE_RESOURCE));
+            REQUIRE(bitmap_named(name1) == bmp1);
+
+            REQUIRE(has_bitmap(name2) == false);
+            bmp2 = load_bitmap(name2, filename2);
             REQUIRE(bmp2 != nullptr);
-            REQUIRE(has_bitmap("ufo") == true);
+            REQUIRE(has_bitmap(name2) == true);
             REQUIRE(bitmap_valid(bmp2) == true);
             REQUIRE(bitmap_width(bmp2) == 35);
             REQUIRE(bitmap_height(bmp2) == 33);
-            REQUIRE(bitmap_name(bmp2) == "ufo");
-            REQUIRE(bitmap_filename(bmp2) == path_to_resource("ufo.png", IMAGE_RESOURCE));
-            REQUIRE(bitmap_named("ufo") == bmp2);
+            REQUIRE(bitmap_name(bmp2) == name2);
+            REQUIRE(bitmap_filename(bmp2) == path_to_resource(filename2, IMAGE_RESOURCE));
+            REQUIRE(bitmap_named(name2) == bmp2);
         }
         SECTION("can free all bitmaps")
         {
             free_all_bitmaps();
-            REQUIRE(has_bitmap("player") == false);
-            REQUIRE(has_bitmap("ufo") == false);
+            REQUIRE(has_bitmap(name1) == false);
+            REQUIRE(has_bitmap(name2) == false);
         }
     }
 }

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -1,0 +1,51 @@
+/**
+ * Bitmap Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "types.h"
+#include "graphics.h"
+
+using namespace splashkit_lib;
+
+TEST_CASE("bitmap can be created and freed", "[bitmap]")
+{
+    SECTION("can detect non-existant bitamp has not been loaded")
+    {
+        bitmap no_bmp = load_bitmap("non_existent", "non_existent.jpg");
+        REQUIRE(has_bitmap("non_existent") == false);
+    }
+    SECTION("can load and create bitmap")
+    {
+        bitmap bmp = load_bitmap("cottage", "cottage_door_and_window_199195.jpg");
+        REQUIRE(has_bitmap("cottage") == true);
+        REQUIRE(bitmap_valid(bmp) == true);
+        REQUIRE(bitmap_width(bmp) == 500);
+        REQUIRE(bitmap_height(bmp) == 333);
+        SECTION("can free bitmap")
+        {
+            free_bitmap(bmp);
+            REQUIRE(has_bitmap("cottage") == false);
+        }
+    }
+    SECTION("can free all bitmaps")
+    {
+        bitmap bmp2, bmp3;
+        SECTION("can load and create two bitmaps")
+        {
+            bmp2 = load_bitmap("player", "player.png");
+            REQUIRE(has_bitmap("player") == true);
+            REQUIRE(bitmap_valid(bmp2) == true);
+            bmp3 = load_bitmap("ufo", "ufo.png");
+            REQUIRE(has_bitmap("ufo") == true);
+            REQUIRE(bitmap_valid(bmp3) == true);
+        }
+        SECTION("can free all bitmaps")
+        {
+            free_all_bitmaps();
+            REQUIRE(has_bitmap("player") == false);
+            REQUIRE(has_bitmap("ufo") == false);
+        }
+    }
+}

--- a/coresdk/src/test/unit_tests/unit_test_music.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_music.cpp
@@ -26,16 +26,17 @@ TEST_CASE("music can be loaded, controlled and freed", "[music]")
     SECTION("can load, control and free music")
     {
         music mus;
+        string filename = "magical_night.ogg", name = "magical_night";
         SECTION("can load music")
         {
-            REQUIRE(has_music("magical_night") == false);
-            mus = load_music("magical_night", "magical_night.ogg");
+            REQUIRE(has_music(name) == false);
+            mus = load_music(name, filename);
             REQUIRE(mus != nullptr);
-            REQUIRE(has_music("magical_night") == true);
+            REQUIRE(has_music(name) == true);
             REQUIRE(music_valid(mus) == true);
-            REQUIRE(music_name(mus) == "magical_night");
-            REQUIRE(music_filename(mus) == path_to_resource("magical_night.ogg", SOUND_RESOURCE));
-            REQUIRE(music_named("magical_night") == mus);
+            REQUIRE(music_name(mus) == name);
+            REQUIRE(music_filename(mus) == path_to_resource(filename, SOUND_RESOURCE));
+            REQUIRE(music_named(name) == mus);
         }
         SECTION("can control music")
         {
@@ -63,37 +64,38 @@ TEST_CASE("music can be loaded, controlled and freed", "[music]")
         SECTION("can free music")
         {
             free_music(mus);
-            REQUIRE(has_music("magical_night") == false);
+            REQUIRE(has_music(name) == false);
         }
     }
     SECTION("can load and free multiple music files")
     {
-        music mus, mus2;
+        music mus1, mus2;
+        string filename1 = "280.mp3", name1 = "280", filename2 = "dancingFrog.wav", name2 = "dancingFrog";
         SECTION("can load and create two music files")
         {
-            REQUIRE(has_music("280") == false);
-            mus = load_music("280", "280.mp3");
-            REQUIRE(mus != nullptr);
-            REQUIRE(has_music("280") == true);
-            REQUIRE(music_valid(mus) == true);
-            REQUIRE(music_name(mus) == "280");
-            REQUIRE(music_filename(mus) == path_to_resource("280.mp3", SOUND_RESOURCE));
-            REQUIRE(music_named("280") == mus);
+            REQUIRE(has_music(name1) == false);
+            mus1 = load_music(name1, filename1);
+            REQUIRE(mus1 != nullptr);
+            REQUIRE(has_music(name1) == true);
+            REQUIRE(music_valid(mus1) == true);
+            REQUIRE(music_name(mus1) == name1);
+            REQUIRE(music_filename(mus1) == path_to_resource(filename1, SOUND_RESOURCE));
+            REQUIRE(music_named(name1) == mus1);
 
-            REQUIRE(has_music("dancingFrog") == false);
-            mus2 = load_music("dancingFrog", "dancingFrog.wav");
+            REQUIRE(has_music(name2) == false);
+            mus2 = load_music(name2, filename2);
             REQUIRE(mus2 != nullptr);
-            REQUIRE(has_music("dancingFrog") == true);
+            REQUIRE(has_music(name2) == true);
             REQUIRE(music_valid(mus2) == true);
-            REQUIRE(music_name(mus2) == "dancingFrog");
-            REQUIRE(music_filename(mus2) == path_to_resource("dancingFrog.wav", SOUND_RESOURCE));
-            REQUIRE(music_named("dancingFrog") == mus2);
+            REQUIRE(music_name(mus2) == name2);
+            REQUIRE(music_filename(mus2) == path_to_resource(filename2, SOUND_RESOURCE));
+            REQUIRE(music_named(name2) == mus2);
         }
         SECTION("can free all music")
         {
             free_all_music();
-            REQUIRE(has_music("280") == false);
-            REQUIRE(has_music("dancingFrog") == false);
+            REQUIRE(has_music(name1) == false);
+            REQUIRE(has_music(name2) == false);
         }
     }
 }

--- a/coresdk/src/test/unit_tests/unit_test_music.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_music.cpp
@@ -1,0 +1,99 @@
+/**
+ * Music Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "types.h"
+#include "audio.h"
+#include "resources.h"
+
+using namespace splashkit_lib;
+
+TEST_CASE("music can be loaded, controlled and freed", "[music]")
+{
+    SECTION("can get audio ready")
+    {
+        open_audio();
+        REQUIRE(audio_ready() == true);
+    }
+    SECTION("can detect non-existent music")
+    {
+        music no_mus = load_music("non_existent", "non_existent.mp3");
+        REQUIRE(no_mus == nullptr);
+        REQUIRE(has_music("non_existent") == false);
+    }
+    SECTION("can load, control and free music")
+    {
+        music mus;
+        SECTION("can load music")
+        {
+            REQUIRE(has_music("magical_night") == false);
+            mus = load_music("magical_night", "magical_night.ogg");
+            REQUIRE(mus != nullptr);
+            REQUIRE(has_music("magical_night") == true);
+            REQUIRE(music_valid(mus) == true);
+            REQUIRE(music_name(mus) == "magical_night");
+            REQUIRE(music_filename(mus) == path_to_resource("magical_night.ogg", SOUND_RESOURCE));
+            REQUIRE(music_named("magical_night") == mus);
+        }
+        SECTION("can control music")
+        {
+            REQUIRE(music_playing() == false);
+            play_music(mus);
+            REQUIRE(music_playing() == true);
+            pause_music();
+            REQUIRE(music_playing() == true); // music is paused, not stopped
+            resume_music();
+            REQUIRE(music_playing() == true);
+            stop_music();
+            REQUIRE(music_playing() == false);
+        }
+        SECTION("can set music volume")
+        {
+            play_music(mus, 1, 0.75f);
+            REQUIRE(music_volume() == 0.75f);
+            set_music_volume(1.0f);
+            REQUIRE(music_volume() == 1.0f);
+            set_music_volume(0.0f);
+            REQUIRE(music_volume() == 0.0f);
+            set_music_volume(0.5f);
+            REQUIRE(music_volume() == 0.5f);
+        }
+        SECTION("can free music")
+        {
+            free_music(mus);
+            REQUIRE(has_music("magical_night") == false);
+        }
+    }
+    SECTION("can load and free multiple music files")
+    {
+        music mus, mus2;
+        SECTION("can load and create two music files")
+        {
+            REQUIRE(has_music("280") == false);
+            mus = load_music("280", "280.mp3");
+            REQUIRE(mus != nullptr);
+            REQUIRE(has_music("280") == true);
+            REQUIRE(music_valid(mus) == true);
+            REQUIRE(music_name(mus) == "280");
+            REQUIRE(music_filename(mus) == path_to_resource("280.mp3", SOUND_RESOURCE));
+            REQUIRE(music_named("280") == mus);
+
+            REQUIRE(has_music("dancingFrog") == false);
+            mus2 = load_music("dancingFrog", "dancingFrog.wav");
+            REQUIRE(mus2 != nullptr);
+            REQUIRE(has_music("dancingFrog") == true);
+            REQUIRE(music_valid(mus2) == true);
+            REQUIRE(music_name(mus2) == "dancingFrog");
+            REQUIRE(music_filename(mus2) == path_to_resource("dancingFrog.wav", SOUND_RESOURCE));
+            REQUIRE(music_named("dancingFrog") == mus2);
+        }
+        SECTION("can free all music")
+        {
+            free_all_music();
+            REQUIRE(has_music("280") == false);
+            REQUIRE(has_music("dancingFrog") == false);
+        }
+    }
+}

--- a/coresdk/src/test/unit_tests/unit_test_sound_effect.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sound_effect.cpp
@@ -1,0 +1,88 @@
+/**
+ * Sound Effect Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "types.h"
+#include "audio.h"
+#include "resources.h"
+
+using namespace splashkit_lib;
+
+TEST_CASE("sound effects can be loaded, played and freed", "[sound_effect]")
+{
+    SECTION("can get audio ready")
+    {
+        open_audio();
+        REQUIRE(audio_ready() == true);
+    }    
+    SECTION("can detect non-existent sound effect")
+    {
+        REQUIRE(has_sound_effect("non_existent") == false);
+        sound_effect no_snd = load_sound_effect("non_existent", "non_existent.mp3");
+        REQUIRE(no_snd == nullptr);
+        REQUIRE(has_sound_effect("non_existent") == false);
+    }
+    SECTION("can load, play, stop and free sound effect")
+    {
+        sound_effect snd;
+        SECTION("can load sound effect")
+        {
+            REQUIRE(has_sound_effect("SwinGameStart") == false);
+            snd = load_sound_effect("SwinGameStart", "SwinGameStart.wav");
+            REQUIRE(snd != nullptr);
+            REQUIRE(has_sound_effect("SwinGameStart") == true);
+            REQUIRE(sound_effect_valid(snd) == true);
+            REQUIRE(sound_effect_name(snd) == "SwinGameStart");
+            REQUIRE(sound_effect_filename(snd) == path_to_resource("SwinGameStart.wav", SOUND_RESOURCE));
+            REQUIRE(sound_effect_named("SwinGameStart") == snd);
+        }
+        SECTION("can play sound effect")
+        {
+            REQUIRE(sound_effect_playing(snd) == false);
+            play_sound_effect(snd);
+            REQUIRE(sound_effect_playing(snd) == true);
+        }
+        SECTION("can stop sound effect")
+        {
+            stop_sound_effect(snd);
+            REQUIRE(sound_effect_playing(snd) == false);
+        }
+        SECTION("can free sound effect")
+        {
+            free_sound_effect(snd);
+            REQUIRE(has_sound_effect("error") == false);
+        }
+    }
+    SECTION("can load and free multiple sounds effects")
+    {
+        sound_effect snd, snd2;
+        SECTION("can load and create two sound effects")
+        {
+            REQUIRE(has_sound_effect("breakdance") == false);
+            snd = load_sound_effect("breakdance", "breakdance.wav");
+            REQUIRE(snd != nullptr);
+            REQUIRE(has_sound_effect("breakdance") == true);
+            REQUIRE(sound_effect_valid(snd) == true);
+            REQUIRE(sound_effect_name(snd) == "breakdance");
+            REQUIRE(sound_effect_filename(snd) == path_to_resource("breakdance.wav", SOUND_RESOURCE));
+            REQUIRE(sound_effect_named("breakdance") == snd);
+
+            REQUIRE(has_sound_effect("comedy_boing") == false);
+            snd2 = load_sound_effect("comedy_boing", "comedy_boing.ogg");
+            REQUIRE(snd2 != nullptr);
+            REQUIRE(has_sound_effect("comedy_boing") == true);
+            REQUIRE(sound_effect_valid(snd2) == true);
+            REQUIRE(sound_effect_name(snd2) == "comedy_boing");
+            REQUIRE(sound_effect_filename(snd2) == path_to_resource("comedy_boing.ogg", SOUND_RESOURCE));
+            REQUIRE(sound_effect_named("comedy_boing") == snd2);
+        }
+        SECTION("can free all sound effects")
+        {
+            free_all_sound_effects();
+            REQUIRE(has_sound_effect("breakdance") == false);
+            REQUIRE(has_sound_effect("comedy_boing") == false);
+        }
+    }
+}

--- a/coresdk/src/test/unit_tests/unit_test_sound_effect.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sound_effect.cpp
@@ -27,16 +27,17 @@ TEST_CASE("sound effects can be loaded, played and freed", "[sound_effect]")
     SECTION("can load, play, stop and free sound effect")
     {
         sound_effect snd;
+        string filename = "SwinGameStart.wav", name = "SwinGameStart";
         SECTION("can load sound effect")
         {
-            REQUIRE(has_sound_effect("SwinGameStart") == false);
-            snd = load_sound_effect("SwinGameStart", "SwinGameStart.wav");
+            REQUIRE(has_sound_effect(name) == false);
+            snd = load_sound_effect(name, filename);
             REQUIRE(snd != nullptr);
-            REQUIRE(has_sound_effect("SwinGameStart") == true);
+            REQUIRE(has_sound_effect(name) == true);
             REQUIRE(sound_effect_valid(snd) == true);
-            REQUIRE(sound_effect_name(snd) == "SwinGameStart");
-            REQUIRE(sound_effect_filename(snd) == path_to_resource("SwinGameStart.wav", SOUND_RESOURCE));
-            REQUIRE(sound_effect_named("SwinGameStart") == snd);
+            REQUIRE(sound_effect_name(snd) == name);
+            REQUIRE(sound_effect_filename(snd) == path_to_resource(filename, SOUND_RESOURCE));
+            REQUIRE(sound_effect_named(name) == snd);
         }
         SECTION("can play sound effect")
         {
@@ -57,32 +58,33 @@ TEST_CASE("sound effects can be loaded, played and freed", "[sound_effect]")
     }
     SECTION("can load and free multiple sounds effects")
     {
-        sound_effect snd, snd2;
+        sound_effect snd1, snd2;
+        string filename1 = "breakdance.wav", name1 = "breakdance", filename2 = "comedy_boing.ogg", name2 = "comedy_boing";
         SECTION("can load and create two sound effects")
         {
-            REQUIRE(has_sound_effect("breakdance") == false);
-            snd = load_sound_effect("breakdance", "breakdance.wav");
-            REQUIRE(snd != nullptr);
-            REQUIRE(has_sound_effect("breakdance") == true);
-            REQUIRE(sound_effect_valid(snd) == true);
-            REQUIRE(sound_effect_name(snd) == "breakdance");
-            REQUIRE(sound_effect_filename(snd) == path_to_resource("breakdance.wav", SOUND_RESOURCE));
-            REQUIRE(sound_effect_named("breakdance") == snd);
+            REQUIRE(has_sound_effect(name1) == false);
+            snd1 = load_sound_effect(name1, filename1);
+            REQUIRE(snd1 != nullptr);
+            REQUIRE(has_sound_effect(name1) == true);
+            REQUIRE(sound_effect_valid(snd1) == true);
+            REQUIRE(sound_effect_name(snd1) == name1);
+            REQUIRE(sound_effect_filename(snd1) == path_to_resource(filename1, SOUND_RESOURCE));
+            REQUIRE(sound_effect_named(name1) == snd1);
 
-            REQUIRE(has_sound_effect("comedy_boing") == false);
-            snd2 = load_sound_effect("comedy_boing", "comedy_boing.ogg");
+            REQUIRE(has_sound_effect(name2) == false);
+            snd2 = load_sound_effect(name2, filename2);
             REQUIRE(snd2 != nullptr);
-            REQUIRE(has_sound_effect("comedy_boing") == true);
+            REQUIRE(has_sound_effect(name2) == true);
             REQUIRE(sound_effect_valid(snd2) == true);
-            REQUIRE(sound_effect_name(snd2) == "comedy_boing");
-            REQUIRE(sound_effect_filename(snd2) == path_to_resource("comedy_boing.ogg", SOUND_RESOURCE));
-            REQUIRE(sound_effect_named("comedy_boing") == snd2);
+            REQUIRE(sound_effect_name(snd2) == name2);
+            REQUIRE(sound_effect_filename(snd2) == path_to_resource(filename2, SOUND_RESOURCE));
+            REQUIRE(sound_effect_named(name2) == snd2);
         }
         SECTION("can free all sound effects")
         {
             free_all_sound_effects();
-            REQUIRE(has_sound_effect("breakdance") == false);
-            REQUIRE(has_sound_effect("comedy_boing") == false);
+            REQUIRE(has_sound_effect(name1) == false);
+            REQUIRE(has_sound_effect(name2) == false);
         }
     }
 }


### PR DESCRIPTION
# Description

There is currently only two unit tests: JSON and text. There are many other processes which could be tested such as audio, images. I have created three unit tests which cover bitmaps, sound effects and music. They each perform exhaustive testing of the types including their loading and freeing.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
expected)
- [ ] Documentation (update or new)

# How Has This Been Tested?

Adding the new tests was achieved by running `cmake -G "Unix Makefiles" .` followed by `make` when in the `/splashkit-core/projects/cmake` directory. The tests deliberately cause warning messages to occur in the terminal when they attempt to load non-existent files.

## Testing Checklist

- [ ] Tested with sktest
- [x] Tested with skunit_tests

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request