### PR TITLE
Feature/gpio error handling

### DIFF
--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -14,6 +14,22 @@
 #include "pigpiod_if2.h"
 #endif
 
+// Relevant error codes from pigpio library
+#define PI_INIT_FAILED             -1
+#define PI_BAD_USER_GPIO           -2
+#define PI_BAD_GPIO                -3
+#define PI_BAD_MODE                -4
+#define PI_BAD_LEVEL               -5
+#define PI_BAD_PUD                 -6
+#define PI_BAD_DUTYCYCLE           -8
+#define PI_BAD_DUTYRANGE           -21
+#define PI_NOT_PERMITTED           -41
+#define PI_SOME_PERMITTED          -42
+#define PIGIF_ERR_BAD_SEND         -2000
+#define PIGIF_ERR_BAD_RECV         -2001
+#define PIGIF_ERR_BAD_GET_ADDRINFO -2002
+#define PIGIF_ERR_BAD_CONNECT      -2003
+#define PIGIF_ERR_BAD_SOCKET       -2004
 
 using namespace std;
 // Use https://abyz.me.uk/rpi/pigpio/pdif2.html for local command reference
@@ -259,5 +275,43 @@ namespace splashkit_lib
                 LOG(ERROR) << "Remote GPIO: Connection has UDP Protocol";
             }
             return -1;
+        }
+        std::string sk_gpio_error_message(int error_code)
+        {
+            switch (error_code)
+            {
+            case PI_INIT_FAILED:
+                return "GPIO initialization failed. Please check your setup and try again.";
+            case PI_BAD_USER_GPIO:
+                return "Invalid GPIO pin number. Valid GPIO pins are 0-31.";
+            case PI_BAD_GPIO:
+                return "Invalid GPIO pin number. Valid GPIO pins are 0-53.";
+            case PI_BAD_MODE:
+                return "Invalid GPIO mode. Valid modes are 0-7.";
+            case PI_BAD_LEVEL:
+                return "Invalid GPIO level. Valid levels are 0 (LOW) or 1 (HIGH).";
+            case PI_BAD_PUD:
+                return "Invalid pull-up/down configuration. Valid options are 0 (OFF), 1 (Pull-down), 2 (Pull-up).";
+            case PI_BAD_DUTYCYCLE:
+                return "Invalid PWM duty cycle. Duty cycle must be between 0 and the range value (default 255).";
+            case PI_BAD_DUTYRANGE:
+                return "Invalid PWM range. Range must be between 25 and 40000.";
+            case PI_NOT_PERMITTED:
+                return "Permission denied to access GPIO. Please check your permissions.";
+            case PI_SOME_PERMITTED:
+                return "Permission denied to access one or more GPIO pins. Please check your permissions.";
+            case PIGIF_ERR_BAD_SEND:
+                return "Failed to send command to remote GPIO daemon (pigpiod).";
+            case PIGIF_ERR_BAD_RECV:
+                return "Failed to receive response from remote GPIO daemon (pigpiod).";
+            case PIGIF_ERR_BAD_GET_ADDRINFO:
+                return "Failed to resolve address of remote GPIO daemon (pigpiod).";
+            case PIGIF_ERR_BAD_CONNECT:
+                return "Failed to connect to remote GPIO daemon (pigpiod).";
+            case PIGIF_ERR_BAD_SOCKET:
+                return "Failed to create socket for connecting to remote GPIO daemon (pigpiod).";
+            default:
+                return "Unknown error code " + std::to_string(error_code);
+            }
         }
 }

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -2,6 +2,7 @@
 // This file is part of the SplashKit Core Library.
 // Copyright (©) 2024 Aditya Parmar. All Rights Reserved.
 
+#include "network_driver.h"
 #include "gpio_driver.h"
 #include "easylogging++.h"
 
@@ -333,10 +334,6 @@ namespace splashkit_lib
                 return "Invalid PWM duty cycle. Duty cycle must be between 0 and the range value (default 255).";
             case PI_BAD_DUTYRANGE:
                 return "Invalid PWM range. Range must be between 25 and 40000.";
-            case PI_NOT_PERMITTED:
-                return "Permission denied to access GPIO. Please check your permissions.";
-            case PI_SOME_PERMITTED:
-                return "Permission denied to access one or more GPIO pins. Please check your permissions.";
             case PIGIF_ERR_BAD_SEND:
                 return "Failed to send command to remote GPIO daemon (pigpiod).";
             case PIGIF_ERR_BAD_RECV:

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -112,7 +112,6 @@ namespace splashkit_lib
                 {
                     LOG(ERROR) << sk_gpio_error_message(result);
                 }
-                return result;
             }
         }
         void sk_set_pwm_range(int pin, int range)
@@ -146,11 +145,13 @@ namespace splashkit_lib
                 {
                     LOG(ERROR) << sk_gpio_error_message(result);
                 }
-                return result;
             }
         }
 
