### PR TITLE
Add sprite collision classification and resolution functions 

### DIFF
--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -534,7 +534,7 @@ namespace splashkit_lib
                 _move_sprite_by_direction_relative_to_size(collider, collider_direction,
                                                                 1.0 / pow(1.5, static_cast<double>(i)));
             }
-            else if (i == 0) // no collision in the first iteration
+            else if (i == 1) // no collision in the first iteration
             {
                 return false;
             }

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -386,4 +386,54 @@ namespace splashkit_lib
         return bitmap_collision(bmp1, 0, translation_matrix(x1, y1), bmp2, 0, translation_matrix(x2, y2));
     }
 
+    bool resolve_collision(sprite s1, sprite s2, collision_resolution_kind kind)
+    {
+        // check if the sprites are colliding
+        if (!sprite_collision(s1, s2))
+        {
+            return false;
+        }
+
+        // get the bounding rectangles of the sprites
+        rectangle r1 = sprite_collision_rectangle(s1);
+        rectangle r2 = sprite_collision_rectangle(s2);
+
+        // get the intersection rectangle
+        rectangle inter = intersection(r1, r2);
+
+        switch(kind)
+        {
+        case TOP:
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case BOTTOM:
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        case LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            break;
+        case RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            break;
+        case TOP_LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case TOP_RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case BOTTOM_LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        case BOTTOM_RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        }
+
+        return true;
+    }
+
 }

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -476,5 +476,19 @@ namespace splashkit_lib
      */
     bool bitmap_collision(bitmap bmp1, double x1, double y1, bitmap bmp2, double x2, double y2);
 
