### PR TITLE
Fix bug in replace_all

### DIFF
--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -76,6 +76,9 @@ namespace splashkit_lib
 
     string replace_all(const string &text, const string &substr, const string &replacement)
     {
+        if (substr.empty())
+            return text;
+        
         string result = text;
         size_t pos = 0;
         while ((pos = result.find(substr, pos)) != string::npos)

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -117,6 +117,7 @@ void test_string_utils()
     cout << "To lower of " << mixedText << " is " << to_lowercase(mixedText) << endl;
     cout << "Trim of " << mixedText << " is " << trim(mixedText) << endl;
     cout << "Replace all of " << mixedText << " is " << replace_all(mixedText, " ", "_") << endl;
+    cout << "Replace all of " << mixedText << " when substring is empty is " << replace_all(mixedText, "", "_") << endl;
     
     vector<string> vec = split(mixedText, ' ');
 


### PR DESCRIPTION
# Description

While creating unit tests, I identified a bug in the `replace_all` function which causes an infinite loop if the `substr` argument is an empty string. I added a check at the beginning of the function which detects if the sub-string is empty. If so, the input string `text` is returned.

There are multiple ways to handle this edge case. One is to throw an exception, another is to return an empty string. I believe the most logical response it to return the unaltered input string as it shows to the user that no action will be taken with an empty sub-string.

This is not a breaking change as the current behavior always results in a program crash.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added an extra line of testing to `test_text.cpp` which uses an empty string as the `substr` argument. It runs as expected. In a separate pull request, I have created unit testing for `replace_all` which also tests this function's edge cases.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