-
+	void sk_gpio_clear_bank_1()
+	{
+		clear_bank_1(pi, PI4B_GPIO_BITMASK);
+	}
         // Cleanup the GPIO library
         void sk_gpio_cleanup()
         {

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -24,302 +24,297 @@ using namespace std;
 //   Archive Link: https://web.archive.org/web/20240423160319/https://abyz.me.uk/rpi/pigpio/sif.html
 namespace splashkit_lib
 {
-        #ifdef RASPBERRY_PI
-        int pi;
-
-        // Check if pigpio_init() has been called before any other GPIO functions
-        bool check_pi()
+    #ifdef RASPBERRY_PI
+    int pi;
+    // Check if pigpio_init() has been called before any other GPIO functions
+    bool check_pi()
+    {
+        if (pi < 0)
         {
+            LOG(ERROR) << sk_gpio_error_message(pi);
+            return false;
+        }
+        else return true;
+    }
+    // Initialize the GPIO library
+    int sk_gpio_init()
+    {
+        pi = pigpio_start(0, 0);
+        return pi;
+    }
 
-                if (pi < 0)
+    // Read the value of a GPIO pin
+    int sk_gpio_read(int pin)
+    {
+        if (check_pi())
+        {
+            int result = gpio_read(pi, pin);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+            return result;
+        }
+        else
+        {
+            return GPIO_DEFAULT_VALUE;
+        }
+    }
+
+    // Write a value to a GPIO pin
+    void sk_gpio_write(int pin, int value)
+    {
+        if (check_pi())
+        {
+            int result = gpio_write(pi, pin, value);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+
+    // Set the mode of a GPIO pin
+    void sk_gpio_set_mode(int pin, int mode)
+    {
+        if(check_pi())
+        {
+            int result = set_mode(pi, pin, mode);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+
+    int sk_gpio_get_mode(int pin)
+    {
+        if(check_pi())
+        {
+            int result = get_mode(pi, pin);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+            return result;
+        }
+    }
+    void sk_gpio_set_pull_up_down(int pin, int pud)
+    {
+        if(check_pi())
+        {
+            int result = set_pull_up_down(pi, pin, pud);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+    void sk_set_pwm_range(int pin, int range)
+    {
+        if(check_pi())
+        {
+            int result = set_PWM_range(pi, pin, range);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+    void sk_set_pwm_frequency(int pin, int frequency)
+    {
+        if(check_pi())
+        {
+            int result = set_PWM_frequency(pi, pin, frequency);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+    void sk_set_pwm_dutycycle(int pin, int dutycycle)
+    {
+        if(check_pi())
+        {
+            int result = set_PWM_dutycycle(pi, pin, dutycycle);
+            if(result < 0)
+            {
+                LOG(ERROR) << sk_gpio_error_message(result);
+            }
+        }
+    }
+    void sk_gpio_clear_bank_1()
+    {
+        clear_bank_1(pi, PI4B_GPIO_BITMASK);
+    }
+    // Cleanup the GPIO library
+    void sk_gpio_cleanup()
+    {
+        if(check_pi())
+        {
+            pigpio_stop(pi);
+        }
+    }
+    #endif
+
+    connection sk_remote_gpio_init(std::string name, const std::string &host, unsigned short int port)
+    {
+        return open_connection(name, host, port);
+    }
+
+    void sk_remote_gpio_set_mode(connection pi, int pin, int mode)
+    {
+        sk_pigpio_cmd_t set_cmd;
+        set_cmd.cmd_code = GPIO_CMD_SET_MODE;
+        set_cmd.param1 = pin;
+        set_cmd.param2 = mode;
+
+        sk_gpio_send_cmd(pi, set_cmd);
+    }
+
+    int sk_remote_gpio_get_mode(connection pi, int pin)
+    {
+        sk_pigpio_cmd_t get_cmd;
+        get_cmd.cmd_code = GPIO_CMD_GET_MODE;
+        get_cmd.param1 = pin;
+
+        return sk_gpio_send_cmd(pi, get_cmd);
+    }
+
+    void sk_remote_gpio_set_pull_up_down(connection pi, int pin, int pud)
+    {
+        sk_pigpio_cmd_t set_pud_cmd;
+        set_pud_cmd.cmd_code = GPIO_CMD_SET_PUD;
+        set_pud_cmd.param1 = pin;
+        set_pud_cmd.param2 = pud;
+
+        sk_gpio_send_cmd(pi, set_pud_cmd);
+    }
+
+    int sk_remote_gpio_read(connection pi, int pin)
+    {
+        sk_pigpio_cmd_t read_cmd;
+        read_cmd.cmd_code = GPIO_CMD_READ;
+        read_cmd.param1 = pin;
+
+        return sk_gpio_send_cmd(pi, read_cmd);
+    }
+
+    void sk_remote_gpio_write(connection pi, int pin, int value)
+    {
+        sk_pigpio_cmd_t write_cmd;
+        write_cmd.cmd_code = GPIO_CMD_WRITE;
+        write_cmd.param1 = pin;
+        write_cmd.param2 = value;
+
+        sk_gpio_send_cmd(pi, write_cmd);
+    }
+
+    void sk_remote_set_pwm_range(connection pi, int pin, int range)
+    {
+        sk_pigpio_cmd_t set_range_cmd;
+        set_range_cmd.cmd_code = GPIO_CMD_SET_PWM_RANGE;
+        set_range_cmd.param1 = pin;
+        set_range_cmd.param2 = range;
+
+        sk_gpio_send_cmd(pi, set_range_cmd);
+    }
+
+    void sk_remote_set_pwm_frequency(connection pi, int pin, int frequency)
+    {
+        sk_pigpio_cmd_t set_freq_cmd;
+        set_freq_cmd.cmd_code = GPIO_CMD_SET_PWM_FREQ;
+        set_freq_cmd.param1 = pin;
+        set_freq_cmd.param2 = frequency;
+
+        sk_gpio_send_cmd(pi, set_freq_cmd);
+    }
+
+    void sk_remote_set_pwm_dutycycle(connection pi, int pin, int dutycycle)
+    {
+        sk_pigpio_cmd_t set_dutycycle_cmd;
+        set_dutycycle_cmd.cmd_code = GPIO_CMD_SET_PWM_DUTYCYCLE;
+        set_dutycycle_cmd.param1 = pin;
+        set_dutycycle_cmd.param2 = dutycycle;
+
+        sk_gpio_send_cmd(pi, set_dutycycle_cmd);
+    }
+
+    void sk_remote_clear_bank_1(connection pi)
+    {
+        sk_pigpio_cmd_t clear_bank_cmd;
+        clear_bank_cmd.cmd_code = GPIO_CMD_CLEAR_BANK_1;
+        clear_bank_cmd.param1 = PI4B_GPIO_BITMASK;
+
+        sk_gpio_send_cmd(pi, clear_bank_cmd);
+    }
+
+    bool sk_remote_gpio_cleanup(connection pi)
+    {
+        if(!is_connection_open(pi))
+        {
+            LOG(ERROR) << "Remote GPIO: Connection not open.";
+            return false;
+        }
+        cout << "Cleaning Pins on Remote Pi Named: " << pi->name << endl;
+        sk_remote_clear_bank_1(pi);
+        return close_connection(pi);
+    }
+
+    int sk_gpio_send_cmd(connection pi, sk_pigpio_cmd_t &cmd)
+    {
+        if(!is_connection_open(pi))
+        {
+            LOG(ERROR) << "Remote GPIO: Connection not open.";
+            return PIGIF_ERR_BAD_CONNECT;
+        }
+
+        if(pi->protocol == TCP)
+        {
+            int num_send_bytes = sizeof(cmd);
+
+            std::vector<char> buffer(num_send_bytes);
+            memcpy(buffer.data(), &cmd, num_send_bytes);
+
+            if(sk_send_bytes(&pi->socket, buffer.data(), num_send_bytes)) 
+            {
+                int num_bytes_recv = sk_read_bytes(&pi->socket, buffer.data(), num_send_bytes); 
+                if(num_bytes_recv == num_send_bytes) 
                 {
-                        LOG(ERROR) << sk_gpio_error_message(pi);
-                        return false;
+                    sk_pigpio_cmd_t resp;
+                    memcpy(&resp, buffer.data(), num_send_bytes);
+
+                    int32_t result = static_cast<int32_t>(resp.result);
+
+                    if (result < 0)
+                    {
+                        LOG(ERROR) << sk_gpio_error_message(result);
+                    }
+
+                    return result;
                 }
                 else
-                        return true;
-        }
-
-        // Initialize the GPIO library
-        int sk_gpio_init()
-        {
-                pi = pigpio_start(0, 0);
-                return pi;
-        }
-
-        // Read the value of a GPIO pin
-        int sk_gpio_read(int pin)
-        {
-            if (check_pi())
             {
-                int result = gpio_read(pi, pin);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-                return result;
-            }
-            else
-            {
-                return GPIO_DEFAULT_VALUE;
-            }
-        }
-
-        // Write a value to a GPIO pin
-        void sk_gpio_write(int pin, int value)
-        {
-            if (check_pi())
-            {
-                int result = gpio_write(pi, pin, value);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-
-        // Set the mode of a GPIO pin
-        void sk_gpio_set_mode(int pin, int mode)
-        {
-            if(check_pi())
-            {
-                int result = set_mode(pi, pin, mode);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-
-        int sk_gpio_get_mode(int pin)
-        {
-            if(check_pi())
-            {
-                int result = get_mode(pi, pin);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-                return result;
-            }
-        }
-        void sk_gpio_set_pull_up_down(int pin, int pud)
-        {
-            if(check_pi())
-            {
-                int result = set_pull_up_down(pi, pin, pud);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-        void sk_set_pwm_range(int pin, int range)
-        {
-            if(check_pi())
-            {
-                int result = set_PWM_range(pi, pin, range);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-        void sk_set_pwm_frequency(int pin, int frequency)
-        {
-            if(check_pi())
-            {
-                int result = set_PWM_frequency(pi, pin, frequency);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-        void sk_set_pwm_dutycycle(int pin, int dutycycle)
-        {
-            if(check_pi())
-            {
-                int result = set_PWM_dutycycle(pi, pin, dutycycle);
-                if(result < 0)
-                {
-                    LOG(ERROR) << sk_gpio_error_message(result);
-                }
-            }
-        }
-
-	void sk_gpio_clear_bank_1()
-	{
-		clear_bank_1(pi, PI4B_GPIO_BITMASK);
-	}
-        // Cleanup the GPIO library
-        void sk_gpio_cleanup()
-        {
-            if(check_pi())
-            {
-                pigpio_stop(pi);
-            }
-        }
-        #endif
-
-        connection sk_remote_gpio_init(std::string name, const std::string &host, unsigned short int port)
-        {
-            return open_connection(name, host, port);
-        }
-
-        void sk_remote_gpio_set_mode(connection pi, int pin, int mode)
-        {
-            sk_pigpio_cmd_t set_cmd;
-            set_cmd.cmd_code = GPIO_CMD_SET_MODE;
-            set_cmd.param1 = pin;
-            set_cmd.param2 = mode;
-
-            sk_gpio_send_cmd(pi, set_cmd);
-        }
-
-        int sk_remote_gpio_get_mode(connection pi, int pin)
-        {
-            sk_pigpio_cmd_t get_cmd;
-            get_cmd.cmd_code = GPIO_CMD_GET_MODE;
-            get_cmd.param1 = pin;
-
-            return sk_gpio_send_cmd(pi, get_cmd);
-        }
-
-        void sk_remote_gpio_set_pull_up_down(connection pi, int pin, int pud)
-        {
-            sk_pigpio_cmd_t set_pud_cmd;
-            set_pud_cmd.cmd_code = GPIO_CMD_SET_PUD;
-            set_pud_cmd.param1 = pin;
-            set_pud_cmd.param2 = pud;
-
-            sk_gpio_send_cmd(pi, set_pud_cmd);
-        }
-
-        int sk_remote_gpio_read(connection pi, int pin)
-        {
-            sk_pigpio_cmd_t read_cmd;
-            read_cmd.cmd_code = GPIO_CMD_READ;
-            read_cmd.param1 = pin;
-
-            return sk_gpio_send_cmd(pi, read_cmd);
-        }
-
-        void sk_remote_gpio_write(connection pi, int pin, int value)
-        {
-            sk_pigpio_cmd_t write_cmd;
-            write_cmd.cmd_code = GPIO_CMD_WRITE;
-            write_cmd.param1 = pin;
-            write_cmd.param2 = value;
-
-            sk_gpio_send_cmd(pi, write_cmd);
-        }
-
-        void sk_remote_set_pwm_range(connection pi, int pin, int range)
-        {
-            sk_pigpio_cmd_t set_range_cmd;
-            set_range_cmd.cmd_code = GPIO_CMD_SET_PWM_RANGE;
-            set_range_cmd.param1 = pin;
-            set_range_cmd.param2 = range;
-
-            sk_gpio_send_cmd(pi, set_range_cmd);
-        }
-
-        void sk_remote_set_pwm_frequency(connection pi, int pin, int frequency)
-        {
-            sk_pigpio_cmd_t set_freq_cmd;
-            set_freq_cmd.cmd_code = GPIO_CMD_SET_PWM_FREQ;
-            set_freq_cmd.param1 = pin;
-            set_freq_cmd.param2 = frequency;
-
-            sk_gpio_send_cmd(pi, set_freq_cmd);
-        }
-
-        void sk_remote_set_pwm_dutycycle(connection pi, int pin, int dutycycle)
-        {
-            sk_pigpio_cmd_t set_dutycycle_cmd;
-            set_dutycycle_cmd.cmd_code = GPIO_CMD_SET_PWM_DUTYCYCLE;
-            set_dutycycle_cmd.param1 = pin;
-            set_dutycycle_cmd.param2 = dutycycle;
-
-            sk_gpio_send_cmd(pi, set_dutycycle_cmd);
-        }
-
-        void sk_remote_clear_bank_1(connection pi)
-        {
-            sk_pigpio_cmd_t clear_bank_cmd;
-            clear_bank_cmd.cmd_code = GPIO_CMD_CLEAR_BANK_1;
-            clear_bank_cmd.param1 = PI4B_GPIO_BITMASK;
-
-            sk_gpio_send_cmd(pi, clear_bank_cmd);
-        }
-
-        bool sk_remote_gpio_cleanup(connection pi)
-        {
-            if(!is_connection_open(pi))
-            {
-                LOG(ERROR) << "Remote GPIO: Connection not open.";
-                return false;
-            }
-            cout << "Cleaning Pins on Remote Pi Named: " << pi->name << endl;
-            sk_remote_clear_bank_1(pi);
-            return close_connection(pi);
-        }
-
-        int sk_gpio_send_cmd(connection pi, sk_pigpio_cmd_t &cmd)
-        {
-            if(!is_connection_open(pi))
-            {
-                LOG(ERROR) << "Remote GPIO: Connection not open.";
-                return PIGIF_ERR_BAD_CONNECT;
-            }
-
-            if(pi->protocol == TCP)
-            {
-                int num_send_bytes = sizeof(cmd);
-
-                std::vector<char> buffer(num_send_bytes);
-                memcpy(buffer.data(), &cmd, num_send_bytes);
-
-                if(sk_send_bytes(&pi->socket, buffer.data(), num_send_bytes)) 
-                {
-                    int num_bytes_recv = sk_read_bytes(&pi->socket, buffer.data(), num_send_bytes); 
-                    if(num_bytes_recv == num_send_bytes) 
-                    {
-                        sk_pigpio_cmd_t resp;
-                        memcpy(&resp, buffer.data(), num_send_bytes);
-
-                        int32_t result = static_cast<int32_t>(resp.result);
-
-                        if (result < 0)
-                        {
-                            LOG(ERROR) << sk_gpio_error_message(result);
-                        }
-                        
-                        return result;
-                    }
-                    else
-                    {
-                        LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_RECV);
-                        return PIGIF_ERR_BAD_RECV;
-                    }
-                }
-                else
-                {
-                    LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_SEND);
-                    return PIGIF_ERR_BAD_SEND;
+                    LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_RECV);
+                    return PIGIF_ERR_BAD_RECV;
                 }
             }
             else
-            {
-                LOG(ERROR) << "Remote GPIO: Connection has UDP Protocol";
-                return -1;
+        {
+                LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_SEND);
+                return PIGIF_ERR_BAD_SEND;
             }
         }
-        std::string sk_gpio_error_message(int error_code)
+        else
         {
-            switch (error_code)
-            {
+            LOG(ERROR) << "Remote GPIO: Connection has UDP Protocol";
+            return -1;
+        }
+    }
+    std::string sk_gpio_error_message(int error_code)
+    {
+        switch (error_code)
+        {
             case PI_INIT_FAILED:
                 return "GPIO initialization failed. Please check your setup and try again.";
             case PI_BAD_USER_GPIO:
@@ -347,6 +342,6 @@ namespace splashkit_lib
                 return "Failed to create socket for connecting to remote GPIO daemon (pigpiod).";
             default:
                 return "Unknown error code " + std::to_string(error_code);
-            }
         }
+    }
 }

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -14,22 +14,6 @@
 #include "pigpiod_if2.h"
 #endif
 
-// Relevant error codes from pigpio library
-#define PI_INIT_FAILED             -1
-#define PI_BAD_USER_GPIO           -2
-#define PI_BAD_GPIO                -3
-#define PI_BAD_MODE                -4
-#define PI_BAD_LEVEL               -5
-#define PI_BAD_PUD                 -6
-#define PI_BAD_DUTYCYCLE           -8
-#define PI_BAD_DUTYRANGE           -21
-#define PI_NOT_PERMITTED           -41
-#define PI_SOME_PERMITTED          -42
-#define PIGIF_ERR_BAD_SEND         -2000
-#define PIGIF_ERR_BAD_RECV         -2001
-#define PIGIF_ERR_BAD_GET_ADDRINFO -2002
-#define PIGIF_ERR_BAD_CONNECT      -2003
-#define PIGIF_ERR_BAD_SOCKET       -2004
 
 using namespace std;
 // Use https://abyz.me.uk/rpi/pigpio/pdif2.html for local command reference
@@ -188,7 +172,6 @@ namespace splashkit_lib
             set_cmd.param1 = pin;
             set_cmd.param2 = mode;
 
-
             sk_gpio_send_cmd(pi, set_cmd);
         }
 
@@ -303,13 +286,15 @@ namespace splashkit_lib
                     {
                         sk_pigpio_cmd_t resp;
                         memcpy(&resp, buffer, num_send_bytes);
-                        
-                        if (resp.result < 0)
+
+                        int32_t result = static_cast<int32_t>(resp.result);
+
+                        if (result < 0)
                         {
-                            LOG(ERROR) << sk_gpio_error_message(resp.result);
+                            LOG(ERROR) << sk_gpio_error_message(result);
                         }
                         
-                        return resp.result;
+                        return result;
                     }
                     else
                     {
@@ -336,9 +321,9 @@ namespace splashkit_lib
             case PI_INIT_FAILED:
                 return "GPIO initialization failed. Please check your setup and try again.";
             case PI_BAD_USER_GPIO:
-                return "Invalid GPIO pin number. Valid GPIO pins are 0-31.";
+                return "Invalid GPIO pin number."; 
             case PI_BAD_GPIO:
-                return "Invalid GPIO pin number. Valid GPIO pins are 0-53.";
+                return "Invalid GPIO pin number.";
             case PI_BAD_MODE:
                 return "Invalid GPIO mode. Valid modes are 0-7.";
             case PI_BAD_LEVEL:

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -265,7 +265,7 @@ namespace splashkit_lib
     {
         if(!is_connection_open(pi))
         {
-            LOG(ERROR) << "Remote GPIO: Connection not open.";
+            LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_CONNECT); 
             return PIGIF_ERR_BAD_CONNECT;
         }
 
@@ -283,7 +283,8 @@ namespace splashkit_lib
                 {
                     sk_pigpio_cmd_t resp;
                     memcpy(&resp, buffer.data(), num_send_bytes);
-
+                    
+                    // We cast it back to a signed type so we can get the negative error codes.
                     int32_t result = static_cast<int32_t>(resp.result);
 
                     if (result < 0)
@@ -294,13 +295,13 @@ namespace splashkit_lib
                     return result;
                 }
                 else
-            {
+                {
                     LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_RECV);
                     return PIGIF_ERR_BAD_RECV;
                 }
             }
             else
-        {
+            {
                 LOG(ERROR) << sk_gpio_error_message(PIGIF_ERR_BAD_SEND);
                 return PIGIF_ERR_BAD_SEND;
             }
@@ -334,12 +335,8 @@ namespace splashkit_lib
                 return "Failed to send command to remote GPIO daemon (pigpiod).";
             case PIGIF_ERR_BAD_RECV:
                 return "Failed to receive response from remote GPIO daemon (pigpiod).";
-            case PIGIF_ERR_BAD_GET_ADDRINFO:
-                return "Failed to resolve address of remote GPIO daemon (pigpiod).";
             case PIGIF_ERR_BAD_CONNECT:
                 return "Failed to connect to remote GPIO daemon (pigpiod).";
-            case PIGIF_ERR_BAD_SOCKET:
-                return "Failed to create socket for connecting to remote GPIO daemon (pigpiod).";
             default:
                 return "Unknown error code " + std::to_string(error_code);
         }

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -276,16 +276,16 @@ namespace splashkit_lib
             {
                 int num_send_bytes = sizeof(cmd);
 
-                char buffer[num_send_bytes];
-                memcpy(buffer, &cmd, num_send_bytes);
+                std::vector<char> buffer(num_send_bytes);
+                memcpy(buffer.data(), &cmd, num_send_bytes);
 
-                if(sk_send_bytes(&pi->socket, buffer, num_send_bytes)) 
+                if(sk_send_bytes(&pi->socket, buffer.data(), num_send_bytes)) 
                 {
-                    int num_bytes_recv = sk_read_bytes(&pi->socket, buffer, num_send_bytes); 
+                    int num_bytes_recv = sk_read_bytes(&pi->socket, buffer.data(), num_send_bytes); 
                     if(num_bytes_recv == num_send_bytes) 
                     {
                         sk_pigpio_cmd_t resp;
-                        memcpy(&resp, buffer, num_send_bytes);
+                        memcpy(&resp, buffer.data(), num_send_bytes);
 
                         int32_t result = static_cast<int32_t>(resp.result);
 
@@ -321,7 +321,6 @@ namespace splashkit_lib
             case PI_INIT_FAILED:
                 return "GPIO initialization failed. Please check your setup and try again.";
             case PI_BAD_USER_GPIO:
-                return "Invalid GPIO pin number."; 
             case PI_BAD_GPIO:
                 return "Invalid GPIO pin number.";
             case PI_BAD_MODE:

--- a/coresdk/src/backend/gpio_driver.cpp
+++ b/coresdk/src/backend/gpio_driver.cpp
@@ -61,7 +61,7 @@ namespace splashkit_lib
             }
             else
             {
-                return PI_INIT_FAILED;
+                return GPIO_DEFAULT_VALUE;
             }
         }
 
@@ -248,7 +248,7 @@ namespace splashkit_lib
         {
             sk_pigpio_cmd_t clear_bank_cmd;
             clear_bank_cmd.cmd_code = GPIO_CMD_CLEAR_BANK_1;
-            clear_bank_cmd.param1 = 0x0FFFFFFC;
+            clear_bank_cmd.param1 = PI4B_GPIO_BITMASK;
 
             sk_gpio_send_cmd(pi, clear_bank_cmd);
         }
@@ -312,8 +312,8 @@ namespace splashkit_lib
             else
             {
                 LOG(ERROR) << "Remote GPIO: Connection has UDP Protocol";
+                return -1;
             }
-            return -1;
         }
         std::string sk_gpio_error_message(int error_code)
         {

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -9,8 +9,26 @@
 #include "backend_types.h"
 #include <stdint.h> // Include the appropriate header file for stdint.h
 
+// Relevant error codes from pigpio library
+#define PI_INIT_FAILED             -1
+#define PI_BAD_USER_GPIO           -2
+#define PI_BAD_GPIO                -3
+#define PI_BAD_MODE                -4
+#define PI_BAD_LEVEL               -5
+#define PI_BAD_PUD                 -6
+#define PI_BAD_DUTYCYCLE           -8
+#define PI_BAD_DUTYRANGE           -21
+#define PI_NOT_PERMITTED           -41
+#define PI_SOME_PERMITTED          -42
+#define PIGIF_ERR_BAD_SEND         -2000
+#define PIGIF_ERR_BAD_RECV         -2001
+#define PIGIF_ERR_BAD_GET_ADDRINFO -2002
+#define PIGIF_ERR_BAD_CONNECT      -2003
+#define PIGIF_ERR_BAD_SOCKET       -2004
+
 namespace splashkit_lib
 {
+
     #ifdef RASPBERRY_PI
     int sk_gpio_init();
     int sk_gpio_read(int pin);

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -37,6 +37,7 @@ namespace splashkit_lib
     bool sk_remote_gpio_cleanup(connection pi);
 
     int sk_gpio_send_cmd(connection pi, sk_pigpio_cmd_t &cmd);
+    std::string sk_gpio_error_message(int error_code);
 }
 
 #endif /* defined(gpio_driver) */

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -23,6 +23,7 @@
 #define PIGIF_ERR_BAD_CONNECT      -2003
 #define PIGIF_ERR_BAD_SOCKET       -2004
 
+#define PI4B_GPIO_BITMASK 0x0FFFFFFC
 namespace splashkit_lib
 {
 

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -17,13 +17,17 @@
 #define PI_BAD_PUD                 -6
 #define PI_BAD_DUTYCYCLE           -8
 #define PI_BAD_DUTYRANGE           -21
+#define PI_NOT_PERMITTED           -41
+#define PI_SOME_PERMITTED          -42
 #define PIGIF_ERR_BAD_SEND         -2000
 #define PIGIF_ERR_BAD_RECV         -2001
 #define PIGIF_ERR_BAD_GET_ADDRINFO -2002
 #define PIGIF_ERR_BAD_CONNECT      -2003
 #define PIGIF_ERR_BAD_SOCKET       -2004
 
+// Bitmask for valid user GPIO on the 4B board
 #define PI4B_GPIO_BITMASK 0x0FFFFFFC
+
 namespace splashkit_lib
 {
 

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -21,9 +21,7 @@
 #define PI_SOME_PERMITTED          -42
 #define PIGIF_ERR_BAD_SEND         -2000
 #define PIGIF_ERR_BAD_RECV         -2001
-#define PIGIF_ERR_BAD_GET_ADDRINFO -2002
 #define PIGIF_ERR_BAD_CONNECT      -2003
-#define PIGIF_ERR_BAD_SOCKET       -2004
 
 // Bitmask for valid user GPIO on the 4B board
 #define PI4B_GPIO_BITMASK 0x0FFFFFFC

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -37,6 +37,7 @@ namespace splashkit_lib
     void sk_set_pwm_range(int pin, int range);
     void sk_set_pwm_frequency(int pin, int frequency);
     void sk_set_pwm_dutycycle(int pin, int dutycycle);
+    void sk_gpio_clear_bank_1();
     void sk_gpio_cleanup();
     #endif
     

--- a/coresdk/src/backend/gpio_driver.h
+++ b/coresdk/src/backend/gpio_driver.h
@@ -5,7 +5,6 @@
 #ifndef SPLASHKIT_GPIO_H
 #define SPLASHKIT_GPIO_H
 
-#include "network_driver.h"
 #include "backend_types.h"
 #include <stdint.h> // Include the appropriate header file for stdint.h
 
@@ -18,8 +17,6 @@
 #define PI_BAD_PUD                 -6
 #define PI_BAD_DUTYCYCLE           -8
 #define PI_BAD_DUTYRANGE           -21
-#define PI_NOT_PERMITTED           -41
-#define PI_SOME_PERMITTED          -42
 #define PIGIF_ERR_BAD_SEND         -2000
 #define PIGIF_ERR_BAD_RECV         -2001
 #define PIGIF_ERR_BAD_GET_ADDRINFO -2002

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -220,8 +220,8 @@ namespace splashkit_lib
             int bcmPin = boardToBCM(static_cast<pins>(i));
             if (bcmPin > 0)
             {
-                raspi_set_mode(static_cast<pins>(bcmPin), GPIO_INPUT);
-                raspi_write(static_cast<pins>(bcmPin), GPIO_LOW);
+                raspi_set_mode(static_cast<pins>(i), GPIO_INPUT);
+                raspi_write(static_cast<pins>(i), GPIO_LOW);
             }
         }
         sk_gpio_cleanup();

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -23,12 +23,17 @@ namespace splashkit_lib
             bcmPinResult = BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
         }
 
+        // Pins 0 and 1 are EEPROM pins and should not be written to
+        // See Page 9. of Raspberry Pi 4B Datasheet:
+        // https://datasheets.raspberrypi.com/rpi4/raspberry-pi-4-datasheet.pdf
+        // Archive Link:
+        // https://web.archive.org/web/20240901170108/https://datasheets.raspberrypi.com/rpi4/raspberry-pi-4-datasheet.pdf
         if(bcmPinResult < 2)
         {
-	    std::string extra_text = " Pin is a";
-	    extra_text += (bcmPinResult >= 0) ? "n EEPROM Pin, using this could corrupt the bootloader." :
-			          (bcmPinResult == -1) ? " POWER line." :
-                      (bcmPinResult == -2) ? " GROUND line." : "n Unknown Pin Type.";
+	        std::string extra_text = " Pin is a";
+    	    extra_text += (bcmPinResult >= 0) ? "n EEPROM Pin, using this could corrupt the bootloader." :
+	    		          (bcmPinResult == -1) ? " POWER line." :
+                          (bcmPinResult == -2) ? " GROUND line." : "n Unknown Pin Type.";
             LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + extra_text;
             return PI_BAD_GPIO;
         }
@@ -182,58 +187,52 @@ namespace splashkit_lib
     void remote_raspi_set_mode(connection pi, pins pin, pin_modes mode)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return;
-        else return sk_remote_gpio_set_mode(pi, bcmPin, mode);
+        if (bcmPin >= 2) sk_remote_gpio_set_mode(pi, bcmPin, mode);
     }
 
     pin_modes remote_raspi_get_mode(connection pi, pins pin)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return GPIO_DEFAULT_MODE;
-        else return static_cast<pin_modes>(sk_remote_gpio_get_mode(pi, bcmPin));
-        return GPIO_DEFAULT_MODE;
+        if(bcmPin >= 2) return static_cast<pin_modes>(sk_remote_gpio_get_mode(pi, bcmPin));
+        else return GPIO_DEFAULT_MODE;
     }
 
     void remote_raspi_set_pull_up_down(connection pi, pins pin, pull_up_down pud)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return;
-        else return sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
+        if(bcmPin >= 2) sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
     }
 
     void remote_raspi_write(connection pi, pins pin, pin_values value)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return;
-        else return sk_remote_gpio_write(pi, bcmPin, value);
+        
+        if(bcmPin >= 2) sk_remote_gpio_write(pi, bcmPin, value);
     }
 
     pin_values remote_raspi_read(connection pi, pins pin)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return GPIO_DEFAULT_VALUE;
-        else return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
+        if(bcmPin >= 2) return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
+        else return GPIO_DEFAULT_VALUE;
     }
 
     void remote_raspi_set_pwm_range(connection pi, pins pin, int range)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return;
-        else return sk_remote_set_pwm_range(pi, bcmPin, range);
+        if(bcmPin >= 2) sk_remote_set_pwm_range(pi, bcmPin, range);
     }
 
     void remote_raspi_set_pwm_frequency(connection pi, pins pin, int frequency)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return; 
-        else return sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
+        if(bcmPin >= 2) sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
     }
 
     void remote_raspi_set_pwm_dutycycle(connection pi, pins pin, int dutycycle)
     {
         int bcmPin = boardToBCM(pin);
-        if(bcmPin < 0) return;
-        else return sk_remote_set_pwm_dutycycle(pi, bcmPin, dutycycle);      
+        if(bcmPin >= 2) sk_remote_set_pwm_dutycycle(pi, bcmPin, dutycycle);
     }
 
     bool remote_raspi_cleanup(connection pi)

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -5,6 +5,7 @@
 #include "raspi_gpio.h"
 #include "gpio_driver.h"
 #include "easylogging++.h"
+#include "types.h"
 #include <iostream>
 using namespace std;
 
@@ -24,11 +25,11 @@ namespace splashkit_lib
 
         if(bcmPinResult < 2)
         {
-	    std::string extra_text " Pin is a";
-	    extra_text += (bcmPinResult >= 0) ? " EEPROM Pin, using this could corrupt the bootloader." :
-			  (bcmPinResult == -1) ? " Pin is a POWER line." :
-                          (bcmPinResult == -2) ? " Pin is a GROUND line." : " Unknown Pin Type.");
-            LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + (
+	    std::string extra_text = " Pin is a";
+	    extra_text += (bcmPinResult >= 0) ? "n EEPROM Pin, using this could corrupt the bootloader." :
+			          (bcmPinResult == -1) ? " POWER line." :
+                      (bcmPinResult == -2) ? " GROUND line." : "n Unknown Pin Type.";
+            LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + extra_text;
             return PI_BAD_GPIO;
         }
         else
@@ -60,15 +61,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)
         {
             sk_gpio_set_mode(bcmPin, static_cast<int>(mode));
         }
@@ -80,15 +73,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)    
         {
             return static_cast<pin_modes>(sk_gpio_get_mode(bcmPin));
         }
@@ -104,15 +89,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant write a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant write a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2) 
         {
             sk_gpio_write(bcmPin, static_cast<int>(value));
         }
@@ -126,17 +103,11 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
+        if(bcmPin >= 2)
         {
-            cout << "Reading of PIN: " << pin << " would always be HIGH" << endl;
-            return GPIO_HIGH;
+            return static_cast<pin_values>(sk_gpio_read(bcmPin));
         }
-        else if (bcmPin == -2)
-        {
-            cout << "Reading of PIN: " << pin << " would always be LOW" << endl;
-            return GPIO_LOW;
-        }
-        return static_cast<pin_values>(sk_gpio_read(bcmPin));
+        return GPIO_DEFAULT_VALUE;
 #else
         cout << "Unable to read pin - GPIO not supported on this platform" << endl;
         return GPIO_DEFAULT_VALUE;
@@ -146,15 +117,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)
         {
             sk_gpio_set_pull_up_down(bcmPin, static_cast<int>(pud));
         }
@@ -166,15 +129,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)
         {
             sk_set_pwm_range(bcmPin, range);
         }
@@ -186,15 +141,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)
         {
             sk_set_pwm_frequency(bcmPin, frequency);
         }
@@ -206,15 +153,7 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
+        if(bcmPin >= 2)
         {
             sk_set_pwm_dutycycle(bcmPin, dutycycle);
         }
@@ -229,7 +168,7 @@ namespace splashkit_lib
 #ifdef RASPBERRY_PI
         cout << "Cleaning GPIO pins" << endl;
        	sk_gpio_clear_bank_1();
-	sk_gpio_cleanup();
+    	sk_gpio_cleanup();
 #else
         cout << "Unable to set cleanup - GPIO not supported on this platform" << endl;
 #endif

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -30,7 +30,7 @@ namespace splashkit_lib
         // https://web.archive.org/web/20240901170108/https://datasheets.raspberrypi.com/rpi4/raspberry-pi-4-datasheet.pdf
         if(bcmPinResult < 2)
         {
-	        std::string extra_text = " Pin is a";
+            std::string extra_text = " Pin is a";
     	    extra_text += (bcmPinResult >= 0) ? "n EEPROM Pin, using this could corrupt the bootloader." :
 	    		          (bcmPinResult == -1) ? " POWER line." :
                           (bcmPinResult == -2) ? " GROUND line." : "n Unknown Pin Type.";

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -22,10 +22,13 @@ namespace splashkit_lib
             bcmPinResult = BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
         }
 
-        if(bcmPinResult < 0)
+        if(bcmPinResult < 2)
         {
-            LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + ((bcmPinResult == -1) ? " Pin is a POWER line." :
-                                                                (bcmPinResult == -2) ? " Pin is a GROUND line." : " Unknown Pin Type.");
+	    std::string extra_text " Pin is a";
+	    extra_text += (bcmPinResult >= 0) ? " EEPROM Pin, using this could corrupt the bootloader." :
+			  (bcmPinResult == -1) ? " Pin is a POWER line." :
+                          (bcmPinResult == -2) ? " Pin is a GROUND line." : " Unknown Pin Type.");
+            LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + (
             return PI_BAD_GPIO;
         }
         else
@@ -225,16 +228,8 @@ namespace splashkit_lib
     {
 #ifdef RASPBERRY_PI
         cout << "Cleaning GPIO pins" << endl;
-        for (int i = 1; i <= 40; i++)
-        {
-            int bcmPin = boardToBCM(static_cast<pins>(i));
-            if (bcmPin > 0)
-            {
-                raspi_set_mode(static_cast<pins>(i), GPIO_INPUT);
-                raspi_write(static_cast<pins>(i), GPIO_LOW);
-            }
-        }
-        sk_gpio_cleanup();
+       	sk_gpio_clear_bank_1();
+	sk_gpio_cleanup();
 #else
         cout << "Unable to set cleanup - GPIO not supported on this platform" << endl;
 #endif

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -4,6 +4,7 @@
 // Copyright © 2024 XQuestCode. All rights reserved.
 #include "raspi_gpio.h"
 #include "gpio_driver.h"
+#include "easylogging++.h"
 #include <iostream>
 using namespace std;
 
@@ -19,8 +20,8 @@ namespace splashkit_lib
         {
             return BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
         }
-        cout << "Invalid board pin" << endl;
-        return -1;
+        LOG(ERROR) << "Invalid board pin";
+        return PI_BAD_GPIO;
     }
     bool has_gpio()
     {
@@ -54,6 +55,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_gpio_set_mode(bcmPin, static_cast<int>(mode));
@@ -73,6 +78,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -97,6 +106,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant write a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -141,6 +154,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_gpio_set_pull_up_down(bcmPin, static_cast<int>(pud));
@@ -160,6 +177,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -181,6 +202,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_set_pwm_frequency(bcmPin, frequency);
@@ -200,6 +225,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -246,6 +275,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_remote_gpio_set_mode(pi, bcmPin, mode);
@@ -262,6 +295,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return GPIO_DEFAULT_MODE;
         }
         else
         {
@@ -281,6 +318,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
@@ -297,6 +338,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -317,6 +362,10 @@ namespace splashkit_lib
             cout << "Reading of PIN: " << pin << " would always be LOW" << endl;
             return GPIO_LOW;
         }
+        else if (bcmPin == -3)
+        {
+            return GPIO_DEFAULT_VALUE;
+        }
         else
         {
             return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
@@ -333,6 +382,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {
@@ -351,6 +404,10 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
+        else if (bcmPin == -3)
+        {
+            return;
+        }
         else
         {
             sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
@@ -367,6 +424,10 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
+        }
+        else if (bcmPin == -3)
+        {
+            return;
         }
         else
         {

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -16,12 +16,22 @@ namespace splashkit_lib
 
     int boardToBCM(pins pin)
     {
+        int bcmPinResult = PI_BAD_GPIO;
         if (pin >= PIN_1 && pin <= PIN_40)
         {
-            return BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
+            bcmPinResult = BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
         }
-        LOG(ERROR) << "Invalid board pin";
-        return pin;
+
+        if(bcmPinResult < 0)
+        {
+            LOG(ERROR) << sk_gpio_error_message(PI_BAD_GPIO) + ((bcmPinResult == -1) ? " Pin is a POWER line." :
+                                                                (bcmPinResult == -2) ? " Pin is a GROUND line." : " Unknown Pin Type.");
+            return PI_BAD_GPIO;
+        }
+        else
+        {
+            return bcmPinResult;
+        }
     }
     bool has_gpio()
     {
@@ -238,141 +248,58 @@ namespace splashkit_lib
     void remote_raspi_set_mode(connection pi, pins pin, pin_modes mode)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_gpio_set_mode(pi, bcmPin, mode);
-        }
+        if(bcmPin < 0) return;
+        else return sk_remote_gpio_set_mode(pi, bcmPin, mode);
     }
 
     pin_modes remote_raspi_get_mode(connection pi, pins pin)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            return static_cast<pin_modes>(sk_remote_gpio_get_mode(pi, bcmPin));
-        }
+        if(bcmPin < 0) return GPIO_DEFAULT_MODE;
+        else return static_cast<pin_modes>(sk_remote_gpio_get_mode(pi, bcmPin));
         return GPIO_DEFAULT_MODE;
     }
 
     void remote_raspi_set_pull_up_down(connection pi, pins pin, pull_up_down pud)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
-        }
+        if(bcmPin < 0) return;
+        else return sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
     }
 
     void remote_raspi_write(connection pi, pins pin, pin_values value)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_gpio_write(pi, bcmPin, value);
-        }
+        if(bcmPin < 0) return;
+        else return sk_remote_gpio_write(pi, bcmPin, value);
     }
 
     pin_values remote_raspi_read(connection pi, pins pin)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Reading of PIN: " << pin << " would always be HIGH" << endl;
-            return GPIO_HIGH;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Reading of PIN: " << pin << " would always be LOW" << endl;
-            return GPIO_LOW;
-        }
-        else
-        {
-            return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
-        }
-        return GPIO_DEFAULT_VALUE;
+        if(bcmPin < 0) return GPIO_DEFAULT_VALUE;
+        else return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
     }
 
     void remote_raspi_set_pwm_range(connection pi, pins pin, int range)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_set_pwm_range(pi, bcmPin, range);