+    enum collision_resolution_kind
+    {
+        TOP,
+        BOTTOM,
+        LEFT,
+        RIGHT,
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
+    };
+
+    bool resolve_collision(sprite collider, sprite collidee, collision_resolution_kind kind);
+
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -18,6 +18,35 @@
 namespace splashkit_lib
 {
     /**
+     *  This enumeration contains a list of directions that a
+     *  sprite can collide with another sprite. For example, a
+     *  collider sprite which is colliding with another sprite
+     *  on its top edge would have a collision direction of TOP.
+     *  
+     *  @constant TOP           The top of the sprite
+     *  @constant BOTTOM        The bottom of the sprite
+     *  @constant LEFT          The left of the sprite
+     *  @constant RIGHT         The right of the sprite
+     *  @constant TOP_LEFT      The top left of the sprite
+     *  @constant TOP_RIGHT     The top right of the sprite
+     *  @constant BOTTOM_LEFT   The bottom left of the sprite
+     *  @constant BOTTOM_RIGHT  The bottom right of the sprite
+     *  @constant NONE          No collision
+     */
+    enum collision_direction
+    {
+        TOP,
+        BOTTOM,
+        LEFT,
+        RIGHT,
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT,
+        NONE,
+    };
+    
+    /**
      * Tests if a bitmap drawn using the passed in translation matrix would draw a pixel
      * at the passed in point. Use to check collisions between a point and a bitmap.
      *
@@ -476,19 +505,36 @@ namespace splashkit_lib
      */
     bool bitmap_collision(bitmap bmp1, double x1, double y1, bitmap bmp2, double x2, double y2);
 
-    enum collision_resolution_kind
-    {
-        TOP,
-        BOTTOM,
-        LEFT,
-        RIGHT,
-        TOP_LEFT,
-        TOP_RIGHT,
-        BOTTOM_LEFT,
-        BOTTOM_RIGHT
-    };
+    /**
+     * Returns the direction of the collision between two sprites
+     * relative to the collider sprite. If the sprites are not colliding,
+     * this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the collider sprite.
+     *                  If the sprites are not colliding, this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction sprite_collision_direction(sprite collider, sprite collidee);
 
-    bool resolve_collision(sprite collider, sprite collidee, collision_resolution_kind kind);
+    /**
+     * Resolves the collision between two sprites by moving the
+     * collider sprite to the edge of the collidee sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprites are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the collider sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprites are colliding and the collision was resolved,
+     *                  false if the sprites are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction);
 
 }
 #endif /* collisions_h */

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -16,9 +16,111 @@
 
 using namespace splashkit_lib;
 
+enum class sprite_perimeter_segment
+{
+    TOP_LEFT,
+    TOP_CENTER,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_CENTER,
+    BOTTOM_RIGHT,
+    LEFT_TOP,
+    LEFT_CENTER,
+    LEFT_BOTTOM,
+    RIGHT_TOP,
+    RIGHT_CENTER,
+    RIGHT_BOTTOM,
+};
+
+void draw_sprite_perimeter_segment(sprite s, sprite_perimeter_segment segment, color clr, int line_width)
+{
+    switch (segment)
+    {
+    case sprite_perimeter_segment::TOP_LEFT:
+        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::TOP_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::TOP_RIGHT:
+        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_LEFT:
+        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_RIGHT:
+        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_TOP:
+        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_CENTER:
+        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_BOTTOM:
+        draw_line(clr, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::RIGHT_TOP:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::RIGHT_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    default: // case sprite_perimeter_segment::RIGHT_BOTTOM:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    };
+}
+
+void draw_sprite_perimeter_by_collision(sprite s, collision_direction direction, color clr, int line_width)
+{
+    switch (direction)
+    {
+    case collision_direction::TOP:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
+        break;
+    case collision_direction::BOTTOM:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
+        break;
+    case collision_direction::LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::TOP_LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
+        break;
+    case collision_direction::TOP_RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
+        break;
+    case collision_direction::BOTTOM_LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::BOTTOM_RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        break;
+    };
+}
+
 void run_sprite_test()
 {
-    sprite sprt, s2;
+    sprite sprt, s2, s3, s4;
     triangle tri, init_tri;
     triangle tri_b, init_tri_b;
     rectangle r;
@@ -37,6 +139,18 @@ void run_sprite_test()
     sprite_set_move_from_anchor_point(s2, true);
     sprite_set_x(s2, 100);
     sprite_set_y(s2, 100);
+
+    s3 = create_sprite(bitmap_named("rocket_sprt.png"));
+    sprite_set_move_from_anchor_point(s3, true);
+    sprite_set_x(s3, 100);
+    sprite_set_y(s3, 400);
+
+    s4 = create_sprite(bitmap_named("rocket_sprt.png"));
+    sprite_set_move_from_anchor_point(s4, true);
+    sprite_set_x(s4, 400);
+    sprite_set_y(s4, 400);
+    sprite_set_collision_kind(s4, AABB_COLLISIONS);
+    sprite_set_scale(s4, 2.0f);
 
     r = rectangle_from(400, 100, 100, 50);
     q = quad_from(r);
@@ -97,6 +211,8 @@ void run_sprite_test()
 
         draw_sprite(sprt);
         draw_sprite(s2);
+        draw_sprite(s3);
+        draw_sprite(s4);
         
         if (sprite_rectangle_collision(sprt, r))
 		{
@@ -132,7 +248,22 @@ void run_sprite_test()
             draw_circle(COLOR_RED, sprite_collision_circle(s2));
 		}
 
+        if (sprite_collision(sprt, s3))
+        {
+            collision_direction dir = sprite_collision_direction(sprt, s3);
+            resolve_sprite_collision(sprt, s3, dir);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+        }
+
+        if (sprite_collision(sprt, s4))
+        {
+            collision_direction dir = sprite_collision_direction(sprt, s4);
+            resolve_sprite_collision(sprt, s4, dir);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+        }
+
         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(sprt));
+        draw_rectangle(COLOR_RED, sprite_collision_rectangle(s4));
 
         draw_line(COLOR_GREEN, line_from(center_point(sprt), matrix_multiply(rotation_matrix(sprite_rotation(sprt)), vector_multiply(sprite_velocity(sprt), 30.0))));
 


### PR DESCRIPTION
# Description

While there are numerous functions to detect collisions in the SplashKit library, there are none which classify and resolve collisions. I have added two functions to the library: `sprite_collision_direction` and `resolve_sprite_collision`.

### sprite_collision_direction
`sprite_collision_direction` takes two sprites and returns the enumeration `collision_direction`, indicating what part of the colliding sprite is being overlapped by the collidee sprite. It is not entirely accurate as it relies on `sprite_collision_rectangle`, particularly with rotated sprites and those using pixel collisions. However, it is robust and will handle any situation, including if one sprite is enclosed by the other.

### resolve_sprite_collision
`resolve_sprite_collision` takes two sprites and moves the collider so that they are no longer overlapping. The direction of collision is passed into the function. Student's are free to `use sprite_collision_direction` to obtain a direction, or their own methods. The function handles both AABB and pixel collisions. Pixel collisions are resolved iteratively, with the number of iterations being set by DEFAULT_BRACKET_ITERATIONS. A possible change would be to allow students to control the number of iterations, emphasizing the precision/performance tradeoff.

I created seven helper functions and an enumeration which are not included in `collisions.h`, as they should not be exposed to students.

There are many overloads which could be created such as sprite-rectangle, sprite-triangle, and sprite-circle and included in a future pull request.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I altered `test_sprites.cpp` to include two more sprites: s3 uses pixel-based collision and s4 uses AABB collision. When the player-controlled sprite collides with s3 or s4, `sprite_collision_direction` and `resolve_sprite_collision` will be called to resolve the collision. In addition, the `collision_direction` is graphically shown on the player-controlled sprite as a red outline.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
