### PR TITLE
Fix bugs in rnd

### DIFF
--- a/coresdk/src/coresdk/random.cpp
+++ b/coresdk/src/coresdk/random.cpp
@@ -10,6 +10,7 @@
 #include "random.h"
 #include <cstdlib>
 #include <ctime>
+#include <iostream>
 namespace splashkit_lib
 {
     static bool _do_seed = true;
@@ -34,6 +35,12 @@ namespace splashkit_lib
     
     int rnd(int min, int max)
     {
+        if (min > max)
+        {
+            std::cout << "Error: min value is greater than max value when calling rnd" << std::endl;
+            return rnd(max, min);
+        }
+
         if (min == max) return min;
         
         if (_do_seed)

--- a/coresdk/src/coresdk/random.cpp
+++ b/coresdk/src/coresdk/random.cpp
@@ -21,6 +21,8 @@ namespace splashkit_lib
 
     int rnd(int ubound)
     {
+        if (ubound == 0) return 0;
+        
         if (_do_seed)
         {
             _do_seed = false;
@@ -32,6 +34,8 @@ namespace splashkit_lib
     
     int rnd(int min, int max)
     {
+        if (min == max) return min;
+        
         if (_do_seed)
         {
             _do_seed = false;

--- a/coresdk/src/coresdk/random.cpp
+++ b/coresdk/src/coresdk/random.cpp
@@ -11,6 +11,8 @@
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
+#include <easylogging++.h>
+
 namespace splashkit_lib
 {
     static bool _do_seed = true;
@@ -37,7 +39,7 @@ namespace splashkit_lib
     {
         if (min > max)
         {
-            std::cout << "Error: min value is greater than max value when calling rnd" << std::endl;
+            LOG(WARNING) << "Min value is greater than max value when calling rnd.";
             return rnd(max, min);
         }
 

--- a/coresdk/src/test/test_graphics.cpp
+++ b/coresdk/src/test/test_graphics.cpp
@@ -26,8 +26,7 @@ void test_drawing_on_new_window()
     save_bitmap(user_image, "0");
     clear_bitmap (user_image, COLOR_BRIGHT_GREEN);
     save_bitmap(user_image, "1");
-    // rnd(0) should return 0, and rnd(10, 10) should return 10
-    fill_rectangle_on_bitmap (user_image, COLOR_BLACK, rnd(0), 0, rnd(10, 10), 10);
+    fill_rectangle_on_bitmap (user_image, COLOR_BLACK, 0, 0, 10, 10);
     save_bitmap(user_image, "2");
 
     window my_window = open_window ("Black TL+BR", 200, 200);

--- a/coresdk/src/test/test_graphics.cpp
+++ b/coresdk/src/test/test_graphics.cpp
@@ -26,7 +26,8 @@ void test_drawing_on_new_window()
     save_bitmap(user_image, "0");
     clear_bitmap (user_image, COLOR_BRIGHT_GREEN);
     save_bitmap(user_image, "1");
-    fill_rectangle_on_bitmap (user_image, COLOR_BLACK, 0, 0, 10, 10);
+    // rnd(0) should return 0, and rnd(10, 10) should return 10
+    fill_rectangle_on_bitmap (user_image, COLOR_BLACK, rnd(0), 0, rnd(10, 10), 10);
     save_bitmap(user_image, "2");
 
     window my_window = open_window ("Black TL+BR", 200, 200);


### PR DESCRIPTION
# Description

The `rnd(int ubound)` and `rnd(int min, int max)` overloads of `rand` generate arithmetic exceptions when a divide by zero occurs through a modulo operator. `rnd(0)` will reliably generate the exception. When `min = max`, the divide by zero will occur in `rnd(int min, int max)` as `... % (max - min)` is used in the function.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added calls to rnd(0) and rnd(10, 10) to `test_graphics.cpp` to test the edge cases. While it may seem out of place to use `rnd` in `test_graphics.cpp`, `#include "random.h"` was already present in the file with no associated references. Now the `#include` is justified.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