-        }
+        if(bcmPin < 0) return;
+        else return sk_remote_set_pwm_range(pi, bcmPin, range);
     }
 
     void remote_raspi_set_pwm_frequency(connection pi, pins pin, int frequency)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
-        }
+        if(bcmPin < 0) return; 
+        else return sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
     }
 
     void remote_raspi_set_pwm_dutycycle(connection pi, pins pin, int dutycycle)
     {
         int bcmPin = boardToBCM(pin);
-        if (bcmPin == -1)
-        {
-            cout << "Cant modify a HIGH Pin" << endl;
-        }
-        else if (bcmPin == -2)
-        {
-            cout << "Cant modify a Ground pin" << endl;
-        }
-        else
-        {
-            sk_remote_set_pwm_dutycycle(pi, bcmPin, dutycycle);
-        }
+        if(bcmPin < 0) return;
+        else return sk_remote_set_pwm_dutycycle(pi, bcmPin, dutycycle);      
     }
 
     bool remote_raspi_cleanup(connection pi)

--- a/coresdk/src/coresdk/raspi_gpio.cpp
+++ b/coresdk/src/coresdk/raspi_gpio.cpp
@@ -21,7 +21,7 @@ namespace splashkit_lib
             return BCMpinData[static_cast<int>(pin) - static_cast<int>(PIN_1)];
         }
         LOG(ERROR) << "Invalid board pin";
