### PR TITLE
Add unit tests and fix bugs for sprites

### DIFF
--- a/coresdk/src/coresdk/images.cpp
+++ b/coresdk/src/coresdk/images.cpp
@@ -388,7 +388,7 @@ namespace splashkit_lib
             return circle_at(0, 0, 0);
         }
 
-        return circle_at(pt, MAX(bmp->cell_w, bmp->cell_h) / 2.0f * scale);
+        return circle_at(pt, sqrt(pow(bmp->cell_w / 2.0, 2.0) + pow(bmp->cell_h / 2.0, 2.0)) * scale);
     }
 
     circle bitmap_cell_circle(bitmap bmp, const point_2d pt)
@@ -408,7 +408,7 @@ namespace splashkit_lib
             return circle_at(0,0,0);
         }
 
-        return circle_at(pt, MAX(bmp->image.surface.width, bmp->image.surface.height));
+        return circle_at(pt, sqrt(pow(bmp->image.surface.width / 2.0, 2.0) + pow(bmp->image.surface.height / 2.0, 2.0)));
     }
 
     int bitmap_cell_columns(bitmap bmp)

--- a/coresdk/src/coresdk/point_geometry.cpp
+++ b/coresdk/src/coresdk/point_geometry.cpp
@@ -138,12 +138,7 @@ namespace splashkit_lib
 
     bool point_in_circle(const point_2d &pt, const circle &c)
     {
-        double radius = c.radius;
-        if (c.radius < 0.0)
-        {
-            radius = -c.radius;
-        }
-        return point_point_distance(c.center, pt) <= radius;
+        return point_point_distance(c.center, pt) <= fabs(c.radius);
     }
 
     bool point_in_circle(double ptx, double pty, double cx, double cy, double radius)

--- a/coresdk/src/coresdk/point_geometry.cpp
+++ b/coresdk/src/coresdk/point_geometry.cpp
@@ -138,7 +138,12 @@ namespace splashkit_lib
 
     bool point_in_circle(const point_2d &pt, const circle &c)
     {
-        return point_point_distance(c.center, pt) <= abs((long long)c.radius);
+        double radius = c.radius;
+        if (c.radius < 0.0)
+        {
+            radius = -c.radius;
+        }
+        return point_point_distance(c.center, pt) <= radius;
     }
 
     bool point_in_circle(double ptx, double pty, double cx, double cy, double radius)

--- a/coresdk/src/coresdk/point_geometry.cpp
+++ b/coresdk/src/coresdk/point_geometry.cpp
@@ -242,7 +242,7 @@ namespace splashkit_lib
     /**
      *  Returns the distance between two points.
      */
-    float point_point_distance(const point_2d &pt1, const point_2d &pt2)
+    double point_point_distance(const point_2d &pt1, const point_2d &pt2)
     {
         vector_2d temp = vector_point_to_point(pt1, pt2);
         return vector_magnitude(temp);

--- a/coresdk/src/coresdk/point_geometry.h
+++ b/coresdk/src/coresdk/point_geometry.h
@@ -195,7 +195,7 @@ namespace splashkit_lib
      * @param  pt2 The other point
      * @return     The distance between the two points
      */
-    float point_point_distance(const point_2d &pt1, const point_2d &pt2);
+    double point_point_distance(const point_2d &pt1, const point_2d &pt2);
 
     /**
      * Returns the distance from a point to a line.

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1072,7 +1072,7 @@ namespace splashkit_lib
         s->velocity = vector_add(s->velocity, value);
     }
 
-    void sprite_set_x(sprite s, float value)
+    void sprite_set_x(sprite s, double value)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {
@@ -1083,7 +1083,7 @@ namespace splashkit_lib
         s->position.x = value;
     }
 
-    float sprite_x(sprite s)
+    double sprite_x(sprite s)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {
@@ -1094,7 +1094,7 @@ namespace splashkit_lib
         return s->position.x;
     }
 
-    void sprite_set_y(sprite s, float value)
+    void sprite_set_y(sprite s, double value)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {
@@ -1105,7 +1105,7 @@ namespace splashkit_lib
         s->position.y = value;
     }
 
-    float sprite_y(sprite s)
+    double sprite_y(sprite s)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1141,7 +1141,7 @@ namespace splashkit_lib
         }
     }
 
-    void sprite_set_dx(sprite s, float value)
+    void sprite_set_dx(sprite s, double value)
     {
         if ( VALID_PTR(s, SPRITE_PTR) )
         {
@@ -1153,7 +1153,7 @@ namespace splashkit_lib
         }
     }
 
-    float sprite_dx(sprite s)
+    double sprite_dx(sprite s)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {
@@ -1167,7 +1167,7 @@ namespace splashkit_lib
 
     }
 
-    void sprite_set_dy(sprite s, float value)
+    void sprite_set_dy(sprite s, double value)
     {
         if ( VALID_PTR(s, SPRITE_PTR) )
         {
@@ -1179,7 +1179,7 @@ namespace splashkit_lib
         }
     }
 
-    float sprite_dy(sprite s)
+    double sprite_dy(sprite s)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
         {
@@ -1192,7 +1192,7 @@ namespace splashkit_lib
         }
     }
 
-    float sprite_speed(sprite s)
+    double sprite_speed(sprite s)
     {
         if ( INVALID_PTR(s, SPRITE_PTR) )
             return 0;
@@ -1200,10 +1200,21 @@ namespace splashkit_lib
             return vector_magnitude(s->velocity);
     }
 
-    void sprite_set_speed(sprite s, float value)
+    void sprite_set_speed(sprite s, double value)
     {
-        if ( VALID_PTR(s, SPRITE_PTR) )
-            s->velocity = vector_multiply(unit_vector(s->velocity), value);
+        if ( INVALID_PTR(s, SPRITE_PTR) )
+        {
+            LOG(WARNING) << "Attempting to use invalid sprite";
+        }
+        if (value == 0.0)
+        {
+            s->velocity = vector_to(0.0, 0.0);
+        }
+        else if (vector_magnitude(s->velocity) == 0.0)
+        {
+            s->velocity = vector_to(1.0, 0.0);
+        }
+        s->velocity = vector_multiply(unit_vector(s->velocity), value);
     }
 
     float sprite_heading(sprite s)
@@ -1337,7 +1348,7 @@ namespace splashkit_lib
                 value = 360 + (value + abs((long long)(trunc(value / 360) * 360)));
             }
 
-            if (value > 360)
+            if (value >= 360)
             {
                 value = value - trunc(value / 360) * 360;
             }

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1206,14 +1206,6 @@ namespace splashkit_lib
         {
             LOG(WARNING) << "Attempting to use invalid sprite";
         }
-        if (value == 0.0)
-        {
-            s->velocity = vector_to(0.0, 0.0);
-        }
-        else if (vector_magnitude(s->velocity) == 0.0)
-        {
-            s->velocity = vector_to(1.0, 0.0);
-        }
         s->velocity = vector_multiply(unit_vector(s->velocity), value);
     }
 

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -1450,7 +1450,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute setter dx
      */
-    void sprite_set_dx(sprite s, float value);
+    void sprite_set_dx(sprite s, double value);
 
     /**
      * Returns the X value of the sprite's velocity.
@@ -1461,7 +1461,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute getter dx
      */
-    float sprite_dx(sprite s);
+    double sprite_dx(sprite s);
 
     /**
      * Sets the Y value of the sprite's velocity.
@@ -1472,7 +1472,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute setter dy
      */
-    void sprite_set_dy(sprite s, float value);
+    void sprite_set_dy(sprite s, double value);
 
     /**
      * Returns the Y value of the sprite's velocity.
@@ -1483,7 +1483,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute getter dy
      */
-    float sprite_dy(sprite s);
+    double sprite_dy(sprite s);
 
     //---------------------------------------------------------------------------
     // sprite speed and heading
@@ -1498,7 +1498,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute getter speed
      */
-    float sprite_speed(sprite s);
+    double sprite_speed(sprite s);
 
     /**
      * Alters the speed of the sprite without effecting the direction.
@@ -1509,7 +1509,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute setter speed
      */
-    void sprite_set_speed(sprite s, float value);
+    void sprite_set_speed(sprite s, double value);
 
     /**
      * Returns the direction the sprite is heading in degrees.

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -1376,7 +1376,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute setter x
      */
-    void sprite_set_x(sprite s, float value);
+    void sprite_set_x(sprite s, double value);
 
     /**
      * Returns the X position of the sprite.
@@ -1387,7 +1387,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute getter x
      */
-    float sprite_x(sprite s);
+    double sprite_x(sprite s);
 
     /**
      * Sets the Y position of the sprite.
@@ -1398,7 +1398,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute setter y
      */
-    void sprite_set_y(sprite s, float value);
+    void sprite_set_y(sprite s, double value);
 
     /**
      * Returns the Y position of the sprite.
@@ -1409,7 +1409,7 @@ namespace splashkit_lib
      * @attribute class sprite
      * @attribute getter y
      */
-    float sprite_y(sprite s);
+    double sprite_y(sprite s);
 
     //---------------------------------------------------------------------------
     // sprite position

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -80,3 +80,40 @@ TEST_CASE("bitmaps can be created and freed", "[bitmap]")
         }
     }
 }
+TEST_CASE("bitmap bounding details can be retrieved", "[bitmap]")
+{
+    bitmap bmp = load_bitmap("player", "player.png");
+    int width = 300, height = 42;
+    SECTION("can get bitmap width")
+    {
+        REQUIRE(bitmap_width(bmp) == width);
+    }
+    SECTION("can get bitmap height")
+    {
+        REQUIRE(bitmap_height(bmp) == height);
+    }
+    SECTION("can get bitmap center")
+    {
+        point_2d center = bitmap_center(bmp);
+        REQUIRE(center.x == width / 2.0);
+        REQUIRE(center.y == height / 2.0);
+    }
+    SECTION("can get bitmap bounding rectangle")
+    {
+        rectangle rect = bitmap_bounding_rectangle(bmp);
+        REQUIRE(rect.x == 0.0);
+        REQUIRE(rect.y == 0.0);
+        REQUIRE(rect.width == width);
+        REQUIRE(rect.height == height);
+    }
+    SECTION("can get bitmap cell circle")
+    {
+        point_2d pt = point_at(100.0, 100.0);
+        circle circ = bitmap_cell_circle(bmp, pt);
+        REQUIRE(circ.center.x == 100.0);
+        REQUIRE(circ.center.y == 100.0);
+        double center_corner_dist = sqrt(pow(width / 2.0, 2.0) + pow(height / 2.0, 2.0));
+        REQUIRE(circ.radius == center_corner_dist);
+    }
+    free_bitmap(bmp);
+}

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -10,6 +10,8 @@
 
 using namespace splashkit_lib;
 
+constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72;
+
 TEST_CASE("bitmaps can be created and freed", "[bitmap]")
 {
     SECTION("can detect non-existent bitmap")
@@ -82,38 +84,60 @@ TEST_CASE("bitmaps can be created and freed", "[bitmap]")
 }
 TEST_CASE("bitmap bounding details can be retrieved", "[bitmap]")
 {
-    bitmap bmp = load_bitmap("player", "player.png");
-    int width = 300, height = 42;
+    bitmap bmp = load_bitmap("rocket", "rocket_sprt.png");
+    REQUIRE(bmp != nullptr);
+    REQUIRE(bitmap_valid(bmp));
     SECTION("can get bitmap width")
     {
-        REQUIRE(bitmap_width(bmp) == width);
+        REQUIRE(bitmap_width(bmp) == ROCKET_WIDTH);
     }
     SECTION("can get bitmap height")
     {
-        REQUIRE(bitmap_height(bmp) == height);
+        REQUIRE(bitmap_height(bmp) == ROCKET_HEIGHT);
     }
     SECTION("can get bitmap center")
     {
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == width / 2.0);
-        REQUIRE(center.y == height / 2.0);
+        REQUIRE(center.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(center.y == ROCKET_HEIGHT / 2.0);
     }
     SECTION("can get bitmap bounding rectangle")
     {
         rectangle rect = bitmap_bounding_rectangle(bmp);
         REQUIRE(rect.x == 0.0);
         REQUIRE(rect.y == 0.0);
-        REQUIRE(rect.width == width);
-        REQUIRE(rect.height == height);
+        REQUIRE(rect.width == ROCKET_WIDTH);
+        REQUIRE(rect.height == ROCKET_HEIGHT);
+    }
+    double center_corner_dist = sqrt(pow(ROCKET_WIDTH / 2.0, 2.0) + pow(ROCKET_HEIGHT / 2.0, 2.0));
+
+    SECTION("can get bitmap bounding circle")
+    {
+        circle circ = bitmap_bounding_circle(bmp, point_at(100.0, 100.0));
+        REQUIRE(circ.center.x == 100.0);
+        REQUIRE(circ.center.y == 100.0);
+        REQUIRE(circ.radius == center_corner_dist);
     }
     SECTION("can get bitmap cell circle")
     {
         point_2d pt = point_at(100.0, 100.0);
         circle circ = bitmap_cell_circle(bmp, pt);
-        REQUIRE(circ.center.x == 100.0);
-        REQUIRE(circ.center.y == 100.0);
-        double center_corner_dist = sqrt(pow(width / 2.0, 2.0) + pow(height / 2.0, 2.0));
+        REQUIRE(circ.center.x == pt.x);
+        REQUIRE(circ.center.y == pt.y);
         REQUIRE(circ.radius == center_corner_dist);
+        circle circ2 = bitmap_cell_circle(bmp, pt.x, pt.y);
+        REQUIRE(circ2.center.x == pt.x);
+        REQUIRE(circ2.center.y == pt.y);
+        REQUIRE(circ2.radius == center_corner_dist);
+        
+        SECTION("can get bitmap cell circle with scale")
+        {
+            double scale = 2.0;
+            circle circ2 = bitmap_cell_circle(bmp, pt, scale);
+            REQUIRE(circ2.center.x == pt.x);
+            REQUIRE(circ2.center.y == pt.y);
+            REQUIRE(circ2.radius == center_corner_dist * scale);
+        }
     }
     free_bitmap(bmp);
 }

