### PR TITLE
Generate C# Documents from headerdoc

### DIFF
--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -144,7 +144,7 @@ namespace splashkit_lib
     {
         vector_2d pm_c = vector_point_to_point(from_pt, c.center);
 
-        double sqr_len = vector_magnitude_sqared(pm_c);
+        double sqr_len = vector_magnitude_squared(pm_c);
         double r_sqr = c.radius * c.radius;
 
         // Quick check for P inside the circle, return False if so

--- a/coresdk/src/coresdk/vector_2d.cpp
+++ b/coresdk/src/coresdk/vector_2d.cpp
@@ -132,14 +132,14 @@ namespace splashkit_lib
         return { -v.y / magnitude, v.x / magnitude };
     }
 
-    double vector_magnitude_sqared(const vector_2d &v)
+    double vector_magnitude_squared(const vector_2d &v)
     {
         return (v.x * v.x) + (v.y * v.y);
     }
 
     double vector_magnitude(const vector_2d &v)
     {
-        return sqrt(vector_magnitude_sqared(v));
+        return sqrt(vector_magnitude_squared(v));
     }
 
     vector_2d vector_limit(const vector_2d &v, double limit)

--- a/coresdk/src/coresdk/vector_2d.h
+++ b/coresdk/src/coresdk/vector_2d.h
@@ -166,7 +166,7 @@ namespace splashkit_lib
      * @param  v The vector
      * @return   Its squared magnitude
      */
-    double vector_magnitude_sqared(const vector_2d &v);
+    double vector_magnitude_squared(const vector_2d &v);
 
     /**
      * Returns the magnitude (or "length") of the vector.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup, Extension
+import os
+
+splashkit_module = Extension(
+    name="splashkit",
+    sources=[
+        os.path.join("languages", "cpp", "splashkit_starter.cpp")
+    ],
+    include_dirs=[os.path.join("languages", "cpp")],
+    language="c++",
+)
+
+setup(
+    name="splashkit",
+    version="0.1.0",
+    description="Python bindings for the SplashKit library",
+    ext_modules=[splashkit_module],
+)


### PR DESCRIPTION
# Description

Generating c# documents from headerdoc.


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

First of all, I locate where the csharp.rb file.

Then, I add method to generate the C# XML based documentation comments from the existing headerdoc.

I add def convert_headerdoc_to_xml(headerdoc) and modify the def docs_signatures_for(function).

Finally, I execute the C# translator by using this command provided in the translator guides. 

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