-        return PI_BAD_GPIO;
+        return pin;
     }
     bool has_gpio()
     {
@@ -55,10 +55,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_gpio_set_mode(bcmPin, static_cast<int>(mode));
@@ -78,10 +74,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {
@@ -107,10 +99,6 @@ namespace splashkit_lib
         {
             cout << "Cant write a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_gpio_write(bcmPin, static_cast<int>(value));
@@ -132,7 +120,6 @@ namespace splashkit_lib
         }
         else if (bcmPin == -2)
         {
-
             cout << "Reading of PIN: " << pin << " would always be LOW" << endl;
             return GPIO_LOW;
         }
@@ -154,10 +141,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_gpio_set_pull_up_down(bcmPin, static_cast<int>(pud));
@@ -177,10 +160,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {
@@ -202,10 +181,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_set_pwm_frequency(bcmPin, frequency);
@@ -225,10 +200,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {
@@ -275,10 +246,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_remote_gpio_set_mode(pi, bcmPin, mode);
@@ -295,10 +262,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return GPIO_DEFAULT_MODE;
         }
         else
         {
@@ -318,10 +281,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_remote_gpio_set_pull_up_down(pi, bcmPin, pud);
@@ -338,10 +297,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {
@@ -362,14 +317,11 @@ namespace splashkit_lib
             cout << "Reading of PIN: " << pin << " would always be LOW" << endl;
             return GPIO_LOW;
         }
-        else if (bcmPin == -3)
-        {
-            return GPIO_DEFAULT_VALUE;
-        }
         else
         {
             return static_cast<pin_values>(sk_remote_gpio_read(pi, bcmPin));
         }
+        return GPIO_DEFAULT_VALUE;
     }
 
     void remote_raspi_set_pwm_range(connection pi, pins pin, int range)
@@ -382,10 +334,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {
@@ -404,10 +352,6 @@ namespace splashkit_lib
         {
             cout << "Cant modify a Ground pin" << endl;
         }
-        else if (bcmPin == -3)
-        {
-            return;
-        }
         else
         {
             sk_remote_set_pwm_frequency(pi, bcmPin, frequency);
@@ -424,10 +368,6 @@ namespace splashkit_lib
         else if (bcmPin == -2)
         {
             cout << "Cant modify a Ground pin" << endl;
-        }
-        else if (bcmPin == -3)
-        {
-            return;
         }
         else
         {

--- a/coresdk/src/coresdk/raspi_gpio.h
+++ b/coresdk/src/coresdk/raspi_gpio.h
@@ -10,7 +10,7 @@
 #define raspi_gpio_hpp
 
 #include <stdint.h>
-#include "gpio_driver.h"
+#include "networking.h"
 #include "types.h"
 
 namespace splashkit_lib

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -38,7 +38,7 @@ void local_gpio_invalid_tests()
 
     // --- ERROR TEST: Invalid GPIO pin number ---
     cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
-    raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+    raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);  
 
     // --- ERROR TEST: Invalid GPIO pin number (EEPROM pin) ---
     cout << "Testing invalid GPIO pin number (EEPROM pin)" << endl;
@@ -46,23 +46,23 @@ void local_gpio_invalid_tests()
     
     // --- ERROR TEST: Invalid GPIO pin number (POWER line) ---
     cout << "Testing invalid GPIO pin number (PIN_17, POWER line)" << endl;
-    raspi_set_mode(PIN_17, GPIO_OUTPUT);  // Invalid pin number
+    raspi_set_mode(PIN_17, GPIO_OUTPUT);  
 
     // --- ERROR TEST: Invalid GPIO pin number (GROUND line) ---
     cout << "Testing invalid GPIO pin number (PIN_6, GROUND line)" << endl;
-    raspi_set_mode(PIN_6, GPIO_OUTPUT);  // Invalid pin number
+    raspi_set_mode(PIN_6, GPIO_OUTPUT);  
 
     // --- ERROR TEST: Invalid GPIO mode ---
     cout << "Testing invalid GPIO mode (mode 10)" << endl;
-    raspi_set_mode(PIN_11, static_cast<pin_modes>(10));  // Invalid mode
+    raspi_set_mode(PIN_11, static_cast<pin_modes>(10));  
 
     // --- ERROR TEST: Invalid GPIO write value ---
     cout << "Testing invalid GPIO value (writing 5)" << endl;
-    raspi_write(PIN_11, static_cast<pin_values>(5));  // Invalid GPIO value
+    raspi_write(PIN_11, static_cast<pin_values>(5));  
 
     // --- ERROR TEST: Invalid pull-up/down configuration ---
     cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
-    raspi_set_pull_up_down(PIN_11, static_cast<pull_up_down>(3));  // Invalid PUD value
+    raspi_set_pull_up_down(PIN_11, static_cast<pull_up_down>(3));  
     
     // --- ERROR TEST: Invalid PWM Duty Cycle
     cout << "Testing invalid PWM duty cycle configuration (Duty Cycle value 300)" << endl;
@@ -83,7 +83,7 @@ void remote_gpio_valid_tests(connection pi)
     // Read the initial value of GPIO pin 11
     int defaultValue = remote_raspi_read(pi, PIN_11);
     cout << "Value of Pin 11: " << defaultValue << endl;
-
+    
     // Write HIGH to GPIO pin 11
     cout << "Writing HIGH to GPIO pin 11" << endl;
     remote_raspi_write(pi, PIN_11, GPIO_HIGH);

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -4,13 +4,14 @@
 * 🚀 © 2024 Aditya Parmar. All Rights Reserved.
 ***********************************************/
 #include <iostream>
+#include "networking.h"
 #include "raspi_gpio.h"
 using namespace std;
 using namespace splashkit_lib;
 
 // Function to run GPIO tests
 
-void local_gpio_tests()
+void local_gpio_valid_tests()
 {
     // Initialize the GPIO
     cout << "Initializing GPIO" << endl;
@@ -40,6 +41,12 @@ void local_gpio_tests()
     cout << "Writing HIGH to Ground PIN" << endl;
     raspi_write(PIN_6, GPIO_HIGH);
 
+    raspi_cleanup();
+}
+
+void local_gpio_invalid_tests()
+{
+    raspi_init();
     cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
     raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);
 
@@ -64,7 +71,7 @@ void local_gpio_tests()
     raspi_cleanup();
 }
 
-void remote_gpio_tests()
+void remote_gpio_valid_tests()
 {
     cout << "This test requires a remote Raspberry Pi running the Pigpio Daemon\n";
     cout << "Enter IP Address of remote Pi:\n";
@@ -95,12 +102,24 @@ void remote_gpio_tests()
     // Write HIGH to GPIO pin 17
     cout << "Writing HIGH to GPIO pin 17" << endl;
     remote_raspi_write(pi, PIN_17, GPIO_HIGH);
-
+  
     // Write HIGH to Ground PIN
     cout << "Writing HIGH to Ground PIN" << endl;
     remote_raspi_write(pi, PIN_6, GPIO_HIGH);
 
+    raspi_cleanup();
+}
+void remote_gpio_invalid_tests()
+{
+    cout << "This test requires a remote Raspberry Pi running the Pigpio Daemon\n";
+    cout << "Enter IP Address of remote Pi:\n";
 
+    std::string host;
+    std::getline(std::cin, host);
+
+    // Initialize the GPIO
+    cout << "Initializing GPIO" << endl;
+    connection pi = remote_raspi_init("Raspi", host, 8888);
     cout << "-- Testing GPIO errors --" << endl;
 
     // --- ERROR TEST: Invalid GPIO pin number ---
@@ -124,9 +143,11 @@ void remote_gpio_tests()
 }
 void run_gpio_tests() 
 {
-    local_gpio_tests();
+    local_gpio_valid_tests();
+    local_gpio_invalid_tests();
 }
 void run_remote_gpio_tests()
 {
-    remote_gpio_tests();
+    remote_gpio_valid_tests();
+    remote_gpio_invalid_tests();
 }

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -39,6 +39,10 @@ void local_gpio_invalid_tests()
     // --- ERROR TEST: Invalid GPIO pin number ---
     cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
     raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+
+    // --- ERROR TEST: Invalid GPIO pin number (EEPROM pin) ---
+    cout << "Testing invalid GPIO pin number (EEPROM pin)" << endl;
+    raspi_set_mode(PIN_27, GPIO_OUTPUT); 
     
     // --- ERROR TEST: Invalid GPIO pin number (POWER line) ---
     cout << "Testing invalid GPIO pin number (PIN_17, POWER line)" << endl;

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -96,6 +96,10 @@ void remote_gpio_invalid_tests(connection pi)
     cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
     remote_raspi_set_mode(pi, static_cast<pins>(60), GPIO_OUTPUT); 
 
+    // --- ERROR TEST: Invalid GPIO pin number (EEPROM pin) ---
+    cout << "Testing invalid GPIO pin number (EEPROM pin)" << endl;
+    remote_raspi_set_mode(pi, PIN_27, GPIO_OUTPUT); 
+     
     // --- ERROR TEST: Invalid GPIO pin number (POWER line) ---
     cout << "Testing invalid GPIO pin number (PIN_17, POWER line)" << endl;
     remote_raspi_set_mode(pi, PIN_17, GPIO_OUTPUT); 

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -9,7 +9,8 @@ using namespace std;
 using namespace splashkit_lib;
 
 // Function to run GPIO tests
-void run_gpio_tests()
+
+void local_gpio_tests()
 {
     // Initialize the GPIO
     cout << "Initializing GPIO" << endl;
@@ -39,11 +40,31 @@ void run_gpio_tests()
     cout << "Writing HIGH to Ground PIN" << endl;
     raspi_write(PIN_6, GPIO_HIGH);
 
+    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
+    raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);
+
+    cout << "-- Testing GPIO errors --" << endl;
+
+    // --- ERROR TEST: Invalid GPIO pin number ---
+    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
+    raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+
+    // --- ERROR TEST: Invalid GPIO mode ---
+    cout << "Testing invalid GPIO mode (mode 10)" << endl;
+    raspi_set_mode(PIN_11, static_cast<pin_modes>(10));  // Invalid mode
+
+    // --- ERROR TEST: Invalid GPIO write value ---
+    cout << "Testing invalid GPIO value (writing 5)" << endl;
+    raspi_write(PIN_11, static_cast<pin_values>(5));  // Invalid GPIO value
+
+    // --- ERROR TEST: Invalid pull-up/down configuration ---
+    cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
+    raspi_set_pull_up_down(PIN_11, static_cast<pull_up_down>(3));  // Invalid PUD value
     // Clean up the GPIO
     raspi_cleanup();
 }
 
-void run_remote_gpio_tests()
+void remote_gpio_tests()
 {
     cout << "This test requires a remote Raspberry Pi running the Pigpio Daemon\n";
     cout << "Enter IP Address of remote Pi:\n";
@@ -79,6 +100,33 @@ void run_remote_gpio_tests()
     cout << "Writing HIGH to Ground PIN" << endl;
     remote_raspi_write(pi, PIN_6, GPIO_HIGH);
 
+
+    cout << "-- Testing GPIO errors --" << endl;
+
+    // --- ERROR TEST: Invalid GPIO pin number ---
+    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
+    remote_raspi_set_mode(pi, static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+
+    // --- ERROR TEST: Invalid GPIO mode ---
+    cout << "Testing invalid GPIO mode (mode 10)" << endl;
+    remote_raspi_set_mode(pi, PIN_11, static_cast<pin_modes>(10));  // Invalid mode
+
+    // --- ERROR TEST: Invalid GPIO write value ---
+    cout << "Testing invalid GPIO value (writing 5)" << endl;
+    remote_raspi_write(pi, PIN_11, static_cast<pin_values>(5));  // Invalid GPIO value
+
+    // --- ERROR TEST: Invalid pull-up/down configuration ---
+    cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
+    remote_raspi_set_pull_up_down(pi, PIN_11, static_cast<pull_up_down>(3));  // Invalid PUD value
+
     // Clean up the GPIO
     remote_raspi_cleanup(pi);
+}
+void run_gpio_tests() 
+{
+    local_gpio_tests();
+}
+void run_remote_gpio_tests()
+{
+    remote_gpio_tests();
 }

--- a/coresdk/src/test/test_raspi_gpio.cpp
+++ b/coresdk/src/test/test_raspi_gpio.cpp
@@ -13,10 +13,8 @@ using namespace splashkit_lib;
 
 void local_gpio_valid_tests()
 {
-    // Initialize the GPIO
-    cout << "Initializing GPIO" << endl;
-    raspi_init();
-
+    cout << "\n-- Testing valid GPIO calls --\n" << endl;
+     
     // Set GPIO pin 11 as an output
     cout << "Setting GPIO pin 11 as an output" << endl;
     raspi_set_mode(PIN_11, GPIO_OUTPUT);
@@ -32,29 +30,23 @@ void local_gpio_valid_tests()
     // Read the value of GPIO pin 11
     int value = raspi_read(PIN_11);
     cout << "GPIO 11 value: " << value << endl;
-
-    // Write HIGH to GPIO pin 17
-    cout << "Writing HIGH to GPIO pin 17" << endl;
-    raspi_write(PIN_17, GPIO_HIGH);
-
-    // Write HIGH to Ground PIN
-    cout << "Writing HIGH to Ground PIN" << endl;
-    raspi_write(PIN_6, GPIO_HIGH);
-
-    raspi_cleanup();
 }
 
 void local_gpio_invalid_tests()
 {
-    raspi_init();
-    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
-    raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);
-
-    cout << "-- Testing GPIO errors --" << endl;
+    cout << "\n-- Testing invalid GPIO calls --\n" << endl;
 
     // --- ERROR TEST: Invalid GPIO pin number ---
     cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
     raspi_set_mode(static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+    
+    // --- ERROR TEST: Invalid GPIO pin number (POWER line) ---
+    cout << "Testing invalid GPIO pin number (PIN_17, POWER line)" << endl;
+    raspi_set_mode(PIN_17, GPIO_OUTPUT);  // Invalid pin number
+
+    // --- ERROR TEST: Invalid GPIO pin number (GROUND line) ---
+    cout << "Testing invalid GPIO pin number (PIN_6, GROUND line)" << endl;
+    raspi_set_mode(PIN_6, GPIO_OUTPUT);  // Invalid pin number
 
     // --- ERROR TEST: Invalid GPIO mode ---
     cout << "Testing invalid GPIO mode (mode 10)" << endl;
@@ -67,22 +59,19 @@ void local_gpio_invalid_tests()
     // --- ERROR TEST: Invalid pull-up/down configuration ---
     cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
     raspi_set_pull_up_down(PIN_11, static_cast<pull_up_down>(3));  // Invalid PUD value
-    // Clean up the GPIO
-    raspi_cleanup();
+    
+    // --- ERROR TEST: Invalid PWM Duty Cycle
+    cout << "Testing invalid PWM duty cycle configuration (Duty Cycle value 300)" << endl;
+    raspi_set_pwm_dutycycle(PIN_11, 300);
+
+    // --- ERROR TEST: Invalid PWM Range
+    cout << "Testing invalid PWM range configuration (Range value 40001)" << endl;
+    raspi_set_pwm_range(PIN_11, 40001);
 }
 
-void remote_gpio_valid_tests()
+void remote_gpio_valid_tests(connection pi)
 {
-    cout << "This test requires a remote Raspberry Pi running the Pigpio Daemon\n";
-    cout << "Enter IP Address of remote Pi:\n";
-
-    std::string host;
-    std::getline(std::cin, host);
-
-    // Initialize the GPIO
-    cout << "Initializing GPIO" << endl;
-    connection pi = remote_raspi_init("Raspi", host, 8888);
-
+    cout << "\n-- Testing valid GPIO calls --\n" << endl;
     // Set GPIO pin 11 as an output
     cout << "Setting GPIO pin 11 as an output" << endl;
     remote_raspi_set_mode(pi, PIN_11, GPIO_OUTPUT);
@@ -98,56 +87,64 @@ void remote_gpio_valid_tests()
     // Read the value of GPIO pin 11
     int value = remote_raspi_read(pi, PIN_11);
     cout << "GPIO 11 value: " << value << endl;
+}
+void remote_gpio_invalid_tests(connection pi)
+{
+    cout << "\n-- Testing invalid GPIO calls --\n" << endl;
 
-    // Write HIGH to GPIO pin 17
-    cout << "Writing HIGH to GPIO pin 17" << endl;
-    remote_raspi_write(pi, PIN_17, GPIO_HIGH);
-  
-    // Write HIGH to Ground PIN
-    cout << "Writing HIGH to Ground PIN" << endl;
-    remote_raspi_write(pi, PIN_6, GPIO_HIGH);
+    // --- ERROR TEST: Invalid GPIO pin number ---
+    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
+    remote_raspi_set_mode(pi, static_cast<pins>(60), GPIO_OUTPUT); 
 
+    // --- ERROR TEST: Invalid GPIO pin number (POWER line) ---
+    cout << "Testing invalid GPIO pin number (PIN_17, POWER line)" << endl;
+    remote_raspi_set_mode(pi, PIN_17, GPIO_OUTPUT); 
+    
+    // --- ERROR TEST: Invalid GPIO pin number (GROUND line) ---
+    cout << "Testing invalid GPIO pin number (PIN_6, GROUND line)" << endl;
+    remote_raspi_set_mode(pi, PIN_6, GPIO_OUTPUT); 
+    
+    // --- ERROR TEST: Invalid GPIO mode ---
+    cout << "Testing invalid GPIO mode (mode 10)" << endl;
+    remote_raspi_set_mode(pi, PIN_11, static_cast<pin_modes>(10));  
+
+    // --- ERROR TEST: Invalid GPIO write value ---
+    cout << "Testing invalid GPIO value (writing 5)" << endl;
+    remote_raspi_write(pi, PIN_11, static_cast<pin_values>(5));  
+
+    // --- ERROR TEST: Invalid pull-up/down configuration ---
+    cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
+    remote_raspi_set_pull_up_down(pi, PIN_11, static_cast<pull_up_down>(3));  
+
+    // --- ERROR TEST: Invalid PWM Duty Cycle
+    cout << "Testing invalid PWM duty cycle configuration (Duty Cycle value 300)" << endl;
+    remote_raspi_set_pwm_dutycycle(pi, PIN_11, 300);
+
+    // --- ERROR TEST: Invalid PWM Range
+    cout << "Testing invalid PWM range configuration (Range value 40001)" << endl;
+    remote_raspi_set_pwm_range(pi, PIN_11, 40001);
+}
+void run_gpio_tests() 
+{
+    raspi_init();
+    local_gpio_valid_tests();
+    local_gpio_invalid_tests();
     raspi_cleanup();
 }
-void remote_gpio_invalid_tests()
+void run_remote_gpio_tests()
 {
+
     cout << "This test requires a remote Raspberry Pi running the Pigpio Daemon\n";
     cout << "Enter IP Address of remote Pi:\n";
 
     std::string host;
     std::getline(std::cin, host);
 
-    // Initialize the GPIO
     cout << "Initializing GPIO" << endl;
     connection pi = remote_raspi_init("Raspi", host, 8888);
-    cout << "-- Testing GPIO errors --" << endl;
 
-    // --- ERROR TEST: Invalid GPIO pin number ---
-    cout << "Testing invalid GPIO pin number (PIN_60)" << endl;
-    remote_raspi_set_mode(pi, static_cast<pins>(60), GPIO_OUTPUT);  // Invalid pin number
+    remote_gpio_valid_tests(pi);
+    remote_gpio_invalid_tests(pi);
 
-    // --- ERROR TEST: Invalid GPIO mode ---
-    cout << "Testing invalid GPIO mode (mode 10)" << endl;
-    remote_raspi_set_mode(pi, PIN_11, static_cast<pin_modes>(10));  // Invalid mode
-
-    // --- ERROR TEST: Invalid GPIO write value ---
-    cout << "Testing invalid GPIO value (writing 5)" << endl;
-    remote_raspi_write(pi, PIN_11, static_cast<pin_values>(5));  // Invalid GPIO value
-
-    // --- ERROR TEST: Invalid pull-up/down configuration ---
-    cout << "Testing invalid pull-up/down configuration (PUD value 3)" << endl;
-    remote_raspi_set_pull_up_down(pi, PIN_11, static_cast<pull_up_down>(3));  // Invalid PUD value
-
-    // Clean up the GPIO
     remote_raspi_cleanup(pi);
-}
-void run_gpio_tests() 
-{
-    local_gpio_valid_tests();
-    local_gpio_invalid_tests();
-}
-void run_remote_gpio_tests()
-{
-    remote_gpio_valid_tests();
-    remote_gpio_invalid_tests();
 }


### PR DESCRIPTION
# Description

This PR adds error handling across all GPIO functions; local and remote.

- Added mechanisms to catch and report on any errors returned from pigpio.
- Moved all messages related to invalid pin type to the `boardToBCM` function.
- Prevented access to the EEPROM pins -- we are not permitted to access these through pigpio anyway (check associated code comment for more information)
- Implemented retrieval of error messages for each possible error code
- Modified test functions to group valid and invalid tests together.
- Added tests that will result in the implemented errors.
- Fixed indentation and whitespace throughout document
- Fixed bug `gpio_cleanup` -- stopped pins from being converted twice.
- Removed 'magic numbers' when calling `clear_bank_1` functions.
- Removed the return of `GPIO_HIGH` and `GPIO_LOW` when reading a Power and Ground pin. This is due to implication that they are in someway part of the GPIO system; they are not.

Note: Running this requires the changes in the following pull request: https://github.com/splashkit/splashkit-core/pull/181
These changes were merged into SKM, here: https://github.com/splashkit/skm/pull/61

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The changes linked above were included in order for the local tests to run. This is not required for the remote functionality. The results of these tests look like:

![image](https://github.com/user-attachments/assets/4c3dcade-d842-4420-8569-0b7724fe2f9a)

For comparison, the same set of tests before these changes results in:
![image](https://github.com/user-attachments/assets/9cd56929-4db4-40bf-9a1e-881cb6cc2a1d)

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