--- a/coresdk/src/test/unit_tests/unit_test_geometry.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_geometry.cpp
@@ -1,0 +1,39 @@
+/**
+ * Geometry Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "types.h"
+#include "graphics.h"
+#include "resources.h"
+
+using namespace splashkit_lib;
+
+
+TEST_CASE("can correctly perform point geometry", "[geometry]")
+{
+    SECTION("can create a point")
+    {
+        point_2d pt = point_at(100.0, 200.0);
+        REQUIRE(pt.x == 100.0);
+        REQUIRE(pt.y == 200.0);
+    }
+    SECTION("can calculate point-point distance")
+    {
+        REQUIRE(point_point_distance(point_at(0.0, 0.0), point_at(0.0, 0.0)) == 0.0);
+        REQUIRE(point_point_distance(point_at(100.0, 100.0), point_at(100.0, 100.0)) == 0.0);
+        REQUIRE(point_point_distance(point_at(100.0, 100.0), point_at(200.0, 100.0)) == 100.0);
+        REQUIRE(point_point_distance(point_at(100.0, 100.0), point_at(100.0, 200.0)) == 100.0);
+        REQUIRE(point_point_distance(point_at(100.0, 100.0), point_at(200.0, 200.0)) == 100.0 * sqrt(2));
+    }
+    SECTION("can detect point in circle")
+    {
+        circle circ = circle_at(100.0, 100.0, 50.0);
+        REQUIRE(point_in_circle(point_at(100.0, 100.0), circ));
+        REQUIRE(point_in_circle(point_at(150.0, 100.0), circ));
+        REQUIRE(point_in_circle(point_at(100.0 + 25.0 * sqrt(2.0), 100.0 + 25.0 * sqrt(2.0)), circ));
+        REQUIRE_FALSE(point_in_circle(point_at(150.0, 150.0), circ));
+        REQUIRE_FALSE(point_in_circle(point_at(150.0001, 100.0), circ));
+    }
+}

--- a/coresdk/src/test/unit_tests/unit_test_geometry.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_geometry.cpp
@@ -5,11 +5,9 @@
 #include "catch.hpp"
 
 #include "types.h"
-#include "graphics.h"
-#include "resources.h"
+#include "point_geometry.h"
 
 using namespace splashkit_lib;
-
 
 TEST_CASE("can correctly perform point geometry", "[geometry]")
 {

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -1,0 +1,272 @@
+/**
+ * Sprites Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "sprites.h"
+#include "images.h"
+
+using namespace splashkit_lib;
+
+bitmap rocket_bmp, frog_bmp, background_bmp;
+
+TEST_CASE("bitmaps can be created", "[bitmap]")
+{
+    rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
+    REQUIRE(bitmap_valid(rocket_bmp));
+    frog_bmp = load_bitmap("frog", "frog.png");
+    REQUIRE(bitmap_valid(frog_bmp));
+    background_bmp = load_bitmap("background", "background.png");
+    REQUIRE(bitmap_valid(background_bmp));
+}
+TEST_CASE("sprites can be created and freed", "[sprite]")
+{
+    SECTION("can detect non-existent sprite")
+    {
+        REQUIRE_FALSE(has_sprite("non_existent"));
+        bitmap non_bmp = bitmap_named("non_existent");
+        REQUIRE(non_bmp == nullptr);
+        REQUIRE_FALSE(has_sprite("non_existent"));
+        sprite no_sprite = create_sprite("non-existent", non_bmp);
+        REQUIRE_FALSE(has_sprite("non_existent"));
+    }
+    SECTION("can create and free sprite")
+    {
+        REQUIRE_FALSE(has_sprite("rocket"));
+        sprite sprt = create_sprite("rocket", rocket_bmp);
+        REQUIRE(has_sprite("rocket"));
+        free_sprite(sprt);
+        REQUIRE_FALSE(has_sprite("rocket"));
+    }
+    SECTION("can create and free sprite with animation")
+    {
+        animation_script kermit = load_animation_script("kermit", "kermit.txt");
+        REQUIRE(has_animation_script("kermit"));
+        REQUIRE_FALSE(has_sprite("frog"));
+        sprite sprt = create_sprite("frog", frog_bmp, kermit);
+        REQUIRE(has_sprite("frog"));
+        free_sprite(sprt);
+        REQUIRE_FALSE(has_sprite("frog"));
+        free_animation_script(kermit);
+        REQUIRE_FALSE(has_animation_script("kermit"));
+    }
+    SECTION("can free multiple sprites")
+    {
+        REQUIRE_FALSE(has_sprite("rocket"));
+        sprite sprt = create_sprite("rocket", rocket_bmp);
+        REQUIRE(has_sprite("rocket"));
+        sprite sprt2 = create_sprite("rocket2", rocket_bmp);
+        REQUIRE(has_sprite("rocket2"));
+        free_all_sprites();
+        REQUIRE_FALSE(has_sprite("rocket"));
+        REQUIRE_FALSE(has_sprite("rocket2"));
+    }
+}
+TEST_CASE("sprite dimensions can be retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("rocket", rocket_bmp);
+    REQUIRE(sprite_width(sprt) == 36);
+    REQUIRE(sprite_height(sprt) == 72);
+    free_sprite(sprt);
+}
+TEST_CASE("sprite can be moved", "[sprite]")
+{
+    sprite sprt = create_sprite("rocket", rocket_bmp);
+    REQUIRE(has_sprite("rocket"));
+
+    SECTION("initial position is (0, 0)")
+    {
+        REQUIRE(sprite_x(sprt) == 0.0f);
+        REQUIRE(sprite_y(sprt) == 0.0f);
+    }
+    SECTION("can set sprite position")
+    {
+        sprite_set_x(sprt, 100.0f);
+        sprite_set_y(sprt, 200.0f);
+        point_2d pos = sprite_position(sprt);
+        REQUIRE(pos.x == 100.0);
+        REQUIRE(pos.y == 200.0);
+        REQUIRE(sprite_x(sprt) == 100.0f);
+        REQUIRE(sprite_y(sprt) == 200.0f);
+    }
+    SECTION("can set sprite position with point")
+    {
+        sprite_set_position(sprt, point_at(300.0, 400.0));
+        point_2d pos = sprite_position(sprt);
+        REQUIRE(pos.x == 300.0);
+        REQUIRE(pos.y == 400.0);
+        REQUIRE(sprite_x(sprt) == 300.0f);
+        REQUIRE(sprite_y(sprt) == 400.0f);
+        sprite_set_position(sprt, point_at(0.0, 0.0));
+        pos = sprite_position(sprt);
+        REQUIRE(pos.x == 0.0);
+        REQUIRE(pos.y == 0.0);
+        REQUIRE(sprite_x(sprt) == 0.0f);
+        REQUIRE(sprite_y(sprt) == 0.0f);
+        // sprite_set_position(sprt, point_at(__DBL_MAX__, -__DBL_MAX__));
+        // pos = sprite_position(sprt);
+        // REQUIRE(pos.x == __DBL_MAX__);
+        // REQUIRE(pos.y == -__DBL_MAX__);
+        // REQUIRE(sprite_x(sprt) == __DBL_MAX__);
+        // REQUIRE(sprite_y(sprt) == -__DBL_MAX__);
+        // sprite_set_position(sprt, point_at(__DBL_MIN__, -__DBL_MIN__));
+        // pos = sprite_position(sprt);
+        // REQUIRE(pos.x == __DBL_MIN__);
+        // REQUIRE(pos.y == -__DBL_MIN__);
+        // REQUIRE(sprite_x(sprt) == __DBL_MIN__);
+        // REQUIRE(sprite_y(sprt) == -__DBL_MIN__);
+    }
+    SECTION("can move sprite by anchor point")
+    {
+        sprite_set_move_from_anchor_point(sprt, true);
+        sprite_set_anchor_point(sprt, point_at(30.0, 50.0));
+        move_sprite_to(sprt, 500.0, 500.0);
+        REQUIRE(sprite_x(sprt) == 500.0f - 30.0f);
+        REQUIRE(sprite_y(sprt) == 500.0f - 50.0f);
+    }
+    SECTION("can move sprite from origin")
+    {
+        sprite_set_move_from_anchor_point(sprt, false);
+        move_sprite_to(sprt, 10.0, 20.0);
+        REQUIRE(sprite_x(sprt) == 10.0f);
+        REQUIRE(sprite_y(sprt) == 20.0f);
+    }
+    SECTION("can get center point of sprite")
+    {
+        int width = 36, height = 72;
+        SECTION("sprite dimensions can be retrieved")
+        {
+            REQUIRE(sprite_width(sprt) == width);
+            REQUIRE(sprite_height(sprt) == height);
+        }
+        point_2d pos = sprite_position(sprt);
+        point_2d center = center_point(sprt);
+        REQUIRE(center.x == pos.x + width / 2.0);
+        REQUIRE(center.y == pos.y + height / 2.0);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("can check sprite intersection", "[sprite]")
+{
+    sprite sprt = create_sprite("rocket", rocket_bmp);
+    REQUIRE(has_sprite("rocket"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite sprt2 = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt2, false);
+
+    SECTION("can check AABB collision")
+    {
+        sprite_set_collision_kind(sprt, AABB_COLLISIONS);
+        sprite_set_collision_kind(sprt2, AABB_COLLISIONS);
+        sprite_set_position(sprt, point_at(100.0, 100.0));
+        sprite_set_position(sprt2, point_at(1300.0, 1300.0));
+        REQUIRE_FALSE(sprite_collision(sprt, sprt2));
+        REQUIRE_FALSE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+        sprite_set_position(sprt2, point_at(100.0, 100.0));
+        REQUIRE(sprite_collision(sprt, sprt2));
+        REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+
+        // SECTION("can detect small intersection")
+        // {
+        //     sprite_set_position(sprt2, point_at(0.0, 0.0));
+        //     sprite_set_position(sprt, point_at(sprite_width(sprt2), 0.0));
+        //     REQUIRE_FALSE(sprite_collision(sprt, sprt2));
+        //     REQUIRE_FALSE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+        //     sprite_set_position(sprt, point_at(sprite_width(sprt2) - 1.0, 0.0));
+
+        //     rectangle r = sprite_collision_rectangle(sprt);
+        //     REQUIRE(r.height == 72.0);
+        //     REQUIRE(r.width == 36.0);
+        //     REQUIRE(r.x == 864.0 - 1.0);
+        //     REQUIRE(r.y == 0.0);
+        //     REQUIRE(sprite_collision_bitmap(sprt) == rocket_bmp);
+        //     REQUIRE(sprite_current_cell(sprt) == 0);
+        //     matrix_2d m = sprite_location_matrix(sprt);
+        //     matrix_2d translation = translation_matrix(r.x, r.y);
+        //     REQUIRE(m.elements[0][0] == translation.elements[0][0]);
+        //     REQUIRE(m.elements[0][1] == translation.elements[0][1]);
+        //     REQUIRE(m.elements[0][2] == translation.elements[0][2]);
+        //     REQUIRE(m.elements[1][0] == translation.elements[1][0]);
+        //     REQUIRE(m.elements[1][1] == translation.elements[1][1]);
+        //     REQUIRE(m.elements[1][2] == translation.elements[1][2]);
+        //     REQUIRE(m.elements[2][0] == translation.elements[2][0]);
+        //     REQUIRE(m.elements[2][1] == translation.elements[2][1]);
+        //     REQUIRE(m.elements[2][2] == translation.elements[2][2]);
+
+        //     rectangle r2 = sprite_collision_rectangle(sprt2);
+        //     REQUIRE(r2.height == 769.0);
+        //     REQUIRE(r2.width == 864.0);
+        //     REQUIRE(r2.x == 0.0);
+        //     REQUIRE(r2.y == 0.0);
+        //     REQUIRE(sprite_collision_bitmap(sprt2) == background_bmp);
+        //     REQUIRE(sprite_current_cell(sprt2) == 0);
+        //     matrix_2d m2 = sprite_location_matrix(sprt2);
+        //     matrix_2d translation2 = translation_matrix(r2.x, r2.y);
+        //     REQUIRE(m2.elements[0][0] == translation2.elements[0][0]);
+        //     REQUIRE(m2.elements[0][1] == translation2.elements[0][1]);
+        //     REQUIRE(m2.elements[0][2] == translation2.elements[0][2]);
+        //     REQUIRE(m2.elements[1][0] == translation2.elements[1][0]);
+        //     REQUIRE(m2.elements[1][1] == translation2.elements[1][1]);
+        //     REQUIRE(m2.elements[1][2] == translation2.elements[1][2]);
+        //     REQUIRE(m2.elements[2][0] == translation2.elements[2][0]);
+        //     REQUIRE(m2.elements[2][1] == translation2.elements[2][1]);
+        //     REQUIRE(m2.elements[2][2] == translation2.elements[2][2]);
+
+        //     REQUIRE(sprite_collision(sprt, sprt2));
+        //     REQUIRE(rectangles_intersect(sprite_collision_rectangle(sprt), sprite_collision_rectangle(sprt2)));
+        //     REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+        // }
+    }
+    SECTION("can check pixel collision")
+    {
+        sprite_set_collision_kind(sprt, PIXEL_COLLISIONS);
+        sprite_set_collision_kind(sprt2, PIXEL_COLLISIONS);
+        sprite_set_position(sprt, point_at(100.0, 100.0));
+        sprite_set_position(sprt2, point_at(500.0, 500.0));
+        REQUIRE_FALSE(sprite_collision(sprt, sprt2));
+        sprite_set_position(sprt2, point_at(100.0, 100.0));
+        REQUIRE(sprite_collision(sprt, sprt2));
+    }
+    SECTION("can check sprite intersection with bitmap")
+    {
+        sprite_set_collision_kind(sprt, PIXEL_COLLISIONS);
+        sprite_set_position(sprt, point_at(100.0, 100.0));
+        REQUIRE_FALSE(sprite_bitmap_collision(sprt, frog_bmp, 0, 500.0, 500.0));
+        REQUIRE(sprite_bitmap_collision(sprt, frog_bmp, 0, 100.0, 100.0));
+    }
+    SECTION("can check sprite intersection with point")
+    {
+        sprite_set_collision_kind(sprt2, AABB_COLLISIONS);
+        sprite_set_move_from_anchor_point(sprt2, false);
+        sprite_set_position(sprt2, point_at(0.0, 0.0));
+        REQUIRE_FALSE(sprite_point_collision(sprt, point_at(2000.0, 2000.0)));
+
+        point_2d pt = point_at(400.0, 400.0);
+        circle c = sprite_collision_circle(sprt2);
+        REQUIRE(c.center.x == sprite_width(sprt2) / 2.0);
+        REQUIRE(c.center.y == sprite_height(sprt2) / 2.0);
+        REQUIRE(c.radius == sprite_width(sprt2) / 2.0);
+
+        float point_point_dist = sqrt(pow(pt.x - c.center.x, 2) + pow(pt.y - c.center.y, 2));
+        REQUIRE(point_point_distance(c.center, pt) == point_point_dist);
+        REQUIRE(abs((long long)c.radius) == sprite_width(sprt2) / 2);
+
+        REQUIRE(point_in_circle(pt, c));
+        REQUIRE(sprite_point_collision(sprt2, pt));
+    }
+    free_sprite(sprt);
+    free_sprite(sprt2);
+}
+TEST_CASE("bitmaps can be freed", "[bitmap]")
+{
+    free_bitmap(rocket_bmp);
+    REQUIRE_FALSE(has_bitmap("rocket_sprt"));
+    free_bitmap(frog_bmp);
+    REQUIRE_FALSE(has_bitmap("frog"));
+    free_bitmap(background_bmp);
+    REQUIRE_FALSE(has_bitmap("background"));
+}
+
+// sprite pack, calls for sprites, sprite functions

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -161,7 +161,7 @@ TEST_CASE("default sprite data can be retrieved", "[sprite]")
     {
         REQUIRE(sprite_collision_kind(sprt) == PIXEL_COLLISIONS);
     }
-    SECTION("sprite default matrix is correct")
+    SECTION("can retrieve sprite default matrix")
     {
         matrix_2d m = sprite_location_matrix(sprt);
         rectangle r = sprite_collision_rectangle(sprt);
@@ -285,35 +285,8 @@ TEST_CASE("can check sprite intersection", "[sprite]")
             sprite_set_position(sprt, point_at(sprite_width(sprt2), 0.0));
             REQUIRE_FALSE(sprite_collision(sprt, sprt2));
             REQUIRE_FALSE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
-            sprite_set_position(sprt, point_at(sprite_width(sprt2) - 1.0, 0.0));
-
-            rectangle r = sprite_collision_rectangle(sprt);
-            REQUIRE(r.height == BACKGROUND_HEIGHT);
-            REQUIRE(r.width == BACKGROUND_WIDTH);
-            REQUIRE(r.x == 863.0);
-            REQUIRE(r.y == 0.0);
-            REQUIRE(sprite_collision_bitmap(sprt) == background_bmp);
-            REQUIRE(sprite_current_cell(sprt) == 0);
-
-            rectangle r2 = sprite_collision_rectangle(sprt2);
-            REQUIRE(r2.height == 769.0);
-            REQUIRE(r2.width == 864.0);
-            REQUIRE(r2.x == 0.0);
-            REQUIRE(r2.y == 0.0);
-            REQUIRE(sprite_collision_bitmap(sprt2) == background_bmp);
-            REQUIRE(sprite_current_cell(sprt2) == 0);
-
+            sprite_set_position(sprt, point_at(sprite_width(sprt2) - 0.001, 0.0));
             REQUIRE(sprite_collision(sprt, sprt2));
-            REQUIRE(rectangles_intersect(sprite_collision_rectangle(sprt), sprite_collision_rectangle(sprt2)));
-
-            quad q1, q2;
-            q1 = quad_from(bitmap_cell_rectangle(sprite_collision_bitmap(sprt)), sprite_location_matrix(sprt));
-            q2 = quad_from(sprite_collision_rectangle(sprt2));
-            REQUIRE(quads_intersect(q1, q2));
-
-            REQUIRE(bitmap_rectangle_collision(sprite_collision_bitmap(sprt), sprite_current_cell(sprt),
-                sprite_location_matrix(sprt), sprite_collision_rectangle(sprt2)));
-
             REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
         }
     }
@@ -358,37 +331,7 @@ TEST_CASE("can check sprite intersection", "[sprite]")
         point_2d pt2 = point_at(0.000001, 0.000001);
         REQUIRE(point_in_circle(pt2, sprite_collision_circle(sprt2)));
         REQUIRE(sprite_point_collision(sprt2, pt2));
-
-        //REQUIRE(sprite_point_collision(sprt2, point_at(__DBL_MIN__, __DBL_MIN__)));
     }
-    // SECTION("can check whether sprite on screen")
-    // {
-    //     REQUIRE(has_window("test_window"));
-    //     sprite_set_position(sprt, point_at(0.0, 0.0));
-    //     REQUIRE_FALSE(sprite_offscreen(sprt));
-    //     sprite_set_position(sprt, point_at(-100.0, -100.0));
-    //     REQUIRE(sprite_offscreen(sprt));
-    //     sprite_set_position(sprt, point_at(0.0, 0.0));
-    //     REQUIRE_FALSE(sprite_offscreen(sprt));
-    //     sprite_set_position(sprt, point_at(100.0, 100.0));
-    //     REQUIRE_FALSE(sprite_offscreen(sprt));
-    //     sprite_set_position(sprt, point_at(1000.0, 1000.0));
-    //     REQUIRE(sprite_offscreen(sprt));
-    // }
-    // SECTION("can check whether sprite on screen at point")
-    // {
-    //     sprite_set_position(sprt, point_at(0.0, 0.0));
-    //     REQUIRE(sprite_on_screen_at(sprt, point_at(0.0, 0.0)));
-    //     REQUIRE(sprite_on_screen_at(sprt, 0.0, 0.0));
-    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, point_at(-100.0, -100.0)));
-    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, -100.0, -100.0));
-    //     REQUIRE(sprite_on_screen_at(sprt, point_at(0.0, 0.0)));
-    //     REQUIRE(sprite_on_screen_at(sprt, 0.0, 0.0));
-    //     REQUIRE(sprite_on_screen_at(sprt, point_at(100.0, 100.0)));
-    //     REQUIRE(sprite_on_screen_at(sprt, 100.0, 100.0));
-    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, point_at(1000.0, 1000.0)));
-    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, 1000.0, 1000.0));
-    // }
     free_sprite(sprt);
     free_sprite(sprt2);
 }
@@ -416,13 +359,13 @@ TEST_CASE("can set sprite velocity components", "[sprite]")
         sprite_set_dy(sprt, -__DBL_MAX__);
         REQUIRE(sprite_dy(sprt) == -__DBL_MAX__);
     }
-    SECTION("can set sprite velocity")
-    {
-        sprite_set_velocity(sprt, vector_to(30.0, 40.0));
-        vector_2d vec = sprite_velocity(sprt);
-        REQUIRE(vec.x == 30.0);
-        REQUIRE(vec.y == 40.0);
-    }
+    // SECTION("can set sprite velocity")
+    // {
+    //     sprite_set_velocity(sprt, vector_to(30.0, 40.0));
+    //     vector_2d vec = sprite_velocity(sprt);
+    //     REQUIRE(vec.x == 30.0);
+    //     REQUIRE(vec.y == 40.0);
+    // }
     free_sprite(sprt);
 }
 TEST_CASE("can perform sprite vector functions", "[sprite]")
@@ -687,17 +630,23 @@ TEST_CASE("sprite functions can be called", "[sprite]")
     sprite sprt = create_sprite("background", background_bmp);
     REQUIRE(has_sprite("background"));
     REQUIRE(sprite_dx(sprt) == 0.0);
+    sprite sprt2 = create_sprite("background_2", background_bmp);
+    REQUIRE(has_sprite("background_2"));
+    REQUIRE(sprite_dx(sprt2) == 0.0);
     SECTION("can call sprite function")
     {
         call_for_all_sprites(test_sprite_function);
         REQUIRE(sprite_dx(sprt) == 10.0);
+        REQUIRE(sprite_dx(sprt2) == 10.0);
     }
     SECTION("can call sprite function with float argument")
     {
         call_for_all_sprites(test_sprite_float_function, 20.0);
         REQUIRE(sprite_dx(sprt) == 20.0);
+        REQUIRE(sprite_dx(sprt2) == 20.0);
     }
     free_sprite(sprt);
+    free_sprite(sprt2);
 }
 TEST_CASE("sprite pack functions can be used", "[sprite]")
 {
@@ -733,15 +682,19 @@ TEST_CASE("sprite pack functions can be used", "[sprite]")
         sprite sprt = create_sprite("sprite_1", background_bmp);
         REQUIRE(has_sprite("sprite_1"));
         REQUIRE(sprite_dx(sprt) == 0.0);
+
         select_sprite_pack("default");
+
         sprite sprt2 = create_sprite("sprite_2", background_bmp);
         REQUIRE(has_sprite("sprite_2"));
         REQUIRE(sprite_dx(sprt2) == 0.0);
+
         select_sprite_pack("test_pack");
         call_for_all_sprites(test_sprite_function);
         REQUIRE(sprite_dx(sprt) == 10.0);
         sprite_set_dx(sprt, 90.0);
         REQUIRE(sprite_dx(sprt2) == 0.0);
+
         select_sprite_pack("default");
         call_for_all_sprites(test_sprite_function);
         REQUIRE(sprite_dx(sprt) == 90.0);
@@ -753,28 +706,104 @@ TEST_CASE("sprite pack functions can be used", "[sprite]")
 void test_sprite_arrived_event(void *s, int evt)
 {
     sprite_event_kind event = static_cast<sprite_event_kind>(evt);
-    if (event == SPRITE_ARRIVED_EVENT)
+    sprite sprt = static_cast<sprite>(s);
+
+    switch (event)
     {
-        sprite_set_dy(static_cast<sprite>(s), 50.0);
-    }
+    case SPRITE_ARRIVED_EVENT:
+        sprite_set_mass(sprt, 75.0f);
+        break;
+    case SPRITE_ANIMATION_ENDED_EVENT:
+        sprite_set_mass(sprt, 85.0f);
+        break;
+    case SPRITE_TOUCHED_EVENT:
+        sprite_set_mass(sprt, 95.0f);
+        break;
+    default: // SPRITE_CUSTOM_EVENT
+        sprite_set_mass(sprt, 105.0f);
+        break;
+    };
 }
 TEST_CASE("sprite events can be created and handled", "[sprite]")
 {
-    sprite sprt = create_sprite("frog", frog_bmp);
-    REQUIRE(has_sprite("frog"));
-    SECTION("can add sprite event")
+    SECTION("can trigger sprite event on single sprite")
     {
-        sprite_call_on_event(sprt, test_sprite_arrived_event);
-    }
-    SECTION("can trigger sprite event")
-    {
-        REQUIRE(sprite_dy(sprt) == 0.0);
-        sprite_set_velocity(sprt, vector_to(50.0, 50.0));
-        sprite_move_to(sprt, point_at(100.0, 100.0), 0.0f);
+        sprite sprt = create_sprite("frog", frog_bmp);
+        REQUIRE(has_sprite("frog"));
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        SECTION("can add sprite event")
+        {
+            sprite_call_on_event(sprt, test_sprite_arrived_event);
+        }
         update_sprite(sprt);
-        REQUIRE(sprite_dy(sprt) == 50.0);
+        REQUIRE(sprite_mass(sprt) == 85.0f);
+        free_sprite(sprt);
     }
-    free_sprite(sprt);
+    SECTION("can remove sprite event on single sprite")
+    {
+        sprite sprt = create_sprite("frog2", frog_bmp);
+        REQUIRE(has_sprite("frog2"));
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        SECTION("can confirm that event is functioning")
+        {
+            sprite_call_on_event(sprt, test_sprite_arrived_event);
+            update_sprite(sprt);
+            REQUIRE(sprite_mass(sprt) == 85.0f);
+        }
+        sprite_set_mass(sprt, 1.0f);
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        sprite_stop_calling_on_event(sprt, test_sprite_arrived_event);
+        update_sprite(sprt);
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        free_sprite(sprt);
+    }
+    SECTION("can trigger sprite event on all sprites")
+    {
+        sprite sprt = create_sprite("frog", frog_bmp);
+        REQUIRE(has_sprite("frog"));
+        sprite sprt2 = create_sprite("frog2", frog_bmp);
+        REQUIRE(has_sprite("frog2"));
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        REQUIRE(sprite_mass(sprt2) == 1.0f);
+        SECTION("can add sprite event")
+        {
+            call_on_sprite_event(test_sprite_arrived_event);
+        }
+        update_sprite(sprt);
+        update_sprite(sprt2);
+        REQUIRE(sprite_mass(sprt) == 85.0f);
+        REQUIRE(sprite_mass(sprt2) == 85.0f);
+        free_sprite(sprt);
+        free_sprite(sprt2);
+    }
+    SECTION("can remove sprite event on all sprites")
+    {
+        sprite sprt = create_sprite("frog", frog_bmp);
+        REQUIRE(has_sprite("frog"));
+        sprite sprt2 = create_sprite("frog2", frog_bmp);
+        REQUIRE(has_sprite("frog2"));
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        REQUIRE(sprite_mass(sprt2) == 1.0f);
+        SECTION("can confirm that event is functioning")
+        {
+            call_on_sprite_event(test_sprite_arrived_event);
+            update_sprite(sprt);
+            update_sprite(sprt2);
+            REQUIRE(sprite_mass(sprt) == 85.0f);
+            REQUIRE(sprite_mass(sprt2) == 85.0f);
+        }
+        sprite_set_mass(sprt, 1.0f);
+        sprite_set_mass(sprt2, 1.0f);
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        REQUIRE(sprite_mass(sprt2) == 1.0f);
+        stop_calling_on_sprite_event(test_sprite_arrived_event);
+        update_sprite(sprt);
+        update_sprite(sprt2);
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+        REQUIRE(sprite_mass(sprt2) == 1.0f);
+        free_sprite(sprt);
+        free_sprite(sprt2);
+    }
 }
 TEST_CASE("bitmaps can be freed", "[bitmap]")
 {

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -9,16 +9,29 @@
 
 using namespace splashkit_lib;
 
+constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72,
+    FROG_WIDTH = 294, FROG_HEIGHT = 422,
+        BACKGROUND_WIDTH = 864, BACKGROUND_HEIGHT = 769;
+
 bitmap rocket_bmp, frog_bmp, background_bmp;
 
 TEST_CASE("bitmaps can be created", "[bitmap]")
 {
     rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
     REQUIRE(bitmap_valid(rocket_bmp));
+    REQUIRE(rocket_bmp != nullptr);
+    REQUIRE(bitmap_width(rocket_bmp) == ROCKET_WIDTH);
+    REQUIRE(bitmap_height(rocket_bmp) == ROCKET_HEIGHT);
     frog_bmp = load_bitmap("frog", "frog.png");
     REQUIRE(bitmap_valid(frog_bmp));
+    REQUIRE(frog_bmp != nullptr);
+    REQUIRE(bitmap_width(frog_bmp) == FROG_WIDTH);
+    REQUIRE(bitmap_height(frog_bmp) == FROG_HEIGHT);
     background_bmp = load_bitmap("background", "background.png");
     REQUIRE(bitmap_valid(background_bmp));
+    REQUIRE(background_bmp != nullptr);
+    REQUIRE(bitmap_width(background_bmp) == BACKGROUND_WIDTH);
+    REQUIRE(bitmap_height(background_bmp) == BACKGROUND_HEIGHT);
 }
 TEST_CASE("sprites can be created and freed", "[sprite]")
 {
@@ -66,9 +79,25 @@ TEST_CASE("sprites can be created and freed", "[sprite]")
 TEST_CASE("sprite dimensions can be retrieved", "[sprite]")
 {
     sprite sprt = create_sprite("rocket", rocket_bmp);
-    REQUIRE(sprite_width(sprt) == 36);
-    REQUIRE(sprite_height(sprt) == 72);
+    REQUIRE(sprite_width(sprt) == ROCKET_WIDTH);
+    REQUIRE(sprite_height(sprt) == ROCKET_HEIGHT);
     free_sprite(sprt);
+}
+TEST_CASE("sprite default matrix is correct", "[sprite]")
+{
+    sprite sprt = create_sprite("rocket", rocket_bmp);
+    matrix_2d m = sprite_location_matrix(sprt);
+    rectangle r = sprite_collision_rectangle(sprt);
+    matrix_2d translation = translation_matrix(r.x, r.y);
+    REQUIRE(m.elements[0][0] == translation.elements[0][0]);
+    REQUIRE(m.elements[0][1] == translation.elements[0][1]);
+    REQUIRE(m.elements[0][2] == translation.elements[0][2]);
+    REQUIRE(m.elements[1][0] == translation.elements[1][0]);
+    REQUIRE(m.elements[1][1] == translation.elements[1][1]);
+    REQUIRE(m.elements[1][2] == translation.elements[1][2]);
+    REQUIRE(m.elements[2][0] == translation.elements[2][0]);
+    REQUIRE(m.elements[2][1] == translation.elements[2][1]);
+    REQUIRE(m.elements[2][2] == translation.elements[2][2]);
 }
 TEST_CASE("sprite can be moved", "[sprite]")
 {
@@ -77,18 +106,18 @@ TEST_CASE("sprite can be moved", "[sprite]")
 
     SECTION("initial position is (0, 0)")
     {
-        REQUIRE(sprite_x(sprt) == 0.0f);
-        REQUIRE(sprite_y(sprt) == 0.0f);
+        REQUIRE(sprite_x(sprt) == 0.0);
+        REQUIRE(sprite_y(sprt) == 0.0);
     }
     SECTION("can set sprite position")
     {
-        sprite_set_x(sprt, 100.0f);
-        sprite_set_y(sprt, 200.0f);
+        sprite_set_x(sprt, 100.0);
+        sprite_set_y(sprt, 200.0);
         point_2d pos = sprite_position(sprt);
         REQUIRE(pos.x == 100.0);
         REQUIRE(pos.y == 200.0);
-        REQUIRE(sprite_x(sprt) == 100.0f);
-        REQUIRE(sprite_y(sprt) == 200.0f);
+        REQUIRE(sprite_x(sprt) == 100.0);
+        REQUIRE(sprite_y(sprt) == 200.0);
     }
     SECTION("can set sprite position with point")
     {
@@ -96,64 +125,67 @@ TEST_CASE("sprite can be moved", "[sprite]")
         point_2d pos = sprite_position(sprt);
         REQUIRE(pos.x == 300.0);
         REQUIRE(pos.y == 400.0);
-        REQUIRE(sprite_x(sprt) == 300.0f);
-        REQUIRE(sprite_y(sprt) == 400.0f);
+        REQUIRE(sprite_x(sprt) == 300.0);
+        REQUIRE(sprite_y(sprt) == 400.0);
         sprite_set_position(sprt, point_at(0.0, 0.0));
         pos = sprite_position(sprt);
         REQUIRE(pos.x == 0.0);
         REQUIRE(pos.y == 0.0);
-        REQUIRE(sprite_x(sprt) == 0.0f);
-        REQUIRE(sprite_y(sprt) == 0.0f);
-        // sprite_set_position(sprt, point_at(__DBL_MAX__, -__DBL_MAX__));
-        // pos = sprite_position(sprt);
-        // REQUIRE(pos.x == __DBL_MAX__);
-        // REQUIRE(pos.y == -__DBL_MAX__);
-        // REQUIRE(sprite_x(sprt) == __DBL_MAX__);
-        // REQUIRE(sprite_y(sprt) == -__DBL_MAX__);
-        // sprite_set_position(sprt, point_at(__DBL_MIN__, -__DBL_MIN__));
-        // pos = sprite_position(sprt);
-        // REQUIRE(pos.x == __DBL_MIN__);
-        // REQUIRE(pos.y == -__DBL_MIN__);
-        // REQUIRE(sprite_x(sprt) == __DBL_MIN__);
-        // REQUIRE(sprite_y(sprt) == -__DBL_MIN__);
+        REQUIRE(sprite_x(sprt) == 0.0);
+        REQUIRE(sprite_y(sprt) == 0.0);
+
+        SECTION("can set sprite position to extreme values")
+        {
+            sprite_set_position(sprt, point_at(__DBL_MAX__, -__DBL_MAX__));
+            pos = sprite_position(sprt);
+            REQUIRE(pos.x == __DBL_MAX__);
+            REQUIRE(pos.y == -__DBL_MAX__);
+            REQUIRE(sprite_x(sprt) == __DBL_MAX__);
+            REQUIRE(sprite_y(sprt) == -__DBL_MAX__);
+            sprite_set_position(sprt, point_at(__DBL_MIN__, -__DBL_MIN__));
+            pos = sprite_position(sprt);
+            REQUIRE(pos.x == __DBL_MIN__);
+            REQUIRE(pos.y == -__DBL_MIN__);
+            REQUIRE(sprite_x(sprt) == __DBL_MIN__);
+            REQUIRE(sprite_y(sprt) == -__DBL_MIN__);
+        }
     }
     SECTION("can move sprite by anchor point")
     {
         sprite_set_move_from_anchor_point(sprt, true);
         sprite_set_anchor_point(sprt, point_at(30.0, 50.0));
         move_sprite_to(sprt, 500.0, 500.0);
-        REQUIRE(sprite_x(sprt) == 500.0f - 30.0f);
-        REQUIRE(sprite_y(sprt) == 500.0f - 50.0f);
+        REQUIRE(sprite_x(sprt) == 500.0 - 30.0);
+        REQUIRE(sprite_y(sprt) == 500.0 - 50.0);
     }
     SECTION("can move sprite from origin")
     {
         sprite_set_move_from_anchor_point(sprt, false);
         move_sprite_to(sprt, 10.0, 20.0);
-        REQUIRE(sprite_x(sprt) == 10.0f);
-        REQUIRE(sprite_y(sprt) == 20.0f);
+        REQUIRE(sprite_x(sprt) == 10.0);
+        REQUIRE(sprite_y(sprt) == 20.0);
     }
     SECTION("can get center point of sprite")
     {
-        int width = 36, height = 72;
         SECTION("sprite dimensions can be retrieved")
         {
-            REQUIRE(sprite_width(sprt) == width);
-            REQUIRE(sprite_height(sprt) == height);
+            REQUIRE(sprite_width(sprt) == ROCKET_WIDTH);
+            REQUIRE(sprite_height(sprt) == ROCKET_HEIGHT);
         }
         point_2d pos = sprite_position(sprt);
         point_2d center = center_point(sprt);
-        REQUIRE(center.x == pos.x + width / 2.0);
-        REQUIRE(center.y == pos.y + height / 2.0);
+        REQUIRE(center.x == pos.x + ROCKET_WIDTH / 2.0);
+        REQUIRE(center.y == pos.y + ROCKET_HEIGHT / 2.0);
     }
     free_sprite(sprt);
 }
 TEST_CASE("can check sprite intersection", "[sprite]")
 {
-    sprite sprt = create_sprite("rocket", rocket_bmp);
-    REQUIRE(has_sprite("rocket"));
-    sprite_set_move_from_anchor_point(sprt, false);
-    sprite sprt2 = create_sprite("background", background_bmp);
+    sprite sprt = create_sprite("background", background_bmp);
     REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite sprt2 = create_sprite("background_2", background_bmp);
+    REQUIRE(has_sprite("background_2"));
     sprite_set_move_from_anchor_point(sprt2, false);
 
     SECTION("can check AABB collision")
@@ -168,63 +200,50 @@ TEST_CASE("can check sprite intersection", "[sprite]")
         REQUIRE(sprite_collision(sprt, sprt2));
         REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
 
-        // SECTION("can detect small intersection")
-        // {
-        //     sprite_set_position(sprt2, point_at(0.0, 0.0));
-        //     sprite_set_position(sprt, point_at(sprite_width(sprt2), 0.0));
-        //     REQUIRE_FALSE(sprite_collision(sprt, sprt2));
-        //     REQUIRE_FALSE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
-        //     sprite_set_position(sprt, point_at(sprite_width(sprt2) - 1.0, 0.0));
+        SECTION("can detect small intersection")
+        {
+            sprite_set_position(sprt2, point_at(0.0, 0.0));
+            sprite_set_position(sprt, point_at(sprite_width(sprt2), 0.0));
+            REQUIRE_FALSE(sprite_collision(sprt, sprt2));
+            REQUIRE_FALSE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+            sprite_set_position(sprt, point_at(sprite_width(sprt2) - 1.0, 0.0));
 
-        //     rectangle r = sprite_collision_rectangle(sprt);
-        //     REQUIRE(r.height == 72.0);
-        //     REQUIRE(r.width == 36.0);
-        //     REQUIRE(r.x == 864.0 - 1.0);
-        //     REQUIRE(r.y == 0.0);
-        //     REQUIRE(sprite_collision_bitmap(sprt) == rocket_bmp);
-        //     REQUIRE(sprite_current_cell(sprt) == 0);
-        //     matrix_2d m = sprite_location_matrix(sprt);
-        //     matrix_2d translation = translation_matrix(r.x, r.y);
-        //     REQUIRE(m.elements[0][0] == translation.elements[0][0]);
-        //     REQUIRE(m.elements[0][1] == translation.elements[0][1]);
-        //     REQUIRE(m.elements[0][2] == translation.elements[0][2]);
-        //     REQUIRE(m.elements[1][0] == translation.elements[1][0]);
-        //     REQUIRE(m.elements[1][1] == translation.elements[1][1]);
-        //     REQUIRE(m.elements[1][2] == translation.elements[1][2]);
-        //     REQUIRE(m.elements[2][0] == translation.elements[2][0]);
-        //     REQUIRE(m.elements[2][1] == translation.elements[2][1]);
-        //     REQUIRE(m.elements[2][2] == translation.elements[2][2]);
+            rectangle r = sprite_collision_rectangle(sprt);
+            REQUIRE(r.height == BACKGROUND_HEIGHT);
+            REQUIRE(r.width == BACKGROUND_WIDTH);
+            REQUIRE(r.x == 863.0);
+            REQUIRE(r.y == 0.0);
+            REQUIRE(sprite_collision_bitmap(sprt) == background_bmp);
+            REQUIRE(sprite_current_cell(sprt) == 0);
 
-        //     rectangle r2 = sprite_collision_rectangle(sprt2);
-        //     REQUIRE(r2.height == 769.0);
-        //     REQUIRE(r2.width == 864.0);
-        //     REQUIRE(r2.x == 0.0);
-        //     REQUIRE(r2.y == 0.0);
-        //     REQUIRE(sprite_collision_bitmap(sprt2) == background_bmp);
-        //     REQUIRE(sprite_current_cell(sprt2) == 0);
-        //     matrix_2d m2 = sprite_location_matrix(sprt2);
-        //     matrix_2d translation2 = translation_matrix(r2.x, r2.y);
-        //     REQUIRE(m2.elements[0][0] == translation2.elements[0][0]);
-        //     REQUIRE(m2.elements[0][1] == translation2.elements[0][1]);
-        //     REQUIRE(m2.elements[0][2] == translation2.elements[0][2]);
-        //     REQUIRE(m2.elements[1][0] == translation2.elements[1][0]);
-        //     REQUIRE(m2.elements[1][1] == translation2.elements[1][1]);
-        //     REQUIRE(m2.elements[1][2] == translation2.elements[1][2]);
-        //     REQUIRE(m2.elements[2][0] == translation2.elements[2][0]);
-        //     REQUIRE(m2.elements[2][1] == translation2.elements[2][1]);
-        //     REQUIRE(m2.elements[2][2] == translation2.elements[2][2]);
+            rectangle r2 = sprite_collision_rectangle(sprt2);
+            REQUIRE(r2.height == 769.0);
+            REQUIRE(r2.width == 864.0);
+            REQUIRE(r2.x == 0.0);
+            REQUIRE(r2.y == 0.0);
+            REQUIRE(sprite_collision_bitmap(sprt2) == background_bmp);
+            REQUIRE(sprite_current_cell(sprt2) == 0);
 
-        //     REQUIRE(sprite_collision(sprt, sprt2));
-        //     REQUIRE(rectangles_intersect(sprite_collision_rectangle(sprt), sprite_collision_rectangle(sprt2)));
-        //     REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
-        // }
+            REQUIRE(sprite_collision(sprt, sprt2));
+            REQUIRE(rectangles_intersect(sprite_collision_rectangle(sprt), sprite_collision_rectangle(sprt2)));
+
+            quad q1, q2;
+            q1 = quad_from(bitmap_cell_rectangle(sprite_collision_bitmap(sprt)), sprite_location_matrix(sprt));
+            q2 = quad_from(sprite_collision_rectangle(sprt2));
+            REQUIRE(quads_intersect(q1, q2));
+
+            REQUIRE(bitmap_rectangle_collision(sprite_collision_bitmap(sprt), sprite_current_cell(sprt),
+                sprite_location_matrix(sprt), sprite_collision_rectangle(sprt2)));
+
+            REQUIRE(sprite_rectangle_collision(sprt, sprite_collision_rectangle(sprt2)));
+        }
     }
     SECTION("can check pixel collision")
     {
         sprite_set_collision_kind(sprt, PIXEL_COLLISIONS);
         sprite_set_collision_kind(sprt2, PIXEL_COLLISIONS);
         sprite_set_position(sprt, point_at(100.0, 100.0));
-        sprite_set_position(sprt2, point_at(500.0, 500.0));
+        sprite_set_position(sprt2, point_at(1500.0, 1500.0));
         REQUIRE_FALSE(sprite_collision(sprt, sprt2));
         sprite_set_position(sprt2, point_at(100.0, 100.0));
         REQUIRE(sprite_collision(sprt, sprt2));
@@ -233,7 +252,7 @@ TEST_CASE("can check sprite intersection", "[sprite]")
     {
         sprite_set_collision_kind(sprt, PIXEL_COLLISIONS);
         sprite_set_position(sprt, point_at(100.0, 100.0));
-        REQUIRE_FALSE(sprite_bitmap_collision(sprt, frog_bmp, 0, 500.0, 500.0));
+        REQUIRE_FALSE(sprite_bitmap_collision(sprt, frog_bmp, 0, 1500.0, 1500.0));
         REQUIRE(sprite_bitmap_collision(sprt, frog_bmp, 0, 100.0, 100.0));
     }
     SECTION("can check sprite intersection with point")
@@ -241,20 +260,24 @@ TEST_CASE("can check sprite intersection", "[sprite]")
         sprite_set_collision_kind(sprt2, AABB_COLLISIONS);
         sprite_set_move_from_anchor_point(sprt2, false);
         sprite_set_position(sprt2, point_at(0.0, 0.0));
-        REQUIRE_FALSE(sprite_point_collision(sprt, point_at(2000.0, 2000.0)));
+        REQUIRE_FALSE(sprite_point_collision(sprt2, point_at(2000.0, 2000.0)));
+        REQUIRE(sprite_point_collision(sprt2, point_at(400.0, 400.0)));
+        REQUIRE_FALSE(sprite_point_collision(sprt2, point_at(0.0, 0.0)));
 
-        point_2d pt = point_at(400.0, 400.0);
+        point_2d pt1 = point_at(0.1, 0.1);
         circle c = sprite_collision_circle(sprt2);
-        REQUIRE(c.center.x == sprite_width(sprt2) / 2.0);
-        REQUIRE(c.center.y == sprite_height(sprt2) / 2.0);
-        REQUIRE(c.radius == sprite_width(sprt2) / 2.0);
+        point_2d center = center_point(sprt2);
+        REQUIRE(c.center.x == center.x);
+        REQUIRE(c.center.y == center.y);
+        REQUIRE(c.radius == sqrt(pow(BACKGROUND_WIDTH / 2.0, 2.0) + pow(BACKGROUND_HEIGHT / 2.0, 2.0)));
+        REQUIRE(point_in_circle(pt1, c));
+        REQUIRE(sprite_point_collision(sprt2, pt1));
 
-        float point_point_dist = sqrt(pow(pt.x - c.center.x, 2) + pow(pt.y - c.center.y, 2));
-        REQUIRE(point_point_distance(c.center, pt) == point_point_dist);
-        REQUIRE(abs((long long)c.radius) == sprite_width(sprt2) / 2);
+        point_2d pt2 = point_at(0.000001, 0.000001);
+        REQUIRE(point_in_circle(pt2, sprite_collision_circle(sprt2)));
+        REQUIRE(sprite_point_collision(sprt2, pt2));
 
-        REQUIRE(point_in_circle(pt, c));
-        REQUIRE(sprite_point_collision(sprt2, pt));
+        //REQUIRE(sprite_point_collision(sprt2, point_at(__DBL_MIN__, __DBL_MIN__)));
     }
     free_sprite(sprt);
     free_sprite(sprt2);

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -359,13 +359,6 @@ TEST_CASE("can set sprite velocity components", "[sprite]")
         sprite_set_dy(sprt, -__DBL_MAX__);
         REQUIRE(sprite_dy(sprt) == -__DBL_MAX__);
     }
-    // SECTION("can set sprite velocity")
-    // {
-    //     sprite_set_velocity(sprt, vector_to(30.0, 40.0));
-    //     vector_2d vec = sprite_velocity(sprt);
-    //     REQUIRE(vec.x == 30.0);
-    //     REQUIRE(vec.y == 40.0);
-    // }
     free_sprite(sprt);
 }
 TEST_CASE("can perform sprite vector functions", "[sprite]")

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -477,7 +477,7 @@ TEST_CASE("sprite heading can be set and retrieved", "[sprite]")
     }
     SECTION("can set sprite heading")
     {
-        sprite_set_speed(sprt, 10.0f);
+        sprite_set_velocity(sprt, vector_to(10.0, 0.0));
         sprite_set_heading(sprt, 0.0f);
         REQUIRE(sprite_heading(sprt) == 0.0f);
         sprite_set_heading(sprt, 180.0f);

--- a/coresdk/src/test/unit_tests/unit_test_sprites.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_sprites.cpp
@@ -49,6 +49,8 @@ TEST_CASE("sprites can be created and freed", "[sprite]")
         REQUIRE_FALSE(has_sprite("rocket"));
         sprite sprt = create_sprite("rocket", rocket_bmp);
         REQUIRE(has_sprite("rocket"));
+        REQUIRE(sprite_named("rocket") == sprt);
+        REQUIRE(sprite_name(sprt) == "rocket");
         free_sprite(sprt);
         REQUIRE_FALSE(has_sprite("rocket"));
     }
@@ -76,28 +78,105 @@ TEST_CASE("sprites can be created and freed", "[sprite]")
         REQUIRE_FALSE(has_sprite("rocket2"));
     }
 }
-TEST_CASE("sprite dimensions can be retrieved", "[sprite]")
+TEST_CASE("default sprite data can be retrieved", "[sprite]")
 {
     sprite sprt = create_sprite("rocket", rocket_bmp);
     REQUIRE(sprite_width(sprt) == ROCKET_WIDTH);
     REQUIRE(sprite_height(sprt) == ROCKET_HEIGHT);
+    SECTION("can retrieve sprite layer details")
+    {
+        REQUIRE(sprite_layer_count(sprt) == 1);
+        REQUIRE(sprite_visible_layer_count(sprt) == 1);
+        REQUIRE(sprite_layer(sprt, 0) == rocket_bmp);
+        REQUIRE(sprite_visible_layer(sprt, 0) == 0);
+        REQUIRE(sprite_visible_layer_id(sprt, 0) == 0);
+        REQUIRE(sprite_visible_index_of_layer(sprt, 0) == 0);
+    }
+    SECTION("can retrieve sprite layer dimensions")
+    {
+        REQUIRE(sprite_layer_width(sprt, 0) == ROCKET_WIDTH);
+        REQUIRE(sprite_layer_height(sprt, 0) == ROCKET_HEIGHT);
+    }
+    SECTION("can retrieve sprite layer rectangle")
+    {
+        rectangle layer_rec = sprite_layer_rectangle(sprt, 0);
+        REQUIRE(layer_rec.height == ROCKET_HEIGHT);
+        REQUIRE(layer_rec.width == ROCKET_WIDTH);
+        REQUIRE(layer_rec.x == 0.0);
+        REQUIRE(layer_rec.y == 0.0);
+    }
+    SECTION("can retrieve sprite collision rectangle")
+    {
+        rectangle coll_rec = sprite_collision_rectangle(sprt);
+        REQUIRE(coll_rec.height == ROCKET_HEIGHT);
+        REQUIRE(coll_rec.width == ROCKET_WIDTH);
+        REQUIRE(coll_rec.x == 0.0);
+        REQUIRE(coll_rec.y == 0.0);
+    } 
+    SECTION("can retrieve sprite layer offset")
+    {
+        vector_2d offset = sprite_layer_offset(sprt, 0);
+        REQUIRE(offset.x == 0.0);
+        REQUIRE(offset.y == 0.0);
+    }
+    SECTION("can retrieve sprite anchor point")
+    {
+        point_2d anchor = sprite_anchor_point(sprt);
+        REQUIRE(anchor.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(anchor.y == ROCKET_HEIGHT / 2.0);
+    }
+    SECTION("can retrieve sprite center point")
+    {
+        point_2d center = center_point(sprt);
+        REQUIRE(center.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(center.y == ROCKET_HEIGHT / 2.0);
+    }
+    SECTION("can retrieve sprite collision circle")
+    {
+        circle circ = sprite_collision_circle(sprt);
+        REQUIRE(circ.center.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(circ.center.y == ROCKET_HEIGHT / 2.0);
+        REQUIRE(circ.radius == sqrt(pow(ROCKET_WIDTH / 2.0, 2.0) + pow(ROCKET_HEIGHT / 2.0, 2.0)));
+    }
+    SECTION("can retrieve sprite layer circle")
+    {
+        circle circ = sprite_layer_circle(sprt, 0);
+        REQUIRE(circ.center.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(circ.center.y == ROCKET_HEIGHT / 2.0);
+        REQUIRE(circ.radius == sqrt(pow(ROCKET_WIDTH / 2.0, 2.0) + pow(ROCKET_HEIGHT / 2.0, 2.0)));
+    }
+    SECTION("can retrieve sprite circle")
+    {
+        circle circ = sprite_circle(sprt);
+        REQUIRE(circ.center.x == ROCKET_WIDTH / 2.0);
+        REQUIRE(circ.center.y == ROCKET_HEIGHT / 2.0);
+        REQUIRE(circ.radius == sqrt(pow(ROCKET_WIDTH / 2.0, 2.0) + pow(ROCKET_HEIGHT / 2.0, 2.0)));
+    }
+    SECTION("can retrieve sprite collision bitmap")
+    {
+        bitmap bmp = sprite_collision_bitmap(sprt);
+        REQUIRE(bmp == rocket_bmp);
+    }
+    SECTION("can retrieve sprite collision kind")
+    {
+        REQUIRE(sprite_collision_kind(sprt) == PIXEL_COLLISIONS);
+    }
+    SECTION("sprite default matrix is correct")
+    {
+        matrix_2d m = sprite_location_matrix(sprt);
+        rectangle r = sprite_collision_rectangle(sprt);
+        matrix_2d translation = translation_matrix(r.x, r.y);
+        REQUIRE(m.elements[0][0] == translation.elements[0][0]);
+        REQUIRE(m.elements[0][1] == translation.elements[0][1]);
+        REQUIRE(m.elements[0][2] == translation.elements[0][2]);
+        REQUIRE(m.elements[1][0] == translation.elements[1][0]);
+        REQUIRE(m.elements[1][1] == translation.elements[1][1]);
+        REQUIRE(m.elements[1][2] == translation.elements[1][2]);
+        REQUIRE(m.elements[2][0] == translation.elements[2][0]);
+        REQUIRE(m.elements[2][1] == translation.elements[2][1]);
+        REQUIRE(m.elements[2][2] == translation.elements[2][2]);
+    }
     free_sprite(sprt);
-}
-TEST_CASE("sprite default matrix is correct", "[sprite]")
-{
-    sprite sprt = create_sprite("rocket", rocket_bmp);
-    matrix_2d m = sprite_location_matrix(sprt);
-    rectangle r = sprite_collision_rectangle(sprt);
-    matrix_2d translation = translation_matrix(r.x, r.y);
-    REQUIRE(m.elements[0][0] == translation.elements[0][0]);
-    REQUIRE(m.elements[0][1] == translation.elements[0][1]);
-    REQUIRE(m.elements[0][2] == translation.elements[0][2]);
-    REQUIRE(m.elements[1][0] == translation.elements[1][0]);
-    REQUIRE(m.elements[1][1] == translation.elements[1][1]);
-    REQUIRE(m.elements[1][2] == translation.elements[1][2]);
-    REQUIRE(m.elements[2][0] == translation.elements[2][0]);
-    REQUIRE(m.elements[2][1] == translation.elements[2][1]);
-    REQUIRE(m.elements[2][2] == translation.elements[2][2]);
 }
 TEST_CASE("sprite can be moved", "[sprite]")
 {
@@ -261,8 +340,11 @@ TEST_CASE("can check sprite intersection", "[sprite]")
         sprite_set_move_from_anchor_point(sprt2, false);
         sprite_set_position(sprt2, point_at(0.0, 0.0));
         REQUIRE_FALSE(sprite_point_collision(sprt2, point_at(2000.0, 2000.0)));
+        REQUIRE_FALSE(sprite_at(sprt2, point_at(2000.0, 2000.0)));
         REQUIRE(sprite_point_collision(sprt2, point_at(400.0, 400.0)));
+        REQUIRE(sprite_at(sprt2, point_at(400.0, 400.0)));
         REQUIRE_FALSE(sprite_point_collision(sprt2, point_at(0.0, 0.0)));
+        REQUIRE_FALSE(sprite_at(sprt2, point_at(0.0, 0.0)));
 
         point_2d pt1 = point_at(0.1, 0.1);
         circle c = sprite_collision_circle(sprt2);
@@ -279,9 +361,350 @@ TEST_CASE("can check sprite intersection", "[sprite]")
 
         //REQUIRE(sprite_point_collision(sprt2, point_at(__DBL_MIN__, __DBL_MIN__)));
     }
+    // SECTION("can check whether sprite on screen")
+    // {
+    //     REQUIRE(has_window("test_window"));
+    //     sprite_set_position(sprt, point_at(0.0, 0.0));
+    //     REQUIRE_FALSE(sprite_offscreen(sprt));
+    //     sprite_set_position(sprt, point_at(-100.0, -100.0));
+    //     REQUIRE(sprite_offscreen(sprt));
+    //     sprite_set_position(sprt, point_at(0.0, 0.0));
+    //     REQUIRE_FALSE(sprite_offscreen(sprt));
+    //     sprite_set_position(sprt, point_at(100.0, 100.0));
+    //     REQUIRE_FALSE(sprite_offscreen(sprt));
+    //     sprite_set_position(sprt, point_at(1000.0, 1000.0));
+    //     REQUIRE(sprite_offscreen(sprt));
+    // }
+    // SECTION("can check whether sprite on screen at point")
+    // {
+    //     sprite_set_position(sprt, point_at(0.0, 0.0));
+    //     REQUIRE(sprite_on_screen_at(sprt, point_at(0.0, 0.0)));
+    //     REQUIRE(sprite_on_screen_at(sprt, 0.0, 0.0));
+    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, point_at(-100.0, -100.0)));
+    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, -100.0, -100.0));
+    //     REQUIRE(sprite_on_screen_at(sprt, point_at(0.0, 0.0)));
+    //     REQUIRE(sprite_on_screen_at(sprt, 0.0, 0.0));
+    //     REQUIRE(sprite_on_screen_at(sprt, point_at(100.0, 100.0)));
+    //     REQUIRE(sprite_on_screen_at(sprt, 100.0, 100.0));
+    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, point_at(1000.0, 1000.0)));
+    //     REQUIRE_FALSE(sprite_on_screen_at(sprt, 1000.0, 1000.0));
+    // }
     free_sprite(sprt);
     free_sprite(sprt2);
 }
+TEST_CASE("can set sprite velocity components", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite_set_position(sprt, point_at(100.0, 100.0));
+    SECTION("can set sprite velocity x")
+    {
+        sprite_set_dx(sprt, 10.0);
+        REQUIRE(sprite_dx(sprt) == 10.0);
+        sprite_set_dx(sprt, __DBL_MIN__);
+        REQUIRE(sprite_dx(sprt) == __DBL_MIN__);
+        sprite_set_dx(sprt, -__DBL_MAX__);
+        REQUIRE(sprite_dx(sprt) == -__DBL_MAX__);
+    }
+    SECTION("can set sprite velocity y")
+    {
+        sprite_set_dy(sprt, 20.0);
+        REQUIRE(sprite_dy(sprt) == 20.0);
+        sprite_set_dy(sprt, __DBL_MIN__);
+        REQUIRE(sprite_dy(sprt) == __DBL_MIN__);
+        sprite_set_dy(sprt, -__DBL_MAX__);
+        REQUIRE(sprite_dy(sprt) == -__DBL_MAX__);
+    }
+    SECTION("can set sprite velocity")
+    {
+        sprite_set_velocity(sprt, vector_to(30.0, 40.0));
+        vector_2d vec = sprite_velocity(sprt);
+        REQUIRE(vec.x == 30.0);
+        REQUIRE(vec.y == 40.0);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("can perform sprite vector functions", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite_set_position(sprt, point_at(100.0, 100.0));
+    SECTION("can get default sprite velocity vector")
+    {
+        vector_2d vec = sprite_velocity(sprt);
+        REQUIRE(vec.x == 0.0);
+        REQUIRE(vec.y == 0.0);
+    }
+    SECTION("can set sprite vector")
+    {
+        sprite_set_velocity(sprt, vector_to(10.0, 20.0));
+        vector_2d vec = sprite_velocity(sprt);
+        REQUIRE(vec.x == 10.0);
+        REQUIRE(vec.y == 20.0);
+    }
+    SECTION("can move sprite by vector")
+    {
+        move_sprite(sprt, vector_to(30.0, 40.0));
+        REQUIRE(sprite_x(sprt) == 100.0 + 30.0);
+        REQUIRE(sprite_y(sprt) == 100.0 + 40.0);
+    }
+    SECTION("can move sprite by vector with scale")
+    {
+        move_sprite(sprt, vector_to(30.0, 40.0), 2.0);
+        REQUIRE(sprite_x(sprt) == 100.0 + 30.0 * 2.0);
+        REQUIRE(sprite_y(sprt) == 100.0 + 40.0 * 2.0);
+    }
+    SECTION("can move sprite by velocity")
+    {
+        sprite_set_velocity(sprt, vector_to(50.0, 60.0));
+        move_sprite(sprt);
+        REQUIRE(sprite_x(sprt) == 100.0 + 50.0);
+        REQUIRE(sprite_y(sprt) == 100.0 + 60.0);
+    }
+    SECTION("can move sprite by vector with percentage")
+    {
+        sprite_set_velocity(sprt, vector_to(30.0, 20.0));
+        move_sprite(sprt, 0.5);
+        REQUIRE(sprite_x(sprt) == 100.0 + 30.0 * 0.5);
+        REQUIRE(sprite_y(sprt) == 100.0 + 20.0 * 0.5);
+    }
+    SECTION("can move sprive by vector with percentage")
+    {
+        move_sprite(sprt, vector_to(150.0, 60.0), 0.5);
+        REQUIRE(sprite_x(sprt) == 100.0 + 150.0 * 0.5);
+        REQUIRE(sprite_y(sprt) == 100.0 + 60.0 * 0.5);
+    }
+    SECTION("can add velocity to sprite")
+    {
+        sprite_set_velocity(sprt, vector_to(10.0, 20.0));
+        sprite_add_to_velocity(sprt, vector_to(30.0, 40.0));
+        vector_2d vec = sprite_velocity(sprt);
+        REQUIRE(vec.x == 10.0 + 30.0);
+        REQUIRE(vec.y == 20.0 + 40.0);
+    }
+    SECTION("can get vector from center of sprite to point")
+    {
+        vector_2d vec = vector_from_center_sprite_to_point(sprt, point_at(200.0, 200.0));
+        point_2d center = center_point(sprt);
+        REQUIRE(vec.x == 200.0 - center.x);
+        REQUIRE(vec.y == 200.0 - center.y);
+    }
+    SECTION("can get vector between two sprites")
+    {
+        sprite sprt2 = create_sprite("background_2", background_bmp);
+        sprite_set_move_from_anchor_point(sprt2, false);
+        sprite_set_position(sprt2, point_at(200.0, 200.0));
+        vector_2d vec = vector_from_to(sprt, sprt2);
+        point_2d center1 = center_point(sprt);
+        point_2d center2 = center_point(sprt2);
+        REQUIRE(vec.x == center2.x - center1.x);
+        REQUIRE(vec.y == center2.y - center1.y);
+        free_sprite(sprt2);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite speed can be set and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite_set_position(sprt, point_at(100.0, 100.0));
+    SECTION("can get default sprite speed")
+    {
+        REQUIRE(sprite_speed(sprt) == 0.0);
+    }
+    SECTION("can set sprite speed")
+    {
+        sprite_set_velocity(sprt, vector_to(10.0, -10.0));
+        sprite_set_speed(sprt, 20.0);
+        REQUIRE(sprite_speed(sprt) == Approx(20.0).margin(__DBL_EPSILON__));
+        sprite_set_speed(sprt, 50.0);
+        REQUIRE(sprite_speed(sprt) == Approx(50.0).margin(__DBL_EPSILON__));
+        sprite_set_speed(sprt, -800.0);
+        REQUIRE(sprite_speed(sprt) == Approx(800.0).margin(__DBL_EPSILON__));
+        sprite_set_speed(sprt, __DBL_MAX__);
+        REQUIRE(sprite_speed(sprt) == Approx(__DBL_MAX__).margin(__DBL_EPSILON__));
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite heading can be set and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    sprite_set_move_from_anchor_point(sprt, false);
+    sprite_set_position(sprt, point_at(100.0, 100.0));
+    SECTION("can get default sprite heading")
+    {
+        REQUIRE(sprite_heading(sprt) == 90.0f);
+    }
+    SECTION("can set sprite heading")
+    {
+        sprite_set_speed(sprt, 10.0f);
+        sprite_set_heading(sprt, 0.0f);
+        REQUIRE(sprite_heading(sprt) == 0.0f);
+        sprite_set_heading(sprt, 180.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(180.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, 270.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(-90.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, -90.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(-90.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, 360.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(0.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, 450.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(90.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, -450.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(-90.0f).margin(__FLT_EPSILON__));
+        sprite_set_heading(sprt, 360.0f * 10000 + 1.0f);
+        REQUIRE(sprite_heading(sprt) == Approx(1.0).margin(__FLT_EPSILON__));
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite mass can be set and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    SECTION("can get default sprite mass")
+    {
+        REQUIRE(sprite_mass(sprt) == 1.0f);
+    }
+    SECTION("can set sprite mass")
+    {
+        sprite_set_mass(sprt, 10.0f);
+        REQUIRE(sprite_mass(sprt) == 10.0f);
+        sprite_set_mass(sprt, 0.0f);
+        REQUIRE(sprite_mass(sprt) == 0.0f);
+        sprite_set_mass(sprt, -800.0f);
+        REQUIRE(sprite_mass(sprt) == -800.0f);
+        sprite_set_mass(sprt, __FLT_MAX__);
+        REQUIRE(sprite_mass(sprt) == __FLT_MAX__);
+        sprite_set_mass(sprt, -__FLT_MIN__);
+        REQUIRE(sprite_mass(sprt) == -__FLT_MIN__);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite rotation can be set and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    SECTION("can get default sprite rotation")
+    {
+        REQUIRE(sprite_rotation(sprt) == 0.0f);
+    }
+    SECTION("can set sprite rotation")
+    {
+        sprite_set_rotation(sprt, 10.0f);
+        REQUIRE(sprite_rotation(sprt) == 10.0f);
+        sprite_set_rotation(sprt, 0.0f);
+        REQUIRE(sprite_rotation(sprt) == 0.0f);
+        sprite_set_rotation(sprt, 360.0f);
+        REQUIRE(sprite_rotation(sprt) == 0.0f);
+        sprite_set_rotation(sprt, 450.0f);
+        REQUIRE(sprite_rotation(sprt) == 90.0f);
+        sprite_set_rotation(sprt, -450.0f);
+        REQUIRE(sprite_rotation(sprt) == 270.0f);
+        sprite_set_rotation(sprt, 360.0f * 10000 + 1.0f);
+        REQUIRE(sprite_rotation(sprt) == 1.0f);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite scale can be set and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    SECTION("can get default sprite scale")
+    {
+        REQUIRE(sprite_scale(sprt) == 1.0f);
+    }
+    SECTION("can set sprite scale")
+    {
+        sprite_set_scale(sprt, 10.0f);
+        REQUIRE(sprite_scale(sprt) == 10.0f);
+        sprite_set_scale(sprt, 0.0f);
+        REQUIRE(sprite_scale(sprt) == 0.0f);
+        sprite_set_scale(sprt, -800.0f);
+        REQUIRE(sprite_scale(sprt) == -800.0f);
+        sprite_set_scale(sprt, __FLT_MAX__);
+        REQUIRE(sprite_scale(sprt) == __FLT_MAX__);
+        sprite_set_scale(sprt, -__FLT_MIN__);
+        REQUIRE(sprite_scale(sprt) == -__FLT_MIN__);
+    }
+    free_sprite(sprt);
+}
+TEST_CASE("sprite values can be created, modified, and retrieved", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    SECTION("can get default sprite values")
+    {
+        REQUIRE(sprite_value_count(sprt) == 3);
+        REQUIRE(sprite_has_value(sprt, "mass"));
+        REQUIRE(sprite_value(sprt, "mass") == 1.0f);
+        REQUIRE(sprite_has_value(sprt, "rotation"));
+        REQUIRE(sprite_value(sprt, "rotation") == 0.0f);
+        REQUIRE(sprite_has_value(sprt, "scale"));
+        REQUIRE(sprite_value(sprt, "scale") == 1.0f);
+    }
+    SECTION("can add sprite values")
+    {
+        sprite_add_value(sprt, "speed");
+        REQUIRE(sprite_value_count(sprt) == 4);
+        REQUIRE(sprite_has_value(sprt, "speed"));
+        REQUIRE(sprite_value(sprt, "speed") == 0.0f);
+
+        SECTION("can set sprite values")
+        { 
+            sprite_set_value(sprt, "speed", 20.0f);
+            REQUIRE(sprite_value(sprt, "speed") == 20.0f);
+        }
+    }
+    SECTION("can add sprite values with initial value")
+    {
+        sprite_add_value(sprt, "ammo", 10.0f);
+        REQUIRE(sprite_value_count(sprt) == 4);
+        REQUIRE(sprite_has_value(sprt, "ammo"));
+        REQUIRE(sprite_value(sprt, "ammo") == 10.0f);
+
+        SECTION("can set sprite values")
+        {
+            sprite_set_value(sprt, "ammo", 5.0f);
+            REQUIRE(sprite_value(sprt, "ammo") == 5.0f);
+        }
+    }
+}
+
+void test_sprite_function(void *s)
+{
+    sprite_set_dx(static_cast<sprite>(s), 10.0);
+}
+
+void test_sprite_float_function(void *s, float f)
+{
+    sprite_set_dx(static_cast<sprite>(s), f);
+}
+
+TEST_CASE("sprite functions can be called", "[sprite]")
+{
+    sprite sprt = create_sprite("background", background_bmp);
+    REQUIRE(has_sprite("background"));
+    REQUIRE(sprite_dx(sprt) == 0.0);
+    SECTION("can call sprite function")
+    {
+        call_for_all_sprites(test_sprite_function);
+        REQUIRE(sprite_dx(sprt) == 10.0);
+    }
+    SECTION("can call sprite function with float argument")
+    {
+        call_for_all_sprites(test_sprite_float_function, 20.0);
+        REQUIRE(sprite_dx(sprt) == 20.0);
+    }
+}
+
+// sprite pack
+
+// events
+
 TEST_CASE("bitmaps can be freed", "[bitmap]")
 {
     free_bitmap(rocket_bmp);
@@ -291,5 +714,3 @@ TEST_CASE("bitmaps can be freed", "[bitmap]")
     free_bitmap(background_bmp);
     REQUIRE_FALSE(has_bitmap("background"));
 }
-
-// sprite pack, calls for sprites, sprite functions


### PR DESCRIPTION
# Description

There are currently no unit tests for sprites. A comprehensive set of tests have been added which cover most sprite methods, with the exception of those which rely on a window. In the process of creating the tests, I discovered multiple bugs which have been also been rectified.

### Position and Velocity Type Changes
`_sprite_data` uses the `point_2d` and `velocity_2d` types for `position` and `velocity` respectively. `point_2d` and `velocity_2d` both use the `double` type. `sprite_x`, `sprite_y`, `sprite_set_x`, `sprite_set_y`, `sprite_dx`, `sprite_dy`, `sprite_set_dx`, and `sprite_set_dy` use the `float` type leading to unnecessary casting. Issues arise when the value stored in `point_2d` or `vector_2d`'s double is outside the range of `float`. The methods have been altered to accept and return `double`.

### Sprite-Point Collision Bug at Corners
`sprite_point_collision` calls `sprite_collision_circle`, which then calls `bitmap_cell_circle` which generates a `circle` which does not encompass the sprite. Points tested at the edges of the sprite will incorrectly return no collision. This occurs because the function uses the greater of a sprite's half-width or half-height as the radius. Instead, the length of the hypotenuse of a right triangle formed with the sprite's half-width and half-height as the opposite and adjacent should equal the circle's radius. `bitmap_bounding_circle` has also been corrected as it contains the same bug.

### Point Methods Type Changes
`point_in_circle` casts `double` to `long long` which causes inaccuracy due to the rounding errors. The method has been altered to retain `circle` radius' `double` precision. In addition, `point_in_circle` calls `point_point_distance` which returns `float` instead of `double`. `point_point_distance` has been altered to return `double`, retaining the `double` precision.

### Sprite Speed Methods Type Changes
`sprite_speed` and `sprite_set_speed` return and accept `float`, while calling the methods `vector_magnitude`, `vector_multiply`, and `unit_vector` which all operate at `double` precision. `sprite_speed` and `sprite_set_speed` have been altered to use `double` precision.

### Sprite Rotation Periodicity
`sprite_set_rotation` incorrectly returns `360` when the input value equals `360`. Instead, it should convert `360` to `0` degrees.

### Additional Unit Tests
As the methods in `sprite.cpp` make calls to methods in `images.cpp` and `point_geometry.cpp`, it was necessary to add unit tests for those methods. In the case of images, there is an existing `unit_test_bitmap.cpp` file which I added to. For geometry tests, I created a new `unit_test_geometry.cpp` file. More geometry tests could be added in the future, however at this stage I only focused on those which are relevant to sprites.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

## How Has This Been Tested?

Adding the new tests was achieved by running `cmake -G "Unix Makefiles" .` followed by `make` when in the `/splashkit-core/projects/cmake` directory.

## Testing Checklist

- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code