### PR TITLE
Convert MAC Address to Hexadecimal and Back

### DIFF
--- a/coresdk/src/coresdk/networking.cpp
+++ b/coresdk/src/coresdk/networking.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <cmath>
 #include <iomanip>
+#include <regex>
 
 #include "easylogging++.h"
 
@@ -1289,8 +1290,30 @@ namespace splashkit_lib
         return "127.0.0.1";
     }
 
+    bool is_valid_mac(const string &mac_address)
+    {
+        string octet = "([0-9A-Fa-f]{2})";
+        string mac_pattern = "^" + octet + ":" + octet + ":" + octet + ":" + octet + ":" + octet + ":" + octet + "$";
+
+        std::regex mac_regex(mac_pattern);
+
+        if (!regex_match(mac_address, mac_regex))
+        {
+            LOG(ERROR) << "Invalid MAC address format: " << mac_address;
+            return false;
+        }
+
+        return true;
+    }
+
     string mac_to_hex(const string &mac_address)
     {
+        if (!is_valid_mac(mac_address))
+        {
+            LOG(ERROR) << "Cannot convert invalid MAC address to hex: " << mac_address;
+            return "";
+        }
+
         stringstream hex_string;
         hex_string << "0x";
 
@@ -1310,9 +1333,15 @@ namespace splashkit_lib
 
     string hex_to_mac(const string &hex_str)
     {
+        if (hex_str.substr(0, 2) != "0x" || hex_str.length() != 14)
+        {
+            LOG(ERROR) << "Invalid hex string format: " << hex_str;
+            return "";
+        }
+
         stringstream mac_string;
 
-        for (int i = 2; i < hex_str.size(); i += 2)
+        for (size_t i = 2; i < hex_str.size(); i += 2)
         {
             if (i > 2)
             {

--- a/coresdk/src/coresdk/networking.cpp
+++ b/coresdk/src/coresdk/networking.cpp
@@ -1288,4 +1288,39 @@ namespace splashkit_lib
         // TODO implement ip address resolution. Should return ip address of connected network if one exists.
         return "127.0.0.1";
     }
+
+    string mac_to_hex(const string &mac_address)
+    {
+        stringstream hex_string;
+        hex_string << "0x";
+
+        string::size_type lastpos = 0;
+        for (int i = 0; i < 6; i++)
+        {
+            string::size_type pos = mac_address.find(':', lastpos);
+            string token = pos == string::npos ? mac_address.substr(lastpos) : mac_address.substr(lastpos, pos - lastpos);
+
+            hex_string << setw(2) << setfill('0') << uppercase << hex << stoi(token, nullptr, 16);
+
+            lastpos = pos + 1;
+        }
+
+        return hex_string.str();
+    }
+
+    string hex_to_mac(const string &hex_str)
+    {
+        stringstream mac_string;
+
+        for (int i = 2; i < hex_str.size(); i += 2)
+        {
+            if (i > 2)
+            {
+                mac_string << ":";
+            }
+            mac_string << hex_str.substr(i, 2);
+        }
+
+        return mac_string.str();
+    }
 }

--- a/coresdk/src/coresdk/networking.h
+++ b/coresdk/src/coresdk/networking.h
@@ -891,5 +891,29 @@ namespace splashkit_lib
      * @return ipv4 address string in X.X.X.X format
      */
     string my_ip();
+
+    /**
+     * @brief Converts a MAC address string to its hexadecimal representation
+     *
+     * Converts a MAC address into its hexadecimal representation.
+     * e.g. 0x0123456789AB from 01:23:45:67:89:AB
+     *
+     * @param mac_address MAC address to convert
+     *
+     * @return hexadecimal representation of MAC address as a string
+     */
+    string mac_to_hex(const string &mac_address);
+
+    /**
+     * @brief Converts a hexadecimal string to a MAC address
+     *
+     * Converts a hexadecimal representation of a MAC address back to its standard format.
+     * e.g. 01:23:45:67:89:AB from 0x0123456789AB
+     *
+     * @param hex_str hexadecimal string to convert
+     *
+     * @return MAC address as a string in the format XX:XX:XX:XX:XX:XX
+     */
+    string hex_to_mac(const string &hex_str);
 }
 #endif //SPLASHKIT_NETWORKING_H

--- a/coresdk/src/coresdk/networking.h
+++ b/coresdk/src/coresdk/networking.h
@@ -893,6 +893,17 @@ namespace splashkit_lib
     string my_ip();
 
     /**
+     * @brief Checks if a MAC address is valid
+     *
+     * Checks if the supplied MAC address is valid.
+     *
+     * @param mac_address MAC address to check
+     *
+     * @return true if the MAC address is valid
+     */
+    bool is_valid_mac(const string &mac_address);
+
+    /**
      * @brief Converts a MAC address string to its hexadecimal representation
      *
      * Converts a MAC address into its hexadecimal representation.

--- a/coresdk/src/test/test_networking.cpp
+++ b/coresdk/src/test/test_networking.cpp
@@ -7,6 +7,8 @@
 
 #define TEST_IP "127.0.0.1"
 #define TEST_IP_HEX "0x7F000001"
+#define TEST_MAC "00:00:00:00:00:00"
+#define TEST_MAC_HEX "0x000000000000"
 
 using namespace splashkit_lib;
 
@@ -34,10 +36,33 @@ void mac_to_hex_test()
     assert(mac_to_hex("00:00:00:00:00:00") == "0x000000000000");
     assert(mac_to_hex("FF:FF:FF:FF:FF:FF") == "0xFFFFFFFFFFFF");
     assert(mac_to_hex("12:34:56:78:9A:BC") == "0x123456789ABC");
+    assert(mac_to_hex("AB:CD:EF:12:34:56") == "0xABCDEF123456");
     assert(mac_to_hex(TEST_MAC) == TEST_MAC_HEX);
 
     std::string result = mac_to_hex("AB:CD:EF:12:34:56");
     assert(result == "0xABCDEF123456");
+
+    // Additional positive tests
+    assert(mac_to_hex("01:23:45:67:89:AB") == "0x0123456789AB");
+    assert(mac_to_hex("DE:AD:BE:EF:00:01") == "0xDEADBEEF0001");
+
+    // Negative tests
+    assert(mac_to_hex("00:00:00:00:00:00") != "0xFFFFFFFFFFFF");
+    assert(mac_to_hex("FF:FF:FF:FF:FF:FF") != "0x000000000000");
+    assert(mac_to_hex("12:34:56:78:9A:BC") != "0xABCDEF123456");
+    assert(mac_to_hex("AB:CD:EF:12:34:56") != "0x123456789ABC");
+
+    // Additional negative tests
+    assert(mac_to_hex("01:23:45:67:89:AB") != "0xDEADBEEF0001");
+    assert(mac_to_hex("DE:AD:BE:EF:00:01") != "0x0123456789AB");
+
+    // Tests for invalid types of MAC addresses
+    assert(mac_to_hex("01:23:45:67:89") != "0x0123456789ABC");
+    assert(mac_to_hex("01:23:45:AB") != "0x0123456789");
+    assert(mac_to_hex("01:23:45:67:89:AB:CD") != "0x0123456789AB");
+    assert(mac_to_hex("01:23:67:89:AB") != "0x0123456789ABCD");
+    assert(mac_to_hex("0000") != "0x0000");
+
 
     std::cout << "All MAC to Hexadecimal tests passed!\n"
               << "AB:CD:EF:12:34:56" << " in hex: " << result << std::endl;
@@ -48,16 +73,72 @@ void hex_to_mac_test()
     assert(hex_to_mac("0x000000000000") == "00:00:00:00:00:00");
     assert(hex_to_mac("0xFFFFFFFFFFFF") == "FF:FF:FF:FF:FF:FF");
     assert(hex_to_mac("0x123456789ABC") == "12:34:56:78:9A:BC");
+    assert(hex_to_mac("0xABCDEF123456") != "AB:CD:GF:12:34:56");
+    assert(hex_to_mac("0xABCDEF123456") == "AB:CD:EF:12:34:56");
 
     std::string result = hex_to_mac(TEST_MAC_HEX);
     assert(result == TEST_MAC);
+
+    // Additional positive tests
+    assert(hex_to_mac("0x0123456789AB") == "01:23:45:67:89:AB");
+    assert(hex_to_mac("0xDEADBEEF0001") == "DE:AD:BE:EF:00:01");
+
+    // Negative tests
+    assert(hex_to_mac("0x000000000000") != "FF:FF:FF:FF:FF:FF");
+    assert(hex_to_mac("0xFFFFFFFFFFFF") != "00:00:00:00:00:00");
+    assert(hex_to_mac("0x123456789ABC") != "AB:CD:EF:12:34:56");
+
+    // Additional negative tests
+    assert(hex_to_mac("0x0123456789AB") != "DE:AD:BE:EF:00:01");
+    assert(hex_to_mac("0xDEADBEEF0001") != "01:23:45:67:89:AB");
+
+    // Tests for invalid types of hex values
+    assert(hex_to_mac("0x123456789AB") != "01:23:45:67:89:AB");
+    assert(hex_to_mac("0x123456789ABCD") != "01:23:45:67:89:AB");
+    assert(hex_to_mac("000000000000") != "00:00:00:00:00:00");
 
     std::cout << "All Hexadecimal to MAC tests passed!\n"
               << TEST_MAC_HEX << " in MAC format: " << result << std::endl;
     std::cout << "-------------------------------------" << std::endl;
 }
 
+void is_valid_mac()
+{
+    // Valid MAC addresses
+    assert(is_valid_mac("00:00:00:00:00:00"));
+    assert(is_valid_mac("FF:FF:FF:FF:FF:FF"));
+    assert(is_valid_mac("12:34:56:78:9A:BC"));
+    assert(is_valid_mac("AB:CD:EF:12:34:56"));
+    assert(is_valid_mac("01:23:45:67:89:AB"));
+    assert(is_valid_mac("DE:AD:BE:EF:00:01"));
+
+    // Invalid MAC addresses - wrong length
+    assert(!is_valid_mac("00:00:00:00:00:0"));
+    assert(!is_valid_mac("FF:FF:FF:FF:FF:F"));
+    assert(!is_valid_mac("12:34:56:78:9A:B"));
+    assert(!is_valid_mac("AB:CD:EF:12:34:5"));
+    assert(!is_valid_mac("AB:CD:EF:12:34:567"));
+    assert(!is_valid_mac("AB:CD:EF:12:34"));
+
+    // Invalid MAC addresses - invalid characters
+    assert(!is_valid_mac("GG:00:00:00:00:00"));
+    assert(!is_valid_mac("00:00:00:00:00:GG"));
+    assert(!is_valid_mac("ZZ:ZZ:ZZ:ZZ:ZZ:ZZ"));
+    assert(!is_valid_mac("12:34:56:78:9A:BG"));
+
+    // Invalid MAC addresses - wrong format
+    assert(!is_valid_mac("00-00-00-00-00-00"));
+    assert(!is_valid_mac("0000.0000.0000"));
+    assert(!is_valid_mac("000000000000"));
+    assert(!is_valid_mac("00:00:00:00:00"));
+    assert(!is_valid_mac("00:00:00:00:00:00:00"));
+
+    std::cout << "All MAC address validation tests passed!\n";
+}
+
 void run_networking_test()
 {
     run_encoding_decoding_tests();
+    mac_to_hex_test();
+    hex_to_mac_test();
 }

--- a/coresdk/src/test/test_networking.cpp
+++ b/coresdk/src/test/test_networking.cpp
@@ -29,6 +29,34 @@ void run_encoding_decoding_tests()
     assert(my_ip() == "127.0.0.1");
 }
 
+void mac_to_hex_test()
+{
+    assert(mac_to_hex("00:00:00:00:00:00") == "0x000000000000");
+    assert(mac_to_hex("FF:FF:FF:FF:FF:FF") == "0xFFFFFFFFFFFF");
+    assert(mac_to_hex("12:34:56:78:9A:BC") == "0x123456789ABC");
+    assert(mac_to_hex(TEST_MAC) == TEST_MAC_HEX);
+
+    std::string result = mac_to_hex("AB:CD:EF:12:34:56");
+    assert(result == "0xABCDEF123456");
+
+    std::cout << "All MAC to Hexadecimal tests passed!\n"
+              << "AB:CD:EF:12:34:56" << " in hex: " << result << std::endl;
+}
+
+void hex_to_mac_test()
+{
+    assert(hex_to_mac("0x000000000000") == "00:00:00:00:00:00");
+    assert(hex_to_mac("0xFFFFFFFFFFFF") == "FF:FF:FF:FF:FF:FF");
+    assert(hex_to_mac("0x123456789ABC") == "12:34:56:78:9A:BC");
+
+    std::string result = hex_to_mac(TEST_MAC_HEX);
+    assert(result == TEST_MAC);
+
+    std::cout << "All Hexadecimal to MAC tests passed!\n"
+              << TEST_MAC_HEX << " in MAC format: " << result << std::endl;
+    std::cout << "-------------------------------------" << std::endl;
+}
+
 void run_networking_test()
 {
     run_encoding_decoding_tests();


### PR DESCRIPTION
# Description

Developed two new functions. The first converts a MAC address into hexadecimal form, the second converts a hexadecimal value into its MAC address form.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I developed a set of tests to check the mac address conversion was correct. These tests were added into the sktest file and included in this PR for testing. 

![image](https://github.com/user-attachments/assets/16fa6c2b-4b10-4c6e-a012-04aa457fcf6a)
![image](https://github.com/user-attachments/assets/ddc54f66-8a37-4703-989a-6e9b6d9323e1)

## Testing Checklist

- [X] Tested with sktest
- [X] Tested with skunit_tests

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [] I have requested a review from ... on the Pull Request
