### PR TITLE
Add object collision classification and resolution functions using OOP

### DIFF
--- a/coresdk/src/backend/backend_types.h
+++ b/coresdk/src/backend/backend_types.h
@@ -9,27 +9,8 @@
 #ifndef BackendTypes_h
 #define BackendTypes_h
 
-#include "drawing_options.h"
-#include "geometry.h"
-#include "audio.h"
-#include "color.h"
-#include "networking.h"
-#include "web_server.h"
-
-#include "concurrency_utils.h"
-#include "civetweb.h"
-
-#include <string>
-#include <vector>
-#include <map>
-
-using std::string;
-using std::vector;
-
 namespace splashkit_lib
 {
-    typedef void *pointer;
-
     /// An identifier for the splashkit pointers.
     /// Each resource will start with an identifier to
     /// Ensure that the dereferenced pointers are likely
@@ -63,6 +44,28 @@ namespace splashkit_lib
         JSON_PTR =                  0x4a534f4e, //'JSON';
         NONE_PTR =                  0x4e4f4e45  //'NONE';
     };
+}
+
+#include "drawing_options.h"
+#include "geometry.h"
+#include "audio.h"
+#include "color.h"
+#include "networking.h"
+#include "web_server.h"
+
+#include "concurrency_utils.h"
+#include "civetweb.h"
+
+#include <string>
+#include <vector>
+#include <map>
+
+using std::string;
+using std::vector;
+
+namespace splashkit_lib
+{
+    typedef void *pointer;
 
     typedef color sk_color;
 

--- a/coresdk/src/backend/interface_driver.cpp
+++ b/coresdk/src/backend/interface_driver.cpp
@@ -320,6 +320,7 @@ namespace splashkit_lib
             mu_Command *cmd = NULL;
             while (mu_next_command(ctx, &cmd))
             {
+                rectangle atlas_rect;
                 switch (cmd->type)
                 {
                     case MU_COMMAND_TEXT:
@@ -344,7 +345,6 @@ namespace splashkit_lib
                         break;
 
                     case MU_COMMAND_ICON:
-                        rectangle atlas_rect;
                         double src_data[4];
                         double dst_data[7];
                         sk_renderer_flip flip;

--- a/coresdk/src/coresdk/circle_geometry.cpp
+++ b/coresdk/src/coresdk/circle_geometry.cpp
@@ -192,4 +192,19 @@ namespace splashkit_lib
 
         return true;
     }
+
+    bool circle_quad_intersect(const circle &c, const quad &q)
+    {
+        vector<triangle> q_tris = triangles_from(q);
+        
+        for (size_t i = 0; i < q_tris.size(); i++)
+        {
+            if (circle_triangle_intersect(c, q_tris[i]))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/coresdk/src/coresdk/circle_geometry.h
+++ b/coresdk/src/coresdk/circle_geometry.h
@@ -213,5 +213,13 @@ namespace splashkit_lib
      */
     bool tangent_points(const point_2d &from_pt, const circle &c, point_2d &p1, point_2d &p2);
 
+    /**
+     * Detects if a circle intersects with a quad.
+     *
+     * @param  c  The circle to test
+     * @param  q  The quad to test
+     * @return    True if the circle and quad intersect, false otherwise
+     */
+    bool circle_quad_intersect(const circle &c, const quad &q);
 }
 #endif /* circle_geometry_hpp */

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -208,58 +208,7 @@ namespace splashkit_lib
         return _sprite_movement_direction::NONE;
     }
 
-    void _move_sprite_by_vector(void* sprt, const vector_2d& amount)
-    {
-        sprite s = *static_cast<const sprite*>(sprt);
-        
-        sprite_set_x(s, sprite_x(s) + amount.x);
-        sprite_set_y(s, sprite_y(s) + amount.y);
-    }
-
-    void _move_rectangle_by_vector(void* rect, const vector_2d& amount)
-    {
-        rectangle* r = static_cast<rectangle*>(rect);
-        
-        r->x += amount.x;
-        r->y += amount.y;
-    }
-
-    void _move_circle_by_vector(void* circ, const vector_2d& amount)
-    {
-        circle* c = static_cast<circle*>(circ);
-        
-        c->center.x += amount.x;
-        c->center.y += amount.y;
-    }
-
-    void _move_triangle_by_vector(void* tri, const vector_2d& amount)
-    {
-        triangle* t = static_cast<triangle*>(tri);
-
-        t->points[0].x += amount.x;
-        t->points[0].y += amount.y;
-        t->points[1].x += amount.x;
-        t->points[1].y += amount.y;
-        t->points[2].x += amount.x;
-        t->points[2].y += amount.y;
-    }
-
-    void _move_quad_by_vector(void* q, const vector_2d& amount)
-    {
-        quad* qd = static_cast<quad*>(q);
-
-        qd->points[0].x += amount.x;
-        qd->points[0].y += amount.y;
-        qd->points[1].x += amount.x;
-        qd->points[1].y += amount.y;
-        qd->points[2].x += amount.x;
-        qd->points[2].y += amount.y;
-        qd->points[3].x += amount.x;
-        qd->points[3].y += amount.y;
-    }
-
-    void _move_object_by_direction(void* obj, std::function<void(void*, const vector_2d& amount)> move_func,
-                                                            _sprite_movement_direction direction, const vector_2d& amount)
+    void _move_object_by_direction(shape* obj, _sprite_movement_direction direction, const vector_2d& amount)
     {
         if (amount.x == 0.0 && amount.y == 0.0)
         {
@@ -269,206 +218,80 @@ namespace splashkit_lib
         switch (direction)
         {
         case _sprite_movement_direction::UP:
-            move_func(obj, vector_to(0.0, -amount.y));
+            obj->move_by(vector_to(0.0, -amount.y));
             break;
         case _sprite_movement_direction::DOWN:
-            move_func(obj, vector_to(0.0, amount.y));
+            obj->move_by(vector_to(0.0, amount.y));
             break;
         case _sprite_movement_direction::LEFT:
-            move_func(obj, vector_to(-amount.x, 0.0));
+            obj->move_by(vector_to(-amount.x, 0.0));
             break;
         case _sprite_movement_direction::RIGHT:
-            move_func(obj, vector_to(amount.x, 0.0));
+            obj->move_by(vector_to(amount.x, 0.0));
             break;
         case _sprite_movement_direction::UP_LEFT:
-            move_func(obj, vector_to(-amount.x, -amount.y));
+            obj->move_by(vector_to(-amount.x, -amount.y));
             break;
         case _sprite_movement_direction::UP_RIGHT:
-            move_func(obj, vector_to(amount.x, -amount.y));
+            obj->move_by(vector_to(amount.x, -amount.y));
             break;
         case _sprite_movement_direction::DOWN_LEFT:
-            move_func(obj, vector_to(-amount.x, amount.y));
+            obj->move_by(vector_to(-amount.x, amount.y));
             break;
         default: // _sprite_movement_direction::DOWN_RIGHT:
-            move_func(obj, vector_to(amount.x, amount.y));
+            obj->move_by(vector_to(amount.x, amount.y));
             break;
         };
     }
 
-    void _move_object_by_direction_relative_to_size(void* obj, const rectangle& obj_aabb,
-        std::function<void(void*, const vector_2d& amount)> move_func,
-            _sprite_movement_direction direction, double relative_amount = 1.0)
+    void _move_object_by_direction_relative_to_size(shape* obj, _sprite_movement_direction direction, double relative_amount = 1.0)
     {
+        rectangle obj_aabb = obj->get_bounding_box();
+        
         double relative_width = obj_aabb.width * relative_amount;
         double relative_height = obj_aabb.height * relative_amount;
 
         switch (direction)
         {
         case _sprite_movement_direction::UP:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::UP, vector_to(0.0, relative_height));
+            _move_object_by_direction(obj,_sprite_movement_direction::UP, vector_to(0.0, relative_height));
             break;
         case _sprite_movement_direction::DOWN:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::DOWN, vector_to(0.0, relative_height));
+            _move_object_by_direction(obj, _sprite_movement_direction::DOWN, vector_to(0.0, relative_height));
             break;
         case _sprite_movement_direction::LEFT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::LEFT, vector_to(relative_width, 0.0));
+            _move_object_by_direction(obj, _sprite_movement_direction::LEFT, vector_to(relative_width, 0.0));
             break;
         case _sprite_movement_direction::RIGHT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::RIGHT, vector_to(relative_width, 0.0));
+            _move_object_by_direction(obj, _sprite_movement_direction::RIGHT, vector_to(relative_width, 0.0));
             break;
         case _sprite_movement_direction::UP_LEFT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::UP_LEFT, vector_to(relative_width, relative_height));
+            _move_object_by_direction(obj, _sprite_movement_direction::UP_LEFT, vector_to(relative_width, relative_height));
             break;
         case _sprite_movement_direction::UP_RIGHT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::UP_RIGHT, vector_to(relative_width, relative_height));
+            _move_object_by_direction(obj, _sprite_movement_direction::UP_RIGHT, vector_to(relative_width, relative_height));
             break;
         case _sprite_movement_direction::DOWN_LEFT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::DOWN_LEFT, vector_to(relative_width, relative_height));
+            _move_object_by_direction(obj, _sprite_movement_direction::DOWN_LEFT, vector_to(relative_width, relative_height));
             break;
         default: // _sprite_movement_direction::DOWN_RIGHT:
-            _move_object_by_direction(obj, move_func, _sprite_movement_direction::DOWN_RIGHT, vector_to(relative_width, relative_height));
+            _move_object_by_direction(obj, _sprite_movement_direction::DOWN_RIGHT, vector_to(relative_width, relative_height));
             break;
         };
-    }
-
-    bool _sprite_sprite_collision_func(const void* s1, const void* s2)
-    {
-        return sprite_collision(*static_cast<const sprite*>(s1), *static_cast<const sprite*>(s2));
-    }
-
-    bool _sprite_rectangle_collision_func(const void* s, const void* rect)
-    {
-        return sprite_rectangle_collision(*static_cast<const sprite*>(s), *static_cast<const rectangle*>(rect));
-    }
-
-    bool _sprite_circle_collision_func(const void* s, const void* circ)
-    {
-        return sprite_circle_collision(*static_cast<const sprite*>(s), *static_cast<const circle*>(circ));
-    }
-
-    bool _sprite_triangle_collision_func(const void* s, const void* tri)
-    {
-        return sprite_triangle_collision(*static_cast<const sprite*>(s), *static_cast<const triangle*>(tri));
-    }
-
-    bool _sprite_quad_collision_func(const void* s, const void* q)
-    {
-        return sprite_quad_collision(*static_cast<const sprite*>(s), *static_cast<const quad*>(q));
-    }
-
-    bool _rectangle_sprite_collision_func(const void* rect, const void* s)
-    {
-        return _sprite_rectangle_collision_func(s, rect);
-    }
-
-    bool _rectangle_rectangle_collision_func(const void* r1, const void* r2)
-    {
-        return rectangles_intersect(*static_cast<const rectangle*>(r1), *static_cast<const rectangle*>(r2));
-    }
-
-    bool _rectangle_circle_collision_func(const void* r, const void* c)
-    {
-        return rectangle_circle_intersect(*static_cast<const rectangle*>(r), *static_cast<const circle*>(c));
-    }
-
-    bool _rectangle_triangle_collision_func(const void* r, const void* t)
-    {
-        return triangle_rectangle_intersect(*static_cast<const triangle*>(t), *static_cast<const rectangle*>(r));
-    }
-
-    bool _rectangle_quad_collision_func(const void* r, const void* q)
-    {
-        return quads_intersect(quad_from(*static_cast<const rectangle*>(r)), *static_cast<const quad*>(q));
-    }
-
-    bool _circle_sprite_collision_func(const void* c, const void* s)
-    {
-        return _sprite_circle_collision_func(s, c);
-    }
-
-    bool _circle_rectangle_collision_func(const void* c, const void* r)
-    {
-        return _rectangle_circle_collision_func(r, c);
-    }
-
-    bool _circle_circle_collision_func(const void* c1, const void* c2)
-    {
-        return circles_intersect(*static_cast<const circle*>(c1), *static_cast<const circle*>(c2));
-    }
-
-    bool _circle_triangle_collision_func(const void* c, const void* t)
-    {
-        return circle_triangle_intersect(*static_cast<const circle*>(c), *static_cast<const triangle*>(t));
-    }
-
-    bool _circle_quad_collision_func(const void* c, const void* q)
-    {
-        return circle_quad_intersect(*static_cast<const circle*>(c), *static_cast<const quad*>(q));
-    }
-
-    bool _triangle_sprite_collision_func(const void* t, const void* s)
-    {
-        return _sprite_triangle_collision_func(s, t);
-    }
-
-    bool _triangle_rectangle_collision_func(const void* t, const void* r)
-    {
-        return _rectangle_triangle_collision_func(r, t);
-    }
-
-    bool _triangle_circle_collision_func(const void* t, const void* c)
-    {
-        return _circle_triangle_collision_func(c, t);
-    }
-
-    bool _triangle_triangle_collision_func(const void* t1, const void* t2)
-    {
-        return triangles_intersect(*static_cast<const triangle*>(t1), *static_cast<const triangle*>(t2));
-    }
-
-    bool _triangle_quad_collision_func(const void* t, const void* q)
-    {
-        return triangle_quad_intersect(*static_cast<const triangle*>(t), *static_cast<const quad*>(q));
-    }
-
-    bool _quad_sprite_collision_func(const void* q, const void* s)
-    {
-        return _sprite_quad_collision_func(s, q);
-    }
-
-    bool _quad_rectangle_collision_func(const void* q, const void* r)
-    {
-        return _rectangle_quad_collision_func(r, q);
-    }
-
-    bool _quad_circle_collision_func(const void* q, const void* c)
-    {
-        return _circle_quad_collision_func(c, q);
-    }
-
-    bool _quad_triangle_collision_func(const void* q, const void* t)
-    {
-        return _triangle_quad_collision_func(t, q);
-    }
-
-    bool _quad_quad_collision_func(const void* q1, const void* q2)
-    {
-        return quads_intersect(*static_cast<const quad*>(q1), *static_cast<const quad*>(q2));
     }
 
     /** 
      * Moves the object back and forth with decreasing step size for
      * the given number of iterations.
     */ 
-    bool _bracket_object_collision(bool colliding, int i, void* collider, const rectangle& collider_aabb,
-                                        std::function<void(void*, const vector_2d& amount)> move_func,
-                                                                _sprite_movement_direction collider_direction)
+    bool _bracket_object_collision(bool colliding, int i, shape* collider, _sprite_movement_direction collider_direction)
     {
+        rectangle collider_aabb = collider->get_bounding_box();
+        
         if (colliding)
         {
-            _move_object_by_direction_relative_to_size(collider, collider_aabb,
-                                                        move_func, collider_direction,
-                                                            1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
+            _move_object_by_direction_relative_to_size(collider, collider_direction,
+                                                        1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
         }
         else if (i == 1) // no collision in the first iteration
         {
@@ -476,227 +299,25 @@ namespace splashkit_lib
         }
         else
         {
-            _move_object_by_direction_relative_to_size(collider, collider_aabb,
-                                                        move_func, _opposite_direction(collider_direction),
-                                                            1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
+            _move_object_by_direction_relative_to_size(collider, _opposite_direction(collider_direction),
+                                                        1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
         }
         return true;
     }
 
-    bool _bracket_object_collision_generic(void* collider, std::function<bool(const void*, const void*)> collision_func,
-                                            const void* collidee, const rectangle& collider_aabb,
-                                            std::function<void(void*, const vector_2d& amount)> move_func,
+    bool _bracket_object_collision_generic(shape* collider, const shape* collidee,
                                             _sprite_movement_direction collider_direction, int iterations)
     {
+        rectangle collider_aabb = collider->get_bounding_box();
+        
         for (int i = 1; i <= iterations; i++)
         {
-            if (!_bracket_object_collision(collision_func(collider, collidee), i, collider,
-                                                collider_aabb, move_func, collider_direction))
+            if (!_bracket_object_collision(collider->intersects(collidee), i, collider, collider_direction))
             {
                 return false;
             }
         }
         return true;
-    }
-
-    bool _bracket_sprite_sprite_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _sprite_sprite_collision_func, collidee,
-                                                sprite_collision_rectangle(*static_cast<const sprite*>(collider)),
-                                                _move_sprite_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_sprite_rectangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _sprite_rectangle_collision_func, collidee,
-                                                sprite_collision_rectangle(*static_cast<const sprite*>(collider)),
-                                                _move_sprite_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_sprite_circle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _sprite_circle_collision_func, collidee,
-                                                sprite_collision_rectangle(*static_cast<const sprite*>(collider)),
-                                                _move_sprite_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_sprite_triangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _sprite_triangle_collision_func, collidee,
-                                                sprite_collision_rectangle(*static_cast<const sprite*>(collider)),
-                                                _move_sprite_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_sprite_quad_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _sprite_quad_collision_func, collidee,
-                                                sprite_collision_rectangle(*static_cast<const sprite*>(collider)),
-                                                _move_sprite_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_rectangle_sprite_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _rectangle_sprite_collision_func, collidee,
-                                                *static_cast<const rectangle*>(collider),
-                                                _move_rectangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_rectangle_rectangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _rectangle_rectangle_collision_func, collidee,
-                                                *static_cast<const rectangle*>(collider),
-                                                _move_rectangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_rectangle_circle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _rectangle_circle_collision_func, collidee,
-                                                *static_cast<const rectangle*>(collider),
-                                                _move_rectangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_rectangle_triangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _rectangle_triangle_collision_func, collidee,
-                                                *static_cast<const rectangle*>(collider),
-                                                _move_rectangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_rectangle_quad_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _rectangle_quad_collision_func, collidee,
-                                                *static_cast<const rectangle*>(collider),
-                                                _move_rectangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_circle_sprite_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _circle_sprite_collision_func, collidee,
-                                                rectangle_around(*static_cast<const circle*>(collider)),
-                                                _move_circle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_circle_rectangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _circle_rectangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const circle*>(collider)),
-                                                _move_circle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_circle_circle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _circle_circle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const circle*>(collider)),
-                                                _move_circle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_circle_triangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _circle_triangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const circle*>(collider)),
-                                                _move_circle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_circle_quad_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _circle_quad_collision_func, collidee,
-                                                rectangle_around(*static_cast<const circle*>(collider)),
-                                                _move_circle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_triangle_sprite_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _triangle_sprite_collision_func, collidee,
-                                                rectangle_around(*static_cast<const triangle*>(collider)),
-                                                _move_triangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_triangle_rectangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _triangle_rectangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const triangle*>(collider)),
-                                                _move_triangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_triangle_circle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _triangle_circle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const triangle*>(collider)),
-                                                _move_triangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_triangle_triangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _triangle_triangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const triangle*>(collider)),
-                                                _move_triangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_triangle_quad_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _triangle_quad_collision_func, collidee,
-                                                rectangle_around(*static_cast<const triangle*>(collider)),
-                                                _move_triangle_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_quad_sprite_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _quad_sprite_collision_func, collidee,
-                                                rectangle_around(*static_cast<const quad*>(collider)),
-                                                _move_quad_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_quad_rectangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _quad_rectangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const quad*>(collider)),
-                                                _move_quad_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_quad_circle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _quad_circle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const quad*>(collider)),
-                                                _move_quad_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_quad_triangle_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _quad_triangle_collision_func, collidee,
-                                                rectangle_around(*static_cast<const quad*>(collider)),
-                                                _move_quad_by_vector, collider_direction, iterations);
-    }
-
-    bool _bracket_quad_quad_collision(void* collider, const void* collidee,
-                                      _sprite_movement_direction collider_direction, int iterations)
-    {
-        return _bracket_object_collision_generic(collider, _quad_quad_collision_func, collidee,
-                                                rectangle_around(*static_cast<const quad*>(collider)),
-                                                _move_quad_by_vector, collider_direction, iterations);
     }
 
     collision_direction _compare_point_collision_depth_horizontal(const point_2d& collider, const point_2d& collidee)
@@ -805,57 +426,61 @@ namespace splashkit_lib
         return _calculate_containing_collision_direction(collider, collidee);
     }
 
-    collision_direction _calculate_object_collision_direction(const void* collider, const void* collidee,
-                                                        const rectangle& collider_rect, const rectangle& collidee_rect,
-                                                        std::function<bool(const void*, const void*)> collision_func)
+    collision_direction _calculate_object_collision_direction(const shape* collider, const shape* collidee)
     {
-        if (!collision_func(collider, collidee))
+        if (!collider->intersects(collidee))
         {
             return collision_direction::NONE;
         }
 
-        return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
+        return _rectangle_rectangle_collision_direction(collider->get_bounding_box(), collidee->get_bounding_box());
     }
 
-    // collision_direction _calculate_object_collision_direction(const shape* collider, const shape* collidee)
-    // {
-    //     if (!collider->intersects(collidee))
-    //     {
-    //         return collision_direction::NONE;
-    //     }
-
-    //     return _rectangle_rectangle_collision_direction(collider->get_bounding_box(), collidee->get_bounding_box());
-    // }
-
-    void _resolve_object_AABB_collision(void* collider, const rectangle& collider_rect, const rectangle& collidee_rect,
-                                collision_direction direction, std::function<void(void*, const vector_2d& amount)> move_func)
+    void _resolve_object_AABB_collision(shape* collider, const shape* collidee, collision_direction direction)
     {
         // get the intersection rectangle
-        rectangle inter = intersection(collider_rect, collidee_rect);
+        rectangle inter = intersection(collider->get_bounding_box(), collidee->get_bounding_box());
         vector_2d amount = vector_to(inter.width, inter.height);
 
-        _move_object_by_direction(collider, move_func, _direction_from_collision(direction), amount);
+        _move_object_by_direction(collider, _direction_from_collision(direction), amount);
     }
 
-    bool _resolve_object_collision(void* collider, const void* collidee, collision_test_kind collider_kind,
-        collision_test_kind collidee_kind, const rectangle& collider_rect, const rectangle& collidee_rect,
-            collision_direction direction, std::function<void(void*, const vector_2d& amount)> move_func,
-                std::function<bool(const void*, const void*)> collision_func,
-                    std::function<bool(void*, const void*, _sprite_movement_direction, int)> bracket_func)
+    collision_test_kind _get_collision_test_kind(const shape* s)
+    {
+        shape_type type = s->get_shape_type();
+        
+        if (type == shape_type::RECTANGLE)
+        {
+            return AABB_COLLISIONS;
+        }
+        else if (type == shape_type::SPRITE)
+        {
+            const _sprite_data* sprite_data = dynamic_cast<const _sprite_data*>(s);
+            if (sprite_data && sprite_collision_kind(const_cast<sprite>(sprite_data)) == AABB_COLLISIONS)
+            {
+                return AABB_COLLISIONS;
+            }
+        }
+        
+        return PIXEL_COLLISIONS;
+    }
+
+    bool _resolve_object_collision(shape* collider, const shape* collidee, collision_direction direction)
     {
         // check if the sprites are colliding
-        if (direction == collision_direction::NONE || !collision_func(collider, collidee))
+        if (direction == collision_direction::NONE || !collider->intersects(collidee))
         {
             return false;
         }
 
-        if (collider_kind == AABB_COLLISIONS && collidee_kind == AABB_COLLISIONS)
+        if (_get_collision_test_kind(collider) == AABB_COLLISIONS && _get_collision_test_kind(collidee) == AABB_COLLISIONS)
         {
-            _resolve_object_AABB_collision(collider, collider_rect, collidee_rect, direction, move_func);
+            _resolve_object_AABB_collision(collider, collidee, direction);
         }
         else // one or both of the sprites are using pixel collision
         {
-            bracket_func(collider, collidee, _direction_from_collision(direction), BRACKET_ITERATIONS);
+            //bracket_func(collider, collidee, _direction_from_collision(direction), BRACKET_ITERATIONS);
+            _bracket_object_collision_generic(collider, collidee, _direction_from_collision(direction), BRACKET_ITERATIONS);
         }
 
         return true;
@@ -1214,346 +839,251 @@ namespace splashkit_lib
 
     collision_direction calculate_collision_direction(const sprite collider, const sprite collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
-                                                    sprite_collision_rectangle(collidee), _sprite_sprite_collision_func);
+        return _calculate_object_collision_direction(collider, collidee);
     }
 
     collision_direction calculate_collision_direction(const sprite collider, const rectangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
-                                                        collidee, _sprite_rectangle_collision_func);
+        return _calculate_object_collision_direction(collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const sprite collider, const circle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
-                                                        rectangle_around(collidee), _sprite_circle_collision_func);
+        return _calculate_object_collision_direction(collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const sprite collider, const triangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
-                                                        rectangle_around(collidee), _sprite_triangle_collision_func);
+        return _calculate_object_collision_direction(collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const sprite collider, const quad& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
-                                                        rectangle_around(collidee), _sprite_quad_collision_func);
+        return _calculate_object_collision_direction(collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const rectangle& collider, const sprite collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, collider,
-                                                        sprite_collision_rectangle(collidee), _rectangle_sprite_collision_func);
+        return _calculate_object_collision_direction(&collider, collidee);
     }
 
     collision_direction calculate_collision_direction(const rectangle& collider, const rectangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, collider, collidee, _rectangle_rectangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const rectangle& collider, const circle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, collider,
-                                                        rectangle_around(collidee), _rectangle_circle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const rectangle& collider, const triangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, collider,
-                                                        rectangle_around(collidee), _rectangle_triangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const rectangle& collider, const quad& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, collider,
-                                                        rectangle_around(collidee), _rectangle_quad_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const circle& collider, const sprite collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        sprite_collision_rectangle(collidee), _circle_sprite_collision_func);
+        return _calculate_object_collision_direction(&collider, collidee);
     }
 
     collision_direction calculate_collision_direction(const circle& collider, const rectangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        collidee, _circle_rectangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const circle& collider, const circle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _circle_circle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const circle& collider, const triangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _circle_triangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const circle& collider, const quad& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _circle_quad_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const triangle& collider, const sprite collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        sprite_collision_rectangle(collidee), _triangle_sprite_collision_func);
+        return _calculate_object_collision_direction(&collider, collidee);
     }
 
     collision_direction calculate_collision_direction(const triangle& collider, const rectangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        collidee, _triangle_rectangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const triangle& collider, const circle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _triangle_circle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const triangle& collider, const triangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _triangle_triangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const triangle& collider, const quad& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _triangle_quad_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const quad& collider, const sprite collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        sprite_collision_rectangle(collidee), _quad_sprite_collision_func);
+        return _calculate_object_collision_direction(&collider, collidee);
     }
 
     collision_direction calculate_collision_direction(const quad& collider, const rectangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        collidee, _quad_rectangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const quad& collider, const circle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _quad_circle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const quad& collider, const triangle& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _quad_triangle_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     collision_direction calculate_collision_direction(const quad& collider, const quad& collidee)
     {
-        return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
-                                                        rectangle_around(collidee), _quad_quad_collision_func);
+        return _calculate_object_collision_direction(&collider, &collidee);
     }
 
     bool resolve_collision(sprite collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
-            sprite_collision_kind(collidee), sprite_collision_rectangle(collider),
-                sprite_collision_rectangle(collidee), direction, _move_sprite_by_vector,
-                    _sprite_sprite_collision_func, _bracket_sprite_sprite_collision);
+        return _resolve_object_collision(collider, collidee, direction);
     }
 
     bool resolve_collision(sprite collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
-            AABB_COLLISIONS, sprite_collision_rectangle(collider),
-                collidee, direction, _move_sprite_by_vector,
-                    _sprite_rectangle_collision_func, _bracket_sprite_rectangle_collision);
+        return _resolve_object_collision(collider, &collidee, direction);
     }
 
     bool resolve_collision(sprite collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
-            AABB_COLLISIONS, sprite_collision_rectangle(collider),
-                rectangle_around(collidee), direction, _move_sprite_by_vector,
-                    _sprite_circle_collision_func, _bracket_sprite_circle_collision);
+        return _resolve_object_collision(collider, &collidee, direction);
     }
 
     bool resolve_collision(sprite collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
-            AABB_COLLISIONS, sprite_collision_rectangle(collider),
-                rectangle_around(collidee), direction, _move_sprite_by_vector,
-                    _sprite_triangle_collision_func, _bracket_sprite_triangle_collision);
+        return _resolve_object_collision(collider, &collidee, direction);
     }
 
     bool resolve_collision(sprite collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
-            AABB_COLLISIONS, sprite_collision_rectangle(collider),
-                rectangle_around(collidee), direction, _move_sprite_by_vector,
-                    _sprite_quad_collision_func, _bracket_sprite_quad_collision);
+        return _resolve_object_collision(collider, &collidee, direction);
     }
 
     bool resolve_collision(rectangle& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            sprite_collision_kind(collidee), collider,
-                sprite_collision_rectangle(collidee), direction, _move_rectangle_by_vector,
-                    _rectangle_sprite_collision_func, _bracket_rectangle_sprite_collision);
+        return _resolve_object_collision(&collider, collidee, direction);
     }
 
     bool resolve_collision(rectangle& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, collider, collidee, direction, _move_rectangle_by_vector,
-                _rectangle_rectangle_collision_func, _bracket_rectangle_rectangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(rectangle& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
-                _rectangle_circle_collision_func, _bracket_rectangle_circle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(rectangle& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
-                _rectangle_triangle_collision_func, _bracket_rectangle_triangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(rectangle& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
-                _rectangle_quad_collision_func, _bracket_rectangle_quad_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(circle& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            sprite_collision_kind(collidee), rectangle_around(collider),
-                sprite_collision_rectangle(collidee), direction, _move_circle_by_vector,
-                    _circle_sprite_collision_func, _bracket_circle_sprite_collision);
+        return _resolve_object_collision(&collider, collidee, direction);
     }
 
     bool resolve_collision(circle& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
-                collidee, direction, _move_circle_by_vector,
-                    _circle_rectangle_collision_func, _bracket_circle_rectangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(circle& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_circle_by_vector,
-                    _circle_circle_collision_func, _bracket_circle_circle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(circle& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_circle_by_vector,
-                    _circle_triangle_collision_func, _bracket_circle_triangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(circle& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_circle_by_vector,
-                    _circle_quad_collision_func, _bracket_circle_quad_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(triangle& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            sprite_collision_kind(collidee), rectangle_around(collider),
-                sprite_collision_rectangle(collidee), direction, _move_triangle_by_vector,
-                    _triangle_sprite_collision_func, _bracket_triangle_sprite_collision);
+        return _resolve_object_collision(&collider, collidee, direction);
     }
 
     bool resolve_collision(triangle& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
-                collidee, direction, _move_triangle_by_vector,
-                    _triangle_rectangle_collision_func, _bracket_triangle_rectangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(triangle& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_triangle_by_vector,
-                    _triangle_circle_collision_func, _bracket_triangle_circle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(triangle& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_triangle_by_vector,
-                    _triangle_triangle_collision_func, _bracket_triangle_triangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(triangle& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_triangle_by_vector,
-                    _triangle_quad_collision_func, _bracket_triangle_quad_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(quad& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            sprite_collision_kind(collidee), rectangle_around(collider),
-                sprite_collision_rectangle(collidee), direction, _move_quad_by_vector,
-                    _quad_sprite_collision_func, _bracket_quad_sprite_collision);
+        return _resolve_object_collision(&collider, collidee, direction);
     }
 
     bool resolve_collision(quad& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
-                collidee, direction, _move_quad_by_vector,
-                    _quad_rectangle_collision_func, _bracket_quad_rectangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(quad& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_quad_by_vector,
-                    _quad_circle_collision_func, _bracket_quad_circle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(quad& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_quad_by_vector,
-                    _quad_triangle_collision_func, _bracket_quad_triangle_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 
     bool resolve_collision(quad& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
-            PIXEL_COLLISIONS, rectangle_around(collider),
-                rectangle_around(collidee), direction, _move_quad_by_vector,
-                    _quad_quad_collision_func, _bracket_quad_quad_collision);
+        return _resolve_object_collision(&collider, &collidee, direction);
     }
 }

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -817,6 +817,16 @@ namespace splashkit_lib
         return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
     }
 
+    // collision_direction _calculate_object_collision_direction(const shape* collider, const shape* collidee)
+    // {
+    //     if (!collider->intersects(collidee))
+    //     {
+    //         return collision_direction::NONE;
+    //     }
+
+    //     return _rectangle_rectangle_collision_direction(collider->get_bounding_box(), collidee->get_bounding_box());
+    // }
+
     void _resolve_object_AABB_collision(void* collider, const rectangle& collider_rect, const rectangle& collidee_rect,
                                 collision_direction direction, std::function<void(void*, const vector_2d& amount)> move_func)
     {

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -534,7 +534,7 @@ namespace splashkit_lib
                 _move_sprite_by_direction_relative_to_size(collider, collider_direction,
                                                                 1.0 / pow(1.5, static_cast<double>(i)));
             }
-            else if (i == 0) // no collision in the first iteration
+            else if (i == 1) // no collision in the first iteration
             {
                 return false;
             }

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -208,7 +208,7 @@ namespace splashkit_lib
         return _sprite_movement_direction::NONE;
     }
 
-    void _move_sprite_by_vector(const void* sprt, const vector_2d& amount)
+    void _move_sprite_by_vector(void* sprt, const vector_2d& amount)
     {
         sprite s = *static_cast<const sprite*>(sprt);
         
@@ -216,49 +216,49 @@ namespace splashkit_lib
         sprite_set_y(s, sprite_y(s) + amount.y);
     }
 
-    void _move_rectangle_by_vector(const void* rect, const vector_2d& amount)
+    void _move_rectangle_by_vector(void* rect, const vector_2d& amount)
     {
-        rectangle r = *static_cast<const rectangle*>(rect);
+        rectangle* r = static_cast<rectangle*>(rect);
         
-        r.x += amount.x;
-        r.y += amount.y;
+        r->x += amount.x;
+        r->y += amount.y;
     }
 
-    void _move_circle_by_vector(const void* circ, const vector_2d& amount)
+    void _move_circle_by_vector(void* circ, const vector_2d& amount)
     {
-        circle c = *static_cast<const circle*>(circ);
+        circle* c = static_cast<circle*>(circ);
         
-        c.center.x += amount.x;
-        c.center.y += amount.y;
+        c->center.x += amount.x;
+        c->center.y += amount.y;
     }
 
-    void _move_triangle_by_vector(const void* tri, const vector_2d& amount)
+    void _move_triangle_by_vector(void* tri, const vector_2d& amount)
     {
-        triangle t = *static_cast<const triangle*>(tri);
-        
-        t.points[0].x += amount.x;
-        t.points[0].y += amount.y;
-        t.points[1].x += amount.x;
-        t.points[1].y += amount.y;
-        t.points[2].x += amount.x;
-        t.points[2].y += amount.y;
+        triangle* t = static_cast<triangle*>(tri);
+
+        t->points[0].x += amount.x;
+        t->points[0].y += amount.y;
+        t->points[1].x += amount.x;
+        t->points[1].y += amount.y;
+        t->points[2].x += amount.x;
+        t->points[2].y += amount.y;
     }
 
-    void _move_quad_by_vector(const void* q, const vector_2d& amount)
+    void _move_quad_by_vector(void* q, const vector_2d& amount)
     {
-        quad qd = *static_cast<const quad*>(q);
-        
-        qd.points[0].x += amount.x;
-        qd.points[0].y += amount.y;
-        qd.points[1].x += amount.x;
-        qd.points[1].y += amount.y;
-        qd.points[2].x += amount.x;
-        qd.points[2].y += amount.y;
-        qd.points[3].x += amount.x;
-        qd.points[3].y += amount.y;
+        quad* qd = static_cast<quad*>(q);
+
+        qd->points[0].x += amount.x;
+        qd->points[0].y += amount.y;
+        qd->points[1].x += amount.x;
+        qd->points[1].y += amount.y;
+        qd->points[2].x += amount.x;
+        qd->points[2].y += amount.y;
+        qd->points[3].x += amount.x;
+        qd->points[3].y += amount.y;
     }
 
-    void _move_object_by_direction(const void* obj, std::function<void(const void*, const vector_2d& amount)> move_func,
+    void _move_object_by_direction(void* obj, std::function<void(void*, const vector_2d& amount)> move_func,
                                                             _sprite_movement_direction direction, const vector_2d& amount)
     {
         if (amount.x == 0.0 && amount.y == 0.0)
@@ -295,8 +295,8 @@ namespace splashkit_lib
         };
     }
 
-    void _move_object_by_direction_relative_to_size(const void* obj, const rectangle& obj_aabb,
-        std::function<void(const void*, const vector_2d& amount)> move_func,
+    void _move_object_by_direction_relative_to_size(void* obj, const rectangle& obj_aabb,
+        std::function<void(void*, const vector_2d& amount)> move_func,
             _sprite_movement_direction direction, double relative_amount = 1.0)
     {
         double relative_width = obj_aabb.width * relative_amount;
@@ -456,8 +456,8 @@ namespace splashkit_lib
         return quads_intersect(*static_cast<const quad*>(q1), *static_cast<const quad*>(q2));
     }
 
-    bool _bracket_object_collision(bool colliding, int i, const void* collider, const rectangle& collider_aabb,
-                                        std::function<void(const void*, const vector_2d& amount)> move_func,
+    bool _bracket_object_collision(bool colliding, int i, void* collider, const rectangle& collider_aabb,
+                                        std::function<void(void*, const vector_2d& amount)> move_func,
                                                                 _sprite_movement_direction collider_direction)
     {
         if (colliding)
@@ -479,9 +479,9 @@ namespace splashkit_lib
         return true;
     }
 
-    bool _bracket_object_collision_generic(const void* collider, std::function<bool(const void*, const void*)> collision_func,
+    bool _bracket_object_collision_generic(void* collider, std::function<bool(const void*, const void*)> collision_func,
                                             const void* collidee, const rectangle& collider_aabb,
-                                            std::function<void(const void*, const vector_2d& amount)> move_func,
+                                            std::function<void(void*, const vector_2d& amount)> move_func,
                                             _sprite_movement_direction collider_direction, int iterations)
     {
         for (int i = 1; i <= iterations; i++)
@@ -495,7 +495,7 @@ namespace splashkit_lib
         return true;
     }
 
-    bool _bracket_sprite_sprite_collision(const void* collider, const void* collidee,
+    bool _bracket_sprite_sprite_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _sprite_sprite_collision_func, collidee,
@@ -503,7 +503,7 @@ namespace splashkit_lib
                                                 _move_sprite_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_sprite_rectangle_collision(const void* collider, const void* collidee,
+    bool _bracket_sprite_rectangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _sprite_rectangle_collision_func, collidee,
@@ -511,7 +511,7 @@ namespace splashkit_lib
                                                 _move_sprite_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_sprite_circle_collision(const void* collider, const void* collidee,
+    bool _bracket_sprite_circle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _sprite_circle_collision_func, collidee,
@@ -519,7 +519,7 @@ namespace splashkit_lib
                                                 _move_sprite_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_sprite_triangle_collision(const void* collider, const void* collidee,
+    bool _bracket_sprite_triangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _sprite_triangle_collision_func, collidee,
@@ -527,7 +527,7 @@ namespace splashkit_lib
                                                 _move_sprite_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_sprite_quad_collision(const void* collider, const void* collidee,
+    bool _bracket_sprite_quad_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _sprite_quad_collision_func, collidee,
@@ -535,7 +535,7 @@ namespace splashkit_lib
                                                 _move_sprite_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_rectangle_sprite_collision(const void* collider, const void* collidee,
+    bool _bracket_rectangle_sprite_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _rectangle_sprite_collision_func, collidee,
@@ -543,7 +543,7 @@ namespace splashkit_lib
                                                 _move_rectangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_rectangle_rectangle_collision(const void* collider, const void* collidee,
+    bool _bracket_rectangle_rectangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _rectangle_rectangle_collision_func, collidee,
@@ -551,7 +551,7 @@ namespace splashkit_lib
                                                 _move_rectangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_rectangle_circle_collision(const void* collider, const void* collidee,
+    bool _bracket_rectangle_circle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _rectangle_circle_collision_func, collidee,
@@ -559,7 +559,7 @@ namespace splashkit_lib
                                                 _move_rectangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_rectangle_triangle_collision(const void* collider, const void* collidee,
+    bool _bracket_rectangle_triangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _rectangle_triangle_collision_func, collidee,
@@ -567,7 +567,7 @@ namespace splashkit_lib
                                                 _move_rectangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_rectangle_quad_collision(const void* collider, const void* collidee,
+    bool _bracket_rectangle_quad_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _rectangle_quad_collision_func, collidee,
@@ -575,7 +575,7 @@ namespace splashkit_lib
                                                 _move_rectangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_circle_sprite_collision(const void* collider, const void* collidee,
+    bool _bracket_circle_sprite_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _circle_sprite_collision_func, collidee,
@@ -583,7 +583,7 @@ namespace splashkit_lib
                                                 _move_circle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_circle_rectangle_collision(const void* collider, const void* collidee,
+    bool _bracket_circle_rectangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _circle_rectangle_collision_func, collidee,
@@ -591,7 +591,7 @@ namespace splashkit_lib
                                                 _move_circle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_circle_circle_collision(const void* collider, const void* collidee,
+    bool _bracket_circle_circle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _circle_circle_collision_func, collidee,
@@ -599,7 +599,7 @@ namespace splashkit_lib
                                                 _move_circle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_circle_triangle_collision(const void* collider, const void* collidee,
+    bool _bracket_circle_triangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _circle_triangle_collision_func, collidee,
@@ -607,7 +607,7 @@ namespace splashkit_lib
                                                 _move_circle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_circle_quad_collision(const void* collider, const void* collidee,
+    bool _bracket_circle_quad_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _circle_quad_collision_func, collidee,
@@ -615,7 +615,7 @@ namespace splashkit_lib
                                                 _move_circle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_triangle_sprite_collision(const void* collider, const void* collidee,
+    bool _bracket_triangle_sprite_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _triangle_sprite_collision_func, collidee,
@@ -623,7 +623,7 @@ namespace splashkit_lib
                                                 _move_triangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_triangle_rectangle_collision(const void* collider, const void* collidee,
+    bool _bracket_triangle_rectangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _triangle_rectangle_collision_func, collidee,
@@ -631,7 +631,7 @@ namespace splashkit_lib
                                                 _move_triangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_triangle_circle_collision(const void* collider, const void* collidee,
+    bool _bracket_triangle_circle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _triangle_circle_collision_func, collidee,
@@ -639,7 +639,7 @@ namespace splashkit_lib
                                                 _move_triangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_triangle_triangle_collision(const void* collider, const void* collidee,
+    bool _bracket_triangle_triangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _triangle_triangle_collision_func, collidee,
@@ -647,7 +647,7 @@ namespace splashkit_lib
                                                 _move_triangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_triangle_quad_collision(const void* collider, const void* collidee,
+    bool _bracket_triangle_quad_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _triangle_quad_collision_func, collidee,
@@ -655,7 +655,7 @@ namespace splashkit_lib
                                                 _move_triangle_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_quad_sprite_collision(const void* collider, const void* collidee,
+    bool _bracket_quad_sprite_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _quad_sprite_collision_func, collidee,
@@ -663,7 +663,7 @@ namespace splashkit_lib
                                                 _move_quad_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_quad_rectangle_collision(const void* collider, const void* collidee,
+    bool _bracket_quad_rectangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _quad_rectangle_collision_func, collidee,
@@ -671,7 +671,7 @@ namespace splashkit_lib
                                                 _move_quad_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_quad_circle_collision(const void* collider, const void* collidee,
+    bool _bracket_quad_circle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _quad_circle_collision_func, collidee,
@@ -679,7 +679,7 @@ namespace splashkit_lib
                                                 _move_quad_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_quad_triangle_collision(const void* collider, const void* collidee,
+    bool _bracket_quad_triangle_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _quad_triangle_collision_func, collidee,
@@ -687,7 +687,7 @@ namespace splashkit_lib
                                                 _move_quad_by_vector, collider_direction, iterations);
     }
 
-    bool _bracket_quad_quad_collision(const void* collider, const void* collidee,
+    bool _bracket_quad_quad_collision(void* collider, const void* collidee,
                                       _sprite_movement_direction collider_direction, int iterations)
     {
         return _bracket_object_collision_generic(collider, _quad_quad_collision_func, collidee,
@@ -813,8 +813,8 @@ namespace splashkit_lib
         return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
     }
 
-    void _resolve_object_AABB_collision(const void* collider, const rectangle& collider_rect, const rectangle& collidee_rect,
-                                collision_direction direction, std::function<void(const void*, const vector_2d& amount)> move_func)
+    void _resolve_object_AABB_collision(void* collider, const rectangle& collider_rect, const rectangle& collidee_rect,
+                                collision_direction direction, std::function<void(void*, const vector_2d& amount)> move_func)
     {
         // get the intersection rectangle
         rectangle inter = intersection(collider_rect, collidee_rect);
@@ -823,11 +823,11 @@ namespace splashkit_lib
         _move_object_by_direction(collider, move_func, _direction_from_collision(direction), amount);
     }
 
-    bool _resolve_object_collision(const void* collider, const void* collidee, collision_test_kind collider_kind,
+    bool _resolve_object_collision(void* collider, const void* collidee, collision_test_kind collider_kind,
         collision_test_kind collidee_kind, const rectangle& collider_rect, const rectangle& collidee_rect,
-            collision_direction direction, std::function<void(const void*, const vector_2d& amount)> move_func,
+            collision_direction direction, std::function<void(void*, const vector_2d& amount)> move_func,
                 std::function<bool(const void*, const void*)> collision_func,
-                    std::function<bool(const void*, const void*, _sprite_movement_direction, int)> bracket_func)
+                    std::function<bool(void*, const void*, _sprite_movement_direction, int)> bracket_func)
     {
         // check if the sprites are colliding
         if (direction == collision_direction::NONE || !collision_func(collider, collidee))
@@ -837,7 +837,7 @@ namespace splashkit_lib
 
         if (collider_kind == AABB_COLLISIONS && collidee_kind == AABB_COLLISIONS)
         {
-            _resolve_object_AABB_collision(collider, collider_rect, collidee_rect, direction, _move_sprite_by_vector);
+            _resolve_object_AABB_collision(collider, collider_rect, collidee_rect, direction, move_func);
         }
         else // one or both of the sprites are using pixel collision
         {
@@ -1198,37 +1198,37 @@ namespace splashkit_lib
         return bitmap_collision(bmp1, 0, translation_matrix(x1, y1), bmp2, 0, translation_matrix(x2, y2));
     }
 
-    collision_direction calculate_collision_direction(sprite collider, sprite collidee)
+    collision_direction calculate_collision_direction(const sprite collider, const sprite collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
                                                     sprite_collision_rectangle(collidee), _sprite_sprite_collision_func);
     }
 
-    collision_direction calculate_collision_direction(sprite collider, const rectangle& collidee)
+    collision_direction calculate_collision_direction(const sprite collider, const rectangle& collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
                                                         collidee, _sprite_rectangle_collision_func);
     }
 
-    collision_direction calculate_collision_direction(sprite collider, const circle& collidee)
+    collision_direction calculate_collision_direction(const sprite collider, const circle& collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
                                                         rectangle_around(collidee), _sprite_circle_collision_func);
     }
 
-    collision_direction calculate_collision_direction(sprite collider, const triangle& collidee)
+    collision_direction calculate_collision_direction(const sprite collider, const triangle& collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
                                                         rectangle_around(collidee), _sprite_triangle_collision_func);
     }
 
-    collision_direction calculate_collision_direction(sprite collider, const quad& collidee)
+    collision_direction calculate_collision_direction(const sprite collider, const quad& collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, sprite_collision_rectangle(collider),
                                                         rectangle_around(collidee), _sprite_quad_collision_func);
     }
 
-    collision_direction calculate_collision_direction(const rectangle& collider, sprite collidee)
+    collision_direction calculate_collision_direction(const rectangle& collider, const sprite collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, collider,
                                                         sprite_collision_rectangle(collidee), _rectangle_sprite_collision_func);
@@ -1257,7 +1257,7 @@ namespace splashkit_lib
                                                         rectangle_around(collidee), _rectangle_quad_collision_func);
     }
 
-    collision_direction calculate_collision_direction(const circle& collider, sprite collidee)
+    collision_direction calculate_collision_direction(const circle& collider, const sprite collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
                                                         sprite_collision_rectangle(collidee), _circle_sprite_collision_func);
@@ -1287,7 +1287,7 @@ namespace splashkit_lib
                                                         rectangle_around(collidee), _circle_quad_collision_func);
     }
 
-    collision_direction calculate_collision_direction(const triangle& collider, sprite collidee)
+    collision_direction calculate_collision_direction(const triangle& collider, const sprite collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
                                                         sprite_collision_rectangle(collidee), _triangle_sprite_collision_func);
@@ -1317,7 +1317,7 @@ namespace splashkit_lib
                                                         rectangle_around(collidee), _triangle_quad_collision_func);
     }
 
-    collision_direction calculate_collision_direction(const quad& collider, sprite collidee)
+    collision_direction calculate_collision_direction(const quad& collider, const sprite collidee)
     {
         return _calculate_object_collision_direction(&collider, &collidee, rectangle_around(collider),
                                                         sprite_collision_rectangle(collidee), _quad_sprite_collision_func);
@@ -1347,7 +1347,7 @@ namespace splashkit_lib
                                                         rectangle_around(collidee), _quad_quad_collision_func);
     }
 
-    bool resolve_collision(sprite collider, sprite collidee, collision_direction direction)
+    bool resolve_collision(sprite collider, const sprite collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, sprite_collision_kind(collider),
             sprite_collision_kind(collidee), sprite_collision_rectangle(collider),
@@ -1387,158 +1387,158 @@ namespace splashkit_lib
                     _sprite_quad_collision_func, _bracket_sprite_quad_collision);
     }
 
-    bool resolve_collision(const rectangle& collider, sprite collidee, collision_direction direction)
+    bool resolve_collision(rectangle& collider, const sprite collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
             sprite_collision_kind(collidee), collider,
-                sprite_collision_rectangle(collidee), direction, _move_sprite_by_vector,
+                sprite_collision_rectangle(collidee), direction, _move_rectangle_by_vector,
                     _rectangle_sprite_collision_func, _bracket_rectangle_sprite_collision);
     }
 
-    bool resolve_collision(const rectangle& collider, const rectangle& collidee, collision_direction direction)
+    bool resolve_collision(rectangle& collider, const rectangle& collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, collider, collidee, direction, _move_sprite_by_vector,
+            AABB_COLLISIONS, collider, collidee, direction, _move_rectangle_by_vector,
                 _rectangle_rectangle_collision_func, _bracket_rectangle_rectangle_collision);
     }
 
-    bool resolve_collision(const rectangle& collider, const circle& collidee, collision_direction direction)
+    bool resolve_collision(rectangle& collider, const circle& collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, collider, rectangle_around(collidee), direction, _move_sprite_by_vector,
+            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
                 _rectangle_circle_collision_func, _bracket_rectangle_circle_collision);
     }
 
-    bool resolve_collision(const rectangle& collider, const triangle& collidee, collision_direction direction)
+    bool resolve_collision(rectangle& collider, const triangle& collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, collider, rectangle_around(collidee), direction, _move_sprite_by_vector,
+            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
                 _rectangle_triangle_collision_func, _bracket_rectangle_triangle_collision);
     }
 
-    bool resolve_collision(const rectangle& collider, const quad& collidee, collision_direction direction)
+    bool resolve_collision(rectangle& collider, const quad& collidee, collision_direction direction)
     {
         return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, collider, rectangle_around(collidee), direction, _move_sprite_by_vector,
+            PIXEL_COLLISIONS, collider, rectangle_around(collidee), direction, _move_rectangle_by_vector,
                 _rectangle_quad_collision_func, _bracket_rectangle_quad_collision);
     }
 
-    bool resolve_collision(const circle& collider, sprite collidee, collision_direction direction)
+    bool resolve_collision(circle& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             sprite_collision_kind(collidee), rectangle_around(collider),
                 sprite_collision_rectangle(collidee), direction, _move_circle_by_vector,
                     _circle_sprite_collision_func, _bracket_circle_sprite_collision);
     }
 
-    bool resolve_collision(const circle& collider, const rectangle& collidee, collision_direction direction)
+    bool resolve_collision(circle& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             AABB_COLLISIONS, rectangle_around(collider),
                 collidee, direction, _move_circle_by_vector,
                     _circle_rectangle_collision_func, _bracket_circle_rectangle_collision);
     }
 
-    bool resolve_collision(const circle& collider, const circle& collidee, collision_direction direction)
+    bool resolve_collision(circle& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_circle_by_vector,
                     _circle_circle_collision_func, _bracket_circle_circle_collision);
     }
 
-    bool resolve_collision(const circle& collider, const triangle& collidee, collision_direction direction)
+    bool resolve_collision(circle& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_circle_by_vector,
                     _circle_triangle_collision_func, _bracket_circle_triangle_collision);
     }
 
-    bool resolve_collision(const circle& collider, const quad& collidee, collision_direction direction)
+    bool resolve_collision(circle& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_circle_by_vector,
                     _circle_quad_collision_func, _bracket_circle_quad_collision);
     }
 
-    bool resolve_collision(const triangle& collider, sprite collidee, collision_direction direction)
+    bool resolve_collision(triangle& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             sprite_collision_kind(collidee), rectangle_around(collider),
                 sprite_collision_rectangle(collidee), direction, _move_triangle_by_vector,
                     _triangle_sprite_collision_func, _bracket_triangle_sprite_collision);
     }
 
-    bool resolve_collision(const triangle& collider, const rectangle& collidee, collision_direction direction)
+    bool resolve_collision(triangle& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             AABB_COLLISIONS, rectangle_around(collider),
                 collidee, direction, _move_triangle_by_vector,
                     _triangle_rectangle_collision_func, _bracket_triangle_rectangle_collision);
     }
 
-    bool resolve_collision(const triangle& collider, const circle& collidee, collision_direction direction)
+    bool resolve_collision(triangle& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_triangle_by_vector,
                     _triangle_circle_collision_func, _bracket_triangle_circle_collision);
     }
 
-    bool resolve_collision(const triangle& collider, const triangle& collidee, collision_direction direction)
+    bool resolve_collision(triangle& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_triangle_by_vector,
                     _triangle_triangle_collision_func, _bracket_triangle_triangle_collision);
     }
 
-    bool resolve_collision(const triangle& collider, const quad& collidee, collision_direction direction)
+    bool resolve_collision(triangle& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_triangle_by_vector,
                     _triangle_quad_collision_func, _bracket_triangle_quad_collision);
     }
 
-    bool resolve_collision(const quad& collider, sprite collidee, collision_direction direction)
+    bool resolve_collision(quad& collider, const sprite collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             sprite_collision_kind(collidee), rectangle_around(collider),
                 sprite_collision_rectangle(collidee), direction, _move_quad_by_vector,
                     _quad_sprite_collision_func, _bracket_quad_sprite_collision);
     }
 
-    bool resolve_collision(const quad& collider, const rectangle& collidee, collision_direction direction)
+    bool resolve_collision(quad& collider, const rectangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
             AABB_COLLISIONS, rectangle_around(collider),
                 collidee, direction, _move_quad_by_vector,
                     _quad_rectangle_collision_func, _bracket_quad_rectangle_collision);
     }
 
-    bool resolve_collision(const quad& collider, const circle& collidee, collision_direction direction)
+    bool resolve_collision(quad& collider, const circle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_quad_by_vector,
                     _quad_circle_collision_func, _bracket_quad_circle_collision);
     }
 
-    bool resolve_collision(const quad& collider, const triangle& collidee, collision_direction direction)
+    bool resolve_collision(quad& collider, const triangle& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_quad_by_vector,
                     _quad_triangle_collision_func, _bracket_quad_triangle_collision);
     }
 
-    bool resolve_collision(const quad& collider, const quad& collidee, collision_direction direction)
+    bool resolve_collision(quad& collider, const quad& collidee, collision_direction direction)
     {
-        return _resolve_object_collision(&collider, &collidee, AABB_COLLISIONS,
-            AABB_COLLISIONS, rectangle_around(collider),
+        return _resolve_object_collision(&collider, &collidee, PIXEL_COLLISIONS,
+            PIXEL_COLLISIONS, rectangle_around(collider),
                 rectangle_around(collidee), direction, _move_quad_by_vector,
                     _quad_quad_collision_func, _bracket_quad_quad_collision);
     }

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -559,46 +559,6 @@ namespace splashkit_lib
         return _sprite_movement_direction::NONE;
     }
 
-    // _sprite_movement_direction _direction_from_velocity(const vector_2d& velocity)
-    // {
-    //     double angle = vector_angle(velocity);
-
-    //     // split the angle into 8 directions (using atan2 in degrees)
-    //     if (angle >= 67.5 && angle < 112.5)
-    //     {
-    //         return _sprite_movement_direction::UP;
-    //     }
-    //     else if (angle >= 112.5 && angle < 157.5)
-    //     {
-    //         return _sprite_movement_direction::UP_LEFT;
-    //     }
-    //     else if (angle >= 157.5 || angle < -157.5)
-    //     {
-    //         return _sprite_movement_direction::LEFT;
-    //     }
-    //     else if (angle >= -157.5 && angle < -112.5)
-    //     {
-    //         return _sprite_movement_direction::DOWN_LEFT;
-    //     }
-    //     else if (angle >= -112.5 && angle < -67.5)
-    //     {
-    //         return _sprite_movement_direction::DOWN;
-    //     }
-    //     else if (angle >= -67.5 && angle < -22.5)
-    //     {
-    //         return _sprite_movement_direction::DOWN_RIGHT;
-    //     }
-    //     else if (angle >= -22.5 && angle < 22.5)
-    //     {
-    //         return _sprite_movement_direction::RIGHT;
-    //     }
-    //     else if (angle >= 22.5 && angle < 67.5)
-    //     {
-    //         return _sprite_movement_direction::UP_RIGHT;
-    //     }
-    //     return _sprite_movement_direction::NONE;
-    // }
-
     void _move_sprite_by_direction(sprite sprt, _sprite_movement_direction direction, const vector_2d& amount)
     {
         if (amount.x == 0.0 && amount.y == 0.0)
@@ -643,20 +603,8 @@ namespace splashkit_lib
     {
         rectangle col_rect = sprite_collision_rectangle(sprt);
 
-        double width = col_rect.width;
-        double height = col_rect.height;
-
-        double relative_width = width * relative_amount;
-        double relative_height = height * relative_amount;
-
-        // vector_2d vel = sprite_velocity(sprt);
-
-        // _sprite_movement_direction vel_direction = _direction_from_velocity(vel);
-
-        // bool up = vel_direction == _sprite_movement_direction::UP;
-        // bool down = vel_direction == _sprite_movement_direction::DOWN;
-        // bool left = vel_direction == _sprite_movement_direction::LEFT;
-        // bool right = vel_direction == _sprite_movement_direction::RIGHT;
+        double relative_width = col_rect.width * relative_amount;
+        double relative_height = col_rect.height * relative_amount;
 
         switch (direction)
         {
@@ -715,9 +663,6 @@ namespace splashkit_lib
             {
                 return false;
             }
-            {
-                return false;
-            }
         }
         return true;
     }
@@ -727,8 +672,7 @@ namespace splashkit_lib
     {
         for (int i = 1; i <= iterations; i++)
         {
-            if (!_bracket_sprite_collision(sprite_rectangle_collision(collider, collidee), i, collider,
-                                                                                    collider_direction))
+            if (!_bracket_sprite_collision(sprite_rectangle_collision(collider, collidee), i, collider, collider_direction))
             {
                 return false;
             }
@@ -898,19 +842,6 @@ namespace splashkit_lib
 
         // collider contains collidee
         return _calculate_containing_collision_direction(collider, collidee);
-
-
-        // // calculate the direction of the greatest distance between the two sprites
-        // point_2d collider_center = rectangle_center(collider);
-        // point_2d collidee_center = rectangle_center(collidee);
-        // double x_distance = abs(collider_center.x - collidee_center.x);
-        // double y_distance = abs(collider_center.y - collidee_center.y);
-
-        // if (x_distance < y_distance)
-        // {
-        //     return _compare_point_collision_depth_horizontal(collider_center, collidee_center);
-        // }
-        // return _compare_point_collision_depth_vertical(collider_center, collidee_center);
     }
 
     collision_direction sprite_collision_direction(sprite collider, sprite collidee)

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -456,6 +456,10 @@ namespace splashkit_lib
         return quads_intersect(*static_cast<const quad*>(q1), *static_cast<const quad*>(q2));
     }
 
+    /** 
+     * Moves the object back and forth with decreasing step size for
+     * the given number of iterations.
+    */ 
     bool _bracket_object_collision(bool colliding, int i, void* collider, const rectangle& collider_aabb,
                                         std::function<void(void*, const vector_2d& amount)> move_func,
                                                                 _sprite_movement_direction collider_direction)

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -18,6 +18,7 @@
 #include "utils.h"
 
 constexpr int DEFAULT_BRACKET_ITERATIONS = 50;
+constexpr double ITERATION_POWER = 1.5;
 
 using std::function;
 
@@ -289,6 +290,85 @@ namespace splashkit_lib
         return bitmap_circle_collision(bmp, cell, translation_matrix(x, y), circ);
     }
 
+    bool bitmap_triangle_collision(bitmap bmp, int cell, const matrix_2d &translation, const triangle &tri)
+    {
+        if (INVALID_PTR(bmp, BITMAP_PTR))
+        {
+            return false;
+        }
+        
+        quad q1 = quad_from(bitmap_cell_rectangle(bmp), translation);
+        rectangle rect = rectangle_around(tri);
+
+        if (! triangle_quad_intersect(tri, q1))
+        {
+            return false;
+        }
+        
+        return _step_through_pixels(rect.width, rect.height, translation_matrix(rect.x, rect.y), bmp->cell_w, bmp->cell_h, translation, [&] (int ax, int ay, int bx, int by)
+                                    {
+                                        return pixel_drawn_at_point(bmp, cell, bx, by) && point_in_triangle(point_at(rect.x + ax, rect.y + ay), tri);
+                                    }); 
+    }
+
+    bool bitmap_triangle_collision(bitmap bmp, int cell, const point_2d& pt, const triangle &tri)
+    {
+        return bitmap_triangle_collision(bmp, cell, translation_matrix(pt), tri);
+    }
+
+    bool bitmap_triangle_collision(bitmap bmp, int cell, double x, double y, const triangle &tri)
+    {
+        return bitmap_triangle_collision(bmp, cell, translation_matrix(x, y), tri);
+    }
+
+    bool bitmap_triangle_collision(bitmap bmp, double x, double y, const triangle &tri)
+    {
+        return bitmap_triangle_collision(bmp, 0, translation_matrix(x, y), tri);
+    }
+
+    bool bitmap_triangle_collision(bitmap bmp, const point_2d& pt, const triangle &tri)
+    {
+        return bitmap_triangle_collision(bmp, 0, translation_matrix(pt), tri);
+    }
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q)
+    {
+        if (INVALID_PTR(bmp, BITMAP_PTR))
+        {
+            return false;
+        }
+        
+        quad q1 = quad_from(bitmap_cell_rectangle(bmp), translation);
+        rectangle rect = rectangle_around(q);
+        
+        if ( not quads_intersect(q1, q) ) return false;
+        
+        return _step_through_pixels(rect.width, rect.height, translation_matrix(rect.x, rect.y), bmp->cell_w, bmp->cell_h, translation, [&] (int ax, int ay, int bx, int by)
+                                    {
+                                        return pixel_drawn_at_point(bmp, cell, bx, by) && point_in_quad(point_at(rect.x + ax, rect.y + ay), q);
+                                    });
+    }
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, const point_2d& pt, const quad &q)
+    {
+        return bitmap_quad_collision(bmp, cell, translation_matrix(pt), q);
+    }
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, double x, double y, const quad &q)
+    {
+        return bitmap_quad_collision(bmp, cell, translation_matrix(x, y), q);
+    }
+
+    bool bitmap_quad_collision(bitmap bmp, double x, double y, const quad &q)
+    {
+        return bitmap_quad_collision(bmp, 0, translation_matrix(x, y), q);
+    }
+
+    bool bitmap_quad_collision(bitmap bmp, const point_2d& pt, const quad &q)
+    {
+        return bitmap_quad_collision(bmp, 0, translation_matrix(pt), q);
+    }
+
     bool sprite_bitmap_collision(sprite s, bitmap bmp, int cell, double x, double y)
     {
         if (!rectangles_intersect(sprite_collision_rectangle(s), bitmap_cell_rectangle(bmp, point_at(x, y))))
@@ -343,6 +423,36 @@ namespace splashkit_lib
         }
         
         return bitmap_rectangle_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), rect);
+    }
+
+    bool sprite_circle_collision(sprite s, const circle &c)
+    {
+        if (!circles_intersect(sprite_collision_circle(s), c))
+        {
+            return false;
+        }
+        
+        return bitmap_circle_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), c);
+    }
+
+    bool sprite_triangle_collision(sprite s, const triangle &t)
+    {
+        if (!triangle_rectangle_intersect(t, sprite_collision_rectangle(s)))
+        {
+            return false;
+        }
+        
+        return bitmap_triangle_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), t);
+    }
+
+    bool sprite_quad_collision(sprite s, const quad &q)
+    {
+        if (!rectangles_intersect(sprite_collision_rectangle(s), rectangle_around(q)))
+        {
+            return false;
+        }
+        
+        return bitmap_quad_collision(sprite_collision_bitmap(s), sprite_current_cell(s), sprite_location_matrix(s), q);
     }
     
     bool sprite_collision(sprite s1, sprite s2)
@@ -449,7 +559,47 @@ namespace splashkit_lib
         return _sprite_movement_direction::NONE;
     }
 
-    void _move_sprite_by_direction(sprite sprt, _sprite_movement_direction direction, vector_2d amount)
+    // _sprite_movement_direction _direction_from_velocity(const vector_2d& velocity)
+    // {
+    //     double angle = vector_angle(velocity);
+
+    //     // split the angle into 8 directions (using atan2 in degrees)
+    //     if (angle >= 67.5 && angle < 112.5)
+    //     {
+    //         return _sprite_movement_direction::UP;
+    //     }
+    //     else if (angle >= 112.5 && angle < 157.5)
+    //     {
+    //         return _sprite_movement_direction::UP_LEFT;
+    //     }
+    //     else if (angle >= 157.5 || angle < -157.5)
+    //     {
+    //         return _sprite_movement_direction::LEFT;
+    //     }
+    //     else if (angle >= -157.5 && angle < -112.5)
+    //     {
+    //         return _sprite_movement_direction::DOWN_LEFT;
+    //     }
+    //     else if (angle >= -112.5 && angle < -67.5)
+    //     {
+    //         return _sprite_movement_direction::DOWN;
+    //     }
+    //     else if (angle >= -67.5 && angle < -22.5)
+    //     {
+    //         return _sprite_movement_direction::DOWN_RIGHT;
+    //     }
+    //     else if (angle >= -22.5 && angle < 22.5)
+    //     {
+    //         return _sprite_movement_direction::RIGHT;
+    //     }
+    //     else if (angle >= 22.5 && angle < 67.5)
+    //     {
+    //         return _sprite_movement_direction::UP_RIGHT;
+    //     }
+    //     return _sprite_movement_direction::NONE;
+    // }
+
+    void _move_sprite_by_direction(sprite sprt, _sprite_movement_direction direction, const vector_2d& amount)
     {
         if (amount.x == 0.0 && amount.y == 0.0)
         {
@@ -482,7 +632,7 @@ namespace splashkit_lib
             sprite_set_x(sprt, sprite_x(sprt) - amount.x);
             sprite_set_y(sprt, sprite_y(sprt) + amount.y);
             break;
-        case _sprite_movement_direction::DOWN_RIGHT:
+        default: // _sprite_movement_direction::DOWN_RIGHT:
             sprite_set_x(sprt, sprite_x(sprt) + amount.x);
             sprite_set_y(sprt, sprite_y(sprt) + amount.y);
             break;
@@ -491,63 +641,144 @@ namespace splashkit_lib
 
     void _move_sprite_by_direction_relative_to_size(sprite sprt, _sprite_movement_direction direction, double relative_amount = 1.0)
     {
+        rectangle col_rect = sprite_collision_rectangle(sprt);
+
+        double width = col_rect.width;
+        double height = col_rect.height;
+
+        double relative_width = width * relative_amount;
+        double relative_height = height * relative_amount;
+
+        // vector_2d vel = sprite_velocity(sprt);
+
+        // _sprite_movement_direction vel_direction = _direction_from_velocity(vel);
+
+        // bool up = vel_direction == _sprite_movement_direction::UP;
+        // bool down = vel_direction == _sprite_movement_direction::DOWN;
+        // bool left = vel_direction == _sprite_movement_direction::LEFT;
+        // bool right = vel_direction == _sprite_movement_direction::RIGHT;
+
         switch (direction)
         {
         case _sprite_movement_direction::UP:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP, vector_to(0.0, sprite_height(sprt) * relative_amount));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP, vector_to(0.0, relative_height));
             break;
         case _sprite_movement_direction::DOWN:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN, vector_to(0.0, sprite_height(sprt) * relative_amount));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN, vector_to(0.0, relative_height));
             break;
         case _sprite_movement_direction::LEFT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::LEFT, vector_to(sprite_width(sprt) * relative_amount, 0.0));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::LEFT, vector_to(relative_width, 0.0));
             break;
         case _sprite_movement_direction::RIGHT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::RIGHT, vector_to(sprite_width(sprt) * relative_amount, 0.0));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::RIGHT, vector_to(relative_width, 0.0));
             break;
         case _sprite_movement_direction::UP_LEFT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP_LEFT, vector_to(sprite_width(sprt) * relative_amount,
-                                                                                                sprite_height(sprt) * relative_amount));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP_LEFT, vector_to(relative_width, relative_height));
             break;
         case _sprite_movement_direction::UP_RIGHT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP_RIGHT, vector_to(sprite_width(sprt) * relative_amount,
-                                                                                                sprite_height(sprt) * relative_amount));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::UP_RIGHT, vector_to(relative_width, relative_height));
             break;
         case _sprite_movement_direction::DOWN_LEFT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN_LEFT, vector_to(sprite_width(sprt) * relative_amount,
-                                                                                                sprite_height(sprt) * relative_amount));
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN_LEFT, vector_to(relative_width, relative_height));
             break;
-        case _sprite_movement_direction::DOWN_RIGHT:
-            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN_RIGHT, vector_to(sprite_width(sprt) * relative_amount,
-                                                                                                sprite_height(sprt) * relative_amount));
+        default: // _sprite_movement_direction::DOWN_RIGHT:
+            _move_sprite_by_direction(sprt, _sprite_movement_direction::DOWN_RIGHT, vector_to(relative_width, relative_height));
             break;
         };
     }
 
-    bool _bracket_sprite_collision( sprite collider, sprite collidee,
+    bool _bracket_sprite_collision(bool colliding, int i, sprite collider, _sprite_movement_direction collider_direction)
+    {
+        if (colliding)
+        {
+            _move_sprite_by_direction_relative_to_size(collider, collider_direction,
+                                                        1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
+        }
+        else if (i == 1) // no collision in the first iteration
+        {
+            return false;
+        }
+        else
+        {
+            _move_sprite_by_direction_relative_to_size(collider, _opposite_direction(collider_direction),
+                                                        1.0 / pow(ITERATION_POWER, static_cast<double>(i)));
+        }
+        return true;
+    }
+
+    bool _bracket_sprite_sprite_collision(sprite collider, sprite collidee,
         _sprite_movement_direction collider_direction, int iterations = DEFAULT_BRACKET_ITERATIONS)
     {
         for (int i = 1; i <= iterations; i++)
         {
-            if (sprite_collision(collider, collidee))
-            {
-                _move_sprite_by_direction_relative_to_size(collider, collider_direction,
-                                                                1.0 / pow(1.5, static_cast<double>(i)));
-            }
-            else if (i == 1) // no collision in the first iteration
+            if (!_bracket_sprite_collision(sprite_collision(collider, collidee), i, collider, collider_direction))
             {
                 return false;
             }
-            else
             {
-                _move_sprite_by_direction_relative_to_size(collider, _opposite_direction(collider_direction),
-                                                                1.0 / pow(1.5, static_cast<double>(i)));
+                return false;
             }
         }
         return true;
     }
 
-    collision_direction _compare_point_collision_depth_horizontal(point_2d collider, point_2d collidee)
+    bool _bracket_sprite_rectangle_collision(sprite collider, const rectangle& collidee,
+        _sprite_movement_direction collider_direction, int iterations = DEFAULT_BRACKET_ITERATIONS)
+    {
+        for (int i = 1; i <= iterations; i++)
+        {
+            if (!_bracket_sprite_collision(sprite_rectangle_collision(collider, collidee), i, collider,
+                                                                                    collider_direction))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool _bracket_sprite_circle_collision(sprite collider, const circle& collidee,
+        _sprite_movement_direction collider_direction, int iterations = DEFAULT_BRACKET_ITERATIONS)
+    {
+        for (int i = 1; i <= iterations; i++)
+        {
+            if (!_bracket_sprite_collision(sprite_circle_collision(collider, collidee), i, collider,
+                                                                                collider_direction))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool _bracket_sprite_triangle_collision(sprite collider, const triangle& collidee,
+        _sprite_movement_direction collider_direction, int iterations = DEFAULT_BRACKET_ITERATIONS)
+    {
+        for (int i = 1; i <= iterations; i++)
+        {
+            if (!_bracket_sprite_collision(sprite_triangle_collision(collider, collidee), i, collider,
+                                                                                    collider_direction))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool _bracket_sprite_quad_collision(sprite collider, const quad& collidee,
+        _sprite_movement_direction collider_direction, int iterations = DEFAULT_BRACKET_ITERATIONS)
+    {
+        for (int i = 1; i <= iterations; i++)
+        {
+            if (!_bracket_sprite_collision(sprite_quad_collision(collider, collidee), i, collider,
+                                                                                collider_direction))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    collision_direction _compare_point_collision_depth_horizontal(const point_2d& collider, const point_2d& collidee)
     {
         if (collider.x < collidee.x)
         {
@@ -556,7 +787,7 @@ namespace splashkit_lib
         return collision_direction::LEFT;
     }
 
-    collision_direction _compare_point_collision_depth_vertical(point_2d collider, point_2d collidee)
+    collision_direction _compare_point_collision_depth_vertical(const point_2d& collider, const point_2d& collidee)
     {
         if (collider.y < collidee.y)
         {
@@ -565,7 +796,31 @@ namespace splashkit_lib
         return collision_direction::TOP;
     }
 
-    collision_direction _rectangle_rectangle_collision_direction(rectangle collider, rectangle collidee)
+    collision_direction _calculate_containing_collision_direction(const rectangle& collider, const rectangle& collidee)
+    {
+        // calculate the direction of the greatest distance between the two sprites
+        point_2d collider_center = rectangle_center(collider);
+        point_2d collidee_center = rectangle_center(collidee);
+        double x_distance = collider_center.x - collidee_center.x;
+        if (x_distance < 0.0)
+        {
+            x_distance *= -1;
+        }
+
+        double y_distance = collider_center.y - collidee_center.y;
+        if (y_distance < 0.0)
+        {
+            y_distance *= -1;
+        }
+
+        if (x_distance > y_distance)
+        {
+            return _compare_point_collision_depth_horizontal(collider_center, collidee_center);
+        }
+        return _compare_point_collision_depth_vertical(collider_center, collidee_center);
+    }
+
+    collision_direction _rectangle_rectangle_collision_direction(const rectangle& collider, const rectangle& collidee)
     {
         vector<line> collider_lines = lines_from(collider);
         line collider_top_edge = collider_lines[0];
@@ -578,79 +833,85 @@ namespace splashkit_lib
         bool top_edge = line_intersects_rect(collider_top_edge, collidee);
         bool bottom_edge = line_intersects_rect(collider_bottom_edge, collidee);
 
+        if (left_edge && right_edge && top_edge && bottom_edge) // collidee contains collider
+        {
+            return _calculate_containing_collision_direction(collider, collidee);
+        }
         if (left_edge && right_edge && top_edge)
         {
             return collision_direction::TOP;
         }
-        else if (left_edge && right_edge && bottom_edge)
+        if (left_edge && right_edge && bottom_edge)
         {
             return collision_direction::BOTTOM;
         }
-        else if (top_edge && bottom_edge && right_edge)
+        if (top_edge && bottom_edge && right_edge)
         {
             return collision_direction::RIGHT;
         }
-        else if (top_edge && bottom_edge && left_edge)
+        if (top_edge && bottom_edge && left_edge)
         {
             return collision_direction::LEFT;
         }
-        else if (left_edge && right_edge)
+        if (left_edge && right_edge)
         {
             // check if the collider is more to the left or right of the collidee
             return _compare_point_collision_depth_horizontal(rectangle_center(collider), rectangle_center(collidee));
         }
-        else if (top_edge && bottom_edge)
+        if (top_edge && bottom_edge)
         {
             // check if the collider is more to the top or bottom of the collidee
             return _compare_point_collision_depth_vertical(rectangle_center(collider), rectangle_center(collidee));
         }
-        else if (left_edge && top_edge)
+        if (left_edge && top_edge)
         {
             return collision_direction::TOP_LEFT;
         }
-        else if (left_edge && bottom_edge)
+        if (left_edge && bottom_edge)
         {
             return collision_direction::BOTTOM_LEFT;
         }
-        else if (right_edge && top_edge)
+        if (right_edge && top_edge)
         {
             return collision_direction::TOP_RIGHT;
         }
-        else if (right_edge && bottom_edge)
+        if (right_edge && bottom_edge)
         {
             return collision_direction::BOTTOM_RIGHT;
         }
-        else if (left_edge)
+        if (left_edge)
         {
             return collision_direction::LEFT;
         }
-        else if (right_edge)
+        if (right_edge)
         {
             return collision_direction::RIGHT;
         }
-        else if (top_edge)
+        if (top_edge)
         {
             return collision_direction::TOP;
         }
-        else if (bottom_edge)
+        if (bottom_edge)
         {
             return collision_direction::BOTTOM;
         }
 
-        // collider contains collidee or collidee contains collider
-        // calculate the direction of the greatest distance between the two sprites
-        point_2d collider_center = rectangle_center(collider);
-        point_2d collidee_center = rectangle_center(collidee);
-        double x_distance = abs(collider_center.x - collidee_center.x);
-        double y_distance = abs(collider_center.y - collidee_center.y);
+        // collider contains collidee
+        return _calculate_containing_collision_direction(collider, collidee);
 
-        if (x_distance > y_distance)
-        {
-            return _compare_point_collision_depth_horizontal(collider_center, collidee_center);
-        }
-        return _compare_point_collision_depth_vertical(collider_center, collidee_center);
+
+        // // calculate the direction of the greatest distance between the two sprites
+        // point_2d collider_center = rectangle_center(collider);
+        // point_2d collidee_center = rectangle_center(collidee);
+        // double x_distance = abs(collider_center.x - collidee_center.x);
+        // double y_distance = abs(collider_center.y - collidee_center.y);
+
+        // if (x_distance < y_distance)
+        // {
+        //     return _compare_point_collision_depth_horizontal(collider_center, collidee_center);
+        // }
+        // return _compare_point_collision_depth_vertical(collider_center, collidee_center);
     }
-
 
     collision_direction sprite_collision_direction(sprite collider, sprite collidee)
     {
@@ -663,6 +924,69 @@ namespace splashkit_lib
         rectangle collidee_rect = sprite_collision_rectangle(collidee);
 
         return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
+    }
+
+    collision_direction sprite_collision_direction(sprite collider, const rectangle& collidee)
+    {
+        if (!sprite_rectangle_collision(collider, collidee))
+        {
+            return collision_direction::NONE;
+        }
+
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+
+        return _rectangle_rectangle_collision_direction(collider_rect, collidee);
+    }
+
+    collision_direction sprite_collision_direction(sprite collider, const circle& collidee)
+    {
+        if (!sprite_circle_collision(collider, collidee))
+        {
+            return collision_direction::NONE;
+        }
+
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+        rectangle collidee_rect = rectangle_around(collidee);
+
+        return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
+    }
+
+    collision_direction sprite_collision_direction(sprite collider, const triangle& collidee)
+    {
+        if (!sprite_triangle_collision(collider, collidee))
+        {
+            return collision_direction::NONE;
+        }
+
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+        rectangle collidee_rect = rectangle_around(collidee);
+
+        return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
+    }
+
+    collision_direction sprite_collision_direction(sprite collider, const quad& collidee)
+    {
+        if (!sprite_quad_collision(collider, collidee))
+        {
+            return collision_direction::NONE;
+        }
+
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+        rectangle collidee_rect = rectangle_around(collidee);
+
+        return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
+    }
+
+    void _resolve_sprite_AABB_collision(sprite collider, const rectangle& collidee_rect, collision_direction direction)
+    {
+        // get the bounding rectangles of the sprites
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+
+        // get the intersection rectangle
+        rectangle inter = intersection(collider_rect, collidee_rect);
+        vector_2d amount = vector_to(inter.width, inter.height);
+
+        _move_sprite_by_direction(collider, _direction_from_collision(direction), amount);
     }
 
     bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction)
@@ -678,19 +1002,99 @@ namespace splashkit_lib
 
         if (collider_kind == AABB_COLLISIONS && collidee_kind == AABB_COLLISIONS)
         {
-            // get the bounding rectangles of the sprites
-            rectangle collider_rect = sprite_collision_rectangle(collider);
-            rectangle collidee_rect = sprite_collision_rectangle(collidee);
-
-            // get the intersection rectangle
-            rectangle inter = intersection(collider_rect, collidee_rect);
-            vector_2d amount = vector_to(inter.width, inter.height);
-
-            _move_sprite_by_direction(collider, _direction_from_collision(direction), amount);
+            _resolve_sprite_AABB_collision(collider, sprite_collision_rectangle(collidee), direction);
         }
         else // one or both of the sprites are using pixel collision
         {
-            _bracket_sprite_collision(collider, collidee, _direction_from_collision(direction));
+            _bracket_sprite_sprite_collision(collider, collidee, _direction_from_collision(direction));
+        }
+
+        return true;
+    }
+
+    bool resolve_sprite_collision(sprite collider, const rectangle& collidee, collision_direction direction)
+    {
+        // check if the sprites are colliding
+        if (direction == collision_direction::NONE || !sprite_rectangle_collision(collider, collidee))
+        {
+            return false;
+        }
+
+        collision_test_kind collider_kind = sprite_collision_kind(collider);
+
+        if (collider_kind == AABB_COLLISIONS)
+        {
+            _resolve_sprite_AABB_collision(collider, collidee, direction);
+        }
+        else // sprite is using pixel collision
+        {
+            _bracket_sprite_rectangle_collision(collider, collidee, _direction_from_collision(direction));
+        }
+
+        return true;
+    }
+
+    bool resolve_sprite_collision(sprite collider, const circle& collidee, collision_direction direction)
+    {
+        // check if the sprites are colliding
+        if (direction == collision_direction::NONE || !sprite_circle_collision(collider, collidee))
+        {
+            return false;
+        }
+
+        collision_test_kind collider_kind = sprite_collision_kind(collider);
+
+        if (collider_kind == AABB_COLLISIONS)
+        {
+            _resolve_sprite_AABB_collision(collider, rectangle_around(collidee), direction);
+        }
+        else // sprite is using pixel collision
+        {
+            _bracket_sprite_circle_collision(collider, collidee, _direction_from_collision(direction));
+        }
+
+        return true;
+    }
+
+    bool resolve_sprite_collision(sprite collider, const triangle& collidee, collision_direction direction)
+    {
+        // check if the sprites are colliding
+        if (direction == collision_direction::NONE || !sprite_triangle_collision(collider, collidee))
+        {
+            return false;
+        }
+
+        collision_test_kind collider_kind = sprite_collision_kind(collider);
+
+        if (collider_kind == AABB_COLLISIONS)
+        {
+            _resolve_sprite_AABB_collision(collider, rectangle_around(collidee), direction);
+        }
+        else // sprite is using pixel collision
+        {
+            _bracket_sprite_triangle_collision(collider, collidee, _direction_from_collision(direction));
+        }
+
+        return true;
+    }
+
+    bool resolve_sprite_collision(sprite collider, const quad& collidee, collision_direction direction)
+    {
+        // check if the sprites are colliding
+        if (direction == collision_direction::NONE || !sprite_quad_collision(collider, collidee))
+        {
+            return false;
+        }
+
+        collision_test_kind collider_kind = sprite_collision_kind(collider);
+
+        if (collider_kind == AABB_COLLISIONS)
+        {
+            _resolve_sprite_AABB_collision(collider, rectangle_around(collidee), direction);
+        }
+        else // sprite is using pixel collision
+        {
+            _bracket_sprite_quad_collision(collider, collidee, _direction_from_collision(direction));
         }
 
         return true;

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -547,56 +547,36 @@ namespace splashkit_lib
         return true;
     }
 
-    collision_direction _compare_sprite_collision_depth_horizontal(sprite collider, sprite collidee)
+    collision_direction _compare_point_collision_depth_horizontal(point_2d collider, point_2d collidee)
     {
-        point_2d collider_center = center_point(collider);
-        point_2d collidee_center = center_point(collidee);
-
-        if (collider_center.x < collidee_center.x)
+        if (collider.x < collidee.x)
         {
             return collision_direction::RIGHT;
         }
-        else
-        {
-            return collision_direction::LEFT;
-        }
+        return collision_direction::LEFT;
     }
 
-    collision_direction _compare_sprite_collision_depth_vertical(sprite collider, sprite collidee)
+    collision_direction _compare_point_collision_depth_vertical(point_2d collider, point_2d collidee)
     {
-        point_2d collider_center = center_point(collider);
-        point_2d collidee_center = center_point(collidee);
-
-        if (collider_center.y < collidee_center.y)
+        if (collider.y < collidee.y)
         {
             return collision_direction::BOTTOM;
         }
-        else
-        {
-            return collision_direction::TOP;
-        }
+        return collision_direction::TOP;
     }
 
-    collision_direction sprite_collision_direction(sprite collider, sprite collidee)
+    collision_direction _rectangle_rectangle_collision_direction(rectangle collider, rectangle collidee)
     {
-        if (!sprite_collision(collider, collidee))
-        {
-            return collision_direction::NONE;
-        }
-        
-        rectangle collider_rect = sprite_collision_rectangle(collider);
-        rectangle collidee_rect = sprite_collision_rectangle(collidee);
-
-        vector<line> collider_lines = lines_from(collider_rect);
+        vector<line> collider_lines = lines_from(collider);
         line collider_top_edge = collider_lines[0];
         line collider_left_edge = collider_lines[1];
         line collider_right_edge = collider_lines[2];
         line collider_bottom_edge = collider_lines[3];
 
-        bool left_edge = line_intersects_rect(collider_left_edge, collidee_rect);
-        bool right_edge = line_intersects_rect(collider_right_edge, collidee_rect);
-        bool top_edge = line_intersects_rect(collider_top_edge, collidee_rect);
-        bool bottom_edge = line_intersects_rect(collider_bottom_edge, collidee_rect);
+        bool left_edge = line_intersects_rect(collider_left_edge, collidee);
+        bool right_edge = line_intersects_rect(collider_right_edge, collidee);
+        bool top_edge = line_intersects_rect(collider_top_edge, collidee);
+        bool bottom_edge = line_intersects_rect(collider_bottom_edge, collidee);
 
         if (left_edge && right_edge && top_edge)
         {
@@ -617,12 +597,12 @@ namespace splashkit_lib
         else if (left_edge && right_edge)
         {
             // check if the collider is more to the left or right of the collidee
-            return _compare_sprite_collision_depth_horizontal(collider, collidee);
+            return _compare_point_collision_depth_horizontal(rectangle_center(collider), rectangle_center(collidee));
         }
         else if (top_edge && bottom_edge)
         {
             // check if the collider is more to the top or bottom of the collidee
-            return _compare_sprite_collision_depth_vertical(collider, collidee);
+            return _compare_point_collision_depth_vertical(rectangle_center(collider), rectangle_center(collidee));
         }
         else if (left_edge && top_edge)
         {
@@ -659,19 +639,30 @@ namespace splashkit_lib
 
         // collider contains collidee or collidee contains collider
         // calculate the direction of the greatest distance between the two sprites
-        point_2d collider_center = center_point(collider);
-        point_2d collidee_center = center_point(collidee);
+        point_2d collider_center = rectangle_center(collider);
+        point_2d collidee_center = rectangle_center(collidee);
         double x_distance = abs(collider_center.x - collidee_center.x);
         double y_distance = abs(collider_center.y - collidee_center.y);
 
         if (x_distance > y_distance)
         {
-            return _compare_sprite_collision_depth_horizontal(collider, collidee);
+            return _compare_point_collision_depth_horizontal(collider_center, collidee_center);
         }
-        else
+        return _compare_point_collision_depth_vertical(collider_center, collidee_center);
+    }
+
+
+    collision_direction sprite_collision_direction(sprite collider, sprite collidee)
+    {
+        if (!sprite_collision(collider, collidee))
         {
-            return _compare_sprite_collision_depth_vertical(collider, collidee);
+            return collision_direction::NONE;
         }
+        
+        rectangle collider_rect = sprite_collision_rectangle(collider);
+        rectangle collidee_rect = sprite_collision_rectangle(collidee);
+
+        return _rectangle_rectangle_collision_direction(collider_rect, collidee_rect);
     }
 
     bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction)

--- a/coresdk/src/coresdk/collisions.cpp
+++ b/coresdk/src/coresdk/collisions.cpp
@@ -386,4 +386,54 @@ namespace splashkit_lib
         return bitmap_collision(bmp1, 0, translation_matrix(x1, y1), bmp2, 0, translation_matrix(x2, y2));
     }
 
+    bool resolve_collision(sprite s1, sprite s2, collision_resolution_kind kind)
+    {
+        // check if the sprites are colliding
+        if (!sprite_collision(s1, s2))
+        {
+            return false;
+        }
+
+        // get the bounding rectangles of the sprites
+        rectangle r1 = sprite_collision_rectangle(s1);
+        rectangle r2 = sprite_collision_rectangle(s2);
+
+        // get the intersection rectangle
+        rectangle inter = intersection(r1, r2);
+
+        switch(kind)
+        {
+        case TOP:
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case BOTTOM:
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        case LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            break;
+        case RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            break;
+        case TOP_LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case TOP_RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            sprite_set_y(s1, sprite_y(s1) + inter.height);
+            break;
+        case BOTTOM_LEFT:
+            sprite_set_x(s1, sprite_x(s1) + inter.width);
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        case BOTTOM_RIGHT:
+            sprite_set_x(s1, sprite_x(s1) - inter.width);
+            sprite_set_y(s1, sprite_y(s1) - inter.height);
+            break;
+        }
+
+        return true;
+    }
+
 }

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -476,5 +476,19 @@ namespace splashkit_lib
      */
     bool bitmap_collision(bitmap bmp1, double x1, double y1, bitmap bmp2, double x2, double y2);
 
+    enum collision_resolution_kind
+    {
+        TOP,
+        BOTTOM,
+        LEFT,
+        RIGHT,
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
+    };
+
+    bool resolve_collision(sprite collider, sprite collidee, collision_resolution_kind kind);
+
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -18,19 +18,19 @@
 namespace splashkit_lib
 {
     /**
-     *  This enumeration contains a list of directions that a
-     *  sprite can collide with another sprite. For example, a
-     *  collider sprite which is colliding with another sprite
+     *  This enumeration contains a list of directions that an
+     *  object can collide with another object. For example, a
+     *  collider object which is colliding with another object
      *  on its top edge would have a collision direction of TOP.
      *  
-     *  @constant TOP           The top of the sprite
-     *  @constant BOTTOM        The bottom of the sprite
-     *  @constant LEFT          The left of the sprite
-     *  @constant RIGHT         The right of the sprite
-     *  @constant TOP_LEFT      The top left of the sprite
-     *  @constant TOP_RIGHT     The top right of the sprite
-     *  @constant BOTTOM_LEFT   The bottom left of the sprite
-     *  @constant BOTTOM_RIGHT  The bottom right of the sprite
+     *  @constant TOP           The top of the object
+     *  @constant BOTTOM        The bottom of the object
+     *  @constant LEFT          The left of the object
+     *  @constant RIGHT         The right of the object
+     *  @constant TOP_LEFT      The top left of the object
+     *  @constant TOP_RIGHT     The top right of the object
+     *  @constant BOTTOM_LEFT   The bottom left of the object
+     *  @constant BOTTOM_RIGHT  The bottom right of the object
      *  @constant NONE          No collision
      */
     enum collision_direction
@@ -326,24 +326,174 @@ namespace splashkit_lib
      */
     bool bitmap_circle_collision(bitmap bmp, const point_2d& pt, const circle& circ);
 
+    /**
+     * Tests if a bitmap cell drawn using a passed in translation, will
+     * intersect with a triangle. You can use this to detect collisions between
+     * bitmaps and triangles.
+     *
+     * @param  bmp         The bitmap to test
+     * @param  cell        The cell of the bitmap to check
+     * @param  translation The matrix used to transfrom the bitmap when drawing
+     * @param  tri         The triangle to test
+     * @return             True if a drawn pixel in the cell of the bitmap will
+     *                     intersect with `tri` when drawn.
+     *
+     * @attribute suffix    for_cell_with_translation
+     *
+     * @attribute class bitmap
+     * @attribute method triangle_collision
+     */
     bool bitmap_triangle_collision(bitmap bmp, int cell, const matrix_2d &translation, const triangle &tri);
 
+    /**
+     * Tests if a bitmap cell drawn at `pt` would intersect with a triangle.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  cell The cell of the bitmap to check
+     * @param  pt   The location where the bitmap is drawn
+     * @param  tri  The triangle to test
+     * @return      True if a drawn pixel in the cell of the bitmap will
+     *              intersect with `tri` when drawn.
+     *
+     * @attribute suffix    for_cell_at_point
+     *
+     * @attribute class bitmap
+     * @attribute method triangle_collision
+     */
     bool bitmap_triangle_collision(bitmap bmp, int cell, const point_2d& pt, const triangle &tri);
 
+    /**
+     * Tests if a bitmap cell drawn at `x`, `y` would intersect with a triangle.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  cell The cell of the bitmap to check
+     * @param  x    The x location where the bitmap is drawn
+     * @param  y    The y location where the bitmap is drawn
+     * @param  tri  The triangle to test
+     * @return      True if a drawn pixel in the bitmap will
+     *              intersect with `tri` when drawn.
+     *
+     * @attribute suffix    for_cell
+     *
+     * @attribute class bitmap
+     * @attribute method triangle_collision
+     */
     bool bitmap_triangle_collision(bitmap bmp, int cell, double x, double y, const triangle &tri);
 
+    /**
+     * Tests if a bitmap drawn at `x`, `y` would intersect with a triangle.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  x    The x location where the bitmap is drawn
+     * @param  y    The y location where the bitmap is drawn
+     * @param  tri  The triangle to test
+     * @return      True if a drawn pixel in the bitmap will
+     *              intersect with `tri` when drawn.
+     *
+     * @attribute class bitmap
+     * @attribute method triangle_collision
+     */
     bool bitmap_triangle_collision(bitmap bmp, double x, double y, const triangle &tri);
 
+    /**
+     * Tests if a bitmap drawn at `pt` would intersect with a triangle.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  pt   The location where the bitmap is drawn
+     * @param  tri  The triangle to test
+     * @return      True if a drawn pixel in the cell of the bitmap will
+     *              intersect with `tri` when drawn.
+     *
+     * @attribute suffix    at_point
+     *
+     * @attribute class bitmap
+     * @attribute method triangle_collision
+     */
     bool bitmap_triangle_collision(bitmap bmp, const point_2d& pt, const triangle &tri);
 
+    /**
+     * Tests if a bitmap cell drawn using a passed in translation, will
+     * intersect with a quad. You can use this to detect collisions between
+     * bitmaps and quads.
+     *
+     * @param  bmp         The bitmap to test
+     * @param  cell        The cell of the bitmap to check
+     * @param  translation The matrix used to transfrom the bitmap when drawing
+     * @param  q           The quad to test
+     * @return             True if a drawn pixel in the cell of the bitmap will
+     *                     intersect with `q` when drawn.
+     *
+     * @attribute suffix    for_cell_with_translation
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
     bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
 
+    /**
+     * Tests if a bitmap cell drawn at `pt` would intersect with a quad.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  cell The cell of the bitmap to check
+     * @param  pt   The location where the bitmap is drawn
+     * @param  q    The quad to test
+     * @return      True if a drawn pixel in the cell of the bitmap will
+     *              intersect with `q` when drawn.
+     *
+     * @attribute suffix    for_cell_at_point
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
     bool bitmap_quad_collision(bitmap bmp, int cell, const point_2d& pt, const quad &q);
 
+    /**
+     * Tests if a bitmap cell drawn at `x`, `y` would intersect with a quad.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  cell The cell of the bitmap to check
+     * @param  x    The x location where the bitmap is drawn
+     * @param  y    The y location where the bitmap is drawn
+     * @param  q    The quad to test
+     * @return      True if a drawn pixel in the bitmap will
+     *              intersect with `q` when drawn.
+     *
+     * @attribute suffix    for_cell
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
     bool bitmap_quad_collision(bitmap bmp, int cell, double x, double y, const quad &q);
 
+    /**
+     * Tests if a bitmap drawn at `x`, `y` would intersect with a quad.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  x    The x location where the bitmap is drawn
+     * @param  y    The y location where the bitmap is drawn
+     * @param  q    The quad to test
+     * @return      True if a drawn pixel in the bitmap will
+     *              intersect with `q` when drawn.
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
     bool bitmap_quad_collision(bitmap bmp, double x, double y, const quad &q);
 
+    /**
+     * Tests if a bitmap drawn at `pt` would intersect with a quad.
+     *
+     * @param  bmp  The bitmap to test
+     * @param  pt   The location where the bitmap is drawn
+     * @param  q    The quad to test
+     * @return      True if a drawn pixel in the cell of the bitmap will
+     *              intersect with `q` when drawn.
+     *
+     * @attribute suffix    at_point
+     *
+     * @attribute class bitmap
+     * @attribute method quad_collision
+     */
     bool bitmap_quad_collision(bitmap bmp, const point_2d& pt, const quad &q);
     
     /**
@@ -423,10 +573,40 @@ namespace splashkit_lib
      */
     bool sprite_rectangle_collision(sprite s, const rectangle& rect);
 
+    /**
+     * Tests if a sprite is drawn within an given area (circle).
+     *
+     * @param  s    The sprite to test
+     * @param  rect The circle to check
+     * @return      True if the sprite it drawn in the circle area
+     *
+     * @attribute class sprite
+     * @attribute method circle_collision
+     */
     bool sprite_circle_collision(sprite s, const circle &c);
 
+    /**
+     * Tests if a sprite is drawn within an given area (triangle).
+     *
+     * @param  s    The sprite to test
+     * @param  rect The triangle to check
+     * @return      True if the sprite it drawn in the triangle area
+     *
+     * @attribute class sprite
+     * @attribute method triangle_collision
+     */
     bool sprite_triangle_collision(sprite s, const triangle &t);
 
+    /**
+     * Tests if a sprite is drawn within an given area (quad).
+     *
+     * @param  s    The sprite to test
+     * @param  rect The quad to check
+     * @return      True if the sprite it drawn in the quad area
+     *
+     * @attribute class sprite
+     * @attribute method quad_collision
+     */
     bool sprite_quad_collision(sprite s, const quad &q);
 
     /**
@@ -543,15 +723,363 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction sprite_collision_direction(sprite collider, sprite collidee);
+    collision_direction calculate_collision_direction(sprite collider, sprite collidee);
 
-    collision_direction sprite_collision_direction(sprite collider, const rectangle& collidee);
+    /**
+     * Returns the direction of the collision between a sprite
+     * and a rectangle relative to the sprite. If the sprite and
+     * rectangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The rectangle that is being collided with
+     * @return          The direction of the collision relative to the sprite.
+     *                  If the sprite and rectangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction calculate_collision_direction(sprite collider, const rectangle& collidee);
 
-    collision_direction sprite_collision_direction(sprite collider, const circle& collidee);
+    /**
+     * Returns the direction of the collision between a sprite
+     * and a circle relative to the sprite. If the sprite and
+     * circle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The circle that is being collided with
+     * @return          The direction of the collision relative to the sprite.
+     *                  If the sprite and circle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction calculate_collision_direction(sprite collider, const circle& collidee);
 
-    collision_direction sprite_collision_direction(sprite collider, const triangle& collidee);
+    /**
+     * Returns the direction of the collision between a sprite
+     * and a triangle relative to the sprite. If the sprite and
+     * triangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The triangle that is being collided with
+     * @return          The direction of the collision relative to the sprite.
+     *                  If the sprite and triangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction calculate_collision_direction(sprite collider, const triangle& collidee);
 
-    collision_direction sprite_collision_direction(sprite collider, const quad& collidee);
+    /**
+     * Returns the direction of the collision between a sprite
+     * and a quad relative to the sprite. If the sprite and
+     * quad are not colliding, this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The quad that is being collided with
+     * @return          The direction of the collision relative to the sprite.
+     *                  If the sprite and quad are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction calculate_collision_direction(sprite collider, const quad& collidee);
+
+    /**
+     * Returns the direction of the collision between a rectangle
+     * and a sprite relative to the rectangle. If the rectangle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The rectangle that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the rectangle.
+     *                  If the rectangle and sprite are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class rectangle
+     */
+    collision_direction calculate_collision_direction(const rectangle& collider, sprite collidee);
+
+    /**
+     * Returns the direction of the collision between a collider rectangle
+     * and a collidee rectangle relative to the collider rectangle. If the rectangles are not
+     * colliding, this function will return NONE.
+     * 
+     * @param collider  The rectangle that is colliding
+     * @param collidee  The rectangle that is being collided with
+     * @return          The direction of the collision relative to the collider rectangle.
+     *                  If the rectangles are not colliding, this function will return NONE.
+     * 
+     * @attribute class rectangle
+     */
+    collision_direction calculate_collision_direction(const rectangle& collider, const rectangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a rectangle
+     * and a circle relative to the rectangle. If the rectangle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The rectangle that is colliding
+     * @param collidee  The circle that is being collided with
+     * @return          The direction of the collision relative to the rectangle.
+     *                  If the rectangle and circle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class rectangle
+     */
+    collision_direction calculate_collision_direction(const rectangle& collider, const circle& collidee);
+
+    /**
+     * Returns the direction of the collision between a rectangle
+     * and a triangle relative to the rectangle. If the rectangle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The rectangle that is colliding
+     * @param collidee  The triangle that is being collided with
+     * @return          The direction of the collision relative to the rectangle.
+     *                  If the rectangle and triangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class rectangle
+     */
+    collision_direction calculate_collision_direction(const rectangle& collider, const triangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a rectangle
+     * and a quad relative to the rectangle. If the rectangle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The rectangle that is colliding
+     * @param collidee  The quad that is being collided with
+     * @return          The direction of the collision relative to the rectangle.
+     *                  If the rectangle and quad are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class rectangle
+     */
+    collision_direction calculate_collision_direction(const rectangle& collider, const quad& collidee);
+
+    /**
+     * Returns the direction of the collision between a circle
+     * and a sprite relative to the circle. If the circle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The circle that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the circle.
+     *                  If the circle and sprite are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class circle
+     */
+    collision_direction calculate_collision_direction(const circle& collider, sprite collidee);
+
+    /**
+     * Returns the direction of the collision between a circle
+     * and a rectangle relative to the circle. If the circle and
+     * rectangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The circle that is colliding
+     * @param collidee  The rectangle that is being collided with
+     * @return          The direction of the collision relative to the circle.
+     *                  If the circle and rectangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class circle
+     */
+    collision_direction calculate_collision_direction(const circle& collider, const rectangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a collider circle
+     * and a collidee circle relative to the collider circle. If the circles are not
+     * colliding, this function will return NONE.
+     * 
+     * @param collider  The circle that is colliding
+     * @param collidee  The circle that is being collided with
+     * @return          The direction of the collision relative to the collider circle.
+     *                  If the circles are not colliding, this function will return NONE.
+     * 
+     * @attribute class circle
+     */
+    collision_direction calculate_collision_direction(const circle& collider, const circle& collidee);
+
+    /**
+     * Returns the direction of the collision between a circle
+     * and a triangle relative to the circle. If the circle and
+     * triangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The circle that is colliding
+     * @param collidee  The triangle that is being collided with
+     * @return          The direction of the collision relative to the circle.
+     *                  If the circle and triangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class circle
+     */
+    collision_direction calculate_collision_direction(const circle& collider, const triangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a circle
+     * and a quad relative to the circle. If the circle and
+     * quad are not colliding, this function will return NONE.
+     * 
+     * @param collider  The circle that is colliding
+     * @param collidee  The quad that is being collided with
+     * @return          The direction of the collision relative to the circle.
+     *                  If the circle and quad are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class circle
+     */
+    collision_direction calculate_collision_direction(const circle& collider, const quad& collidee);
+
+    /**
+     * Returns the direction of the collision between a triangle
+     * and a sprite relative to the triangle. If the triangle and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The triangle that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the triangle.
+     *                  If the triangle and sprite are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class triangle
+     */
+    collision_direction calculate_collision_direction(const triangle& collider, sprite collidee);
+
+    /**
+     * Returns the direction of the collision between a triangle
+     * and a rectangle relative to the triangle. If the triangle and
+     * rectangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The triangle that is colliding
+     * @param collidee  The rectangle that is being collided with
+     * @return          The direction of the collision relative to the triangle.
+     *                  If the triangle and rectangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class triangle
+     */
+    collision_direction calculate_collision_direction(const triangle& collider, const rectangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a triangle
+     * and a circle relative to the triangle. If the triangle and
+     * circle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The triangle that is colliding
+     * @param collidee  The circle that is being collided with
+     * @return          The direction of the collision relative to the triangle.
+     *                  If the triangle and circle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class triangle
+     */
+    collision_direction calculate_collision_direction(const triangle& collider, const circle& collidee);
+
+    /**
+     * Returns the direction of the collision between a collider triangle
+     * and a collidee triangle relative to the collider triangle. If the triangles are not
+     * colliding, this function will return NONE.
+     * 
+     * @param collider  The triangle that is colliding
+     * @param collidee  The triangle that is being collided with
+     * @return          The direction of the collision relative to the collider triangle.
+     *                  If the triangles are not colliding, this function will return NONE.
+     * 
+     * @attribute class triangle
+     */
+    collision_direction calculate_collision_direction(const triangle& collider, const triangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a triangle
+     * and a quad relative to the triangle. If the triangle and
+     * quad are not colliding, this function will return NONE.
+     * 
+     * @param collider  The triangle that is colliding
+     * @param collidee  The quad that is being collided with
+     * @return          The direction of the collision relative to the triangle.
+     *                  If the triangle and quad are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class triangle
+     */
+    collision_direction calculate_collision_direction(const triangle& collider, const quad& collidee);
+
+    /**
+     * Returns the direction of the collision between a quad
+     * and a sprite relative to the quad. If the quad and
+     * sprite are not colliding, this function will return NONE.
+     * 
+     * @param collider  The quad that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the quad.
+     *                  If the quad and sprite are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class quad
+     */
+    collision_direction calculate_collision_direction(const quad& collider, sprite collidee);
+
+    /**
+     * Returns the direction of the collision between a quad
+     * and a rectangle relative to the quad. If the quad and
+     * rectangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The quad that is colliding
+     * @param collidee  The rectangle that is being collided with
+     * @return          The direction of the collision relative to the quad.
+     *                  If the quad and rectangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class quad
+     */
+    collision_direction calculate_collision_direction(const quad& collider, const rectangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a quad
+     * and a circle relative to the quad. If the quad and
+     * circle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The quad that is colliding
+     * @param collidee  The circle that is being collided with
+     * @return          The direction of the collision relative to the quad.
+     *                  If the quad and circle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class quad
+     */
+    collision_direction calculate_collision_direction(const quad& collider, const circle& collidee);
+
+    /**
+     * Returns the direction of the collision between a quad
+     * and a triangle relative to the quad. If the quad and
+     * triangle are not colliding, this function will return NONE.
+     * 
+     * @param collider  The quad that is colliding
+     * @param collidee  The triangle that is being collided with
+     * @return          The direction of the collision relative to the quad.
+     *                  If the quad and triangle are not colliding,
+     *                  this function will return NONE.
+     * 
+     * @attribute class quad
+     */
+    collision_direction calculate_collision_direction(const quad& collider, const triangle& collidee);
+
+    /**
+     * Returns the direction of the collision between a collider quad
+     * and a collidee quad relative to the collider quad. If the quads are not
+     * colliding, this function will return NONE.
+     * 
+     * @param collider  The quad that is colliding
+     * @param collidee  The quad that is being collided with
+     * @return          The direction of the collision relative to the collider quad.
+     *                  If the quads are not colliding, this function will return NONE.
+     * 
+     * @attribute class quad
+     */
+    collision_direction calculate_collision_direction(const quad& collider, const quad& collidee);
 
     /**
      * Resolves the collision between two sprites by moving the
@@ -568,15 +1096,415 @@ namespace splashkit_lib
      * 
      * @atrribute class sprite
      */
-    bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(sprite collider, sprite collidee, collision_direction direction);
 
-    bool resolve_sprite_collision(sprite collider, const rectangle& collidee, collision_direction direction);
+    /**
+     * Resolves the collision between a sprite and a rectangle by moving the
+     * sprite to the edge of the rectangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprite and
+     * rectangle are not colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The rectangle which will not be altered
+     * @param direction The direction of the collision relative to the sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprite and rectangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_collision(sprite collider, const rectangle& collidee, collision_direction direction);
 
-    bool resolve_sprite_collision(sprite collider, const circle& collidee, collision_direction direction);
+    /**
+     * Resolves the collision between a sprite and a circle by moving the
+     * sprite to the edge of the circle. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprite and
+     * circle are not colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The circle which will not be altered
+     * @param direction The direction of the collision relative to the sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprite and circle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_collision(sprite collider, const circle& collidee, collision_direction direction);
 
-    bool resolve_sprite_collision(sprite collider, const triangle& collidee, collision_direction direction);
+    /**
+     * Resolves the collision between a sprite and a triangle by moving the
+     * sprite to the edge of the triangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprite and
+     * triangle are not colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The triangle which will not be altered
+     * @param direction The direction of the collision relative to the sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprite and triangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_collision(sprite collider, const triangle& collidee, collision_direction direction);
 
-    bool resolve_sprite_collision(sprite collider, const quad& collidee, collision_direction direction);
+    /**
+     * Resolves the collision between a sprite and a quad by moving the
+     * sprite to the edge of the quad. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprite and
+     * quad are not colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The quad which will not be altered
+     * @param direction The direction of the collision relative to the sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprite and quad are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_collision(sprite collider, const quad& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a rectangle and a sprite by moving the
+     * rectangle to the edge of the sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the rectangle and
+     * sprite are not colliding, this function will return false.
+     * 
+     * @param collider  The rectangle which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the rectangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the rectangle and sprite are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class rectangle
+     */
+    bool resolve_collision(const rectangle& collider, sprite collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between two rectangles by moving the
+     * collider rectangle to the edge of the collidee rectangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the rectangles are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The rectangle which will be altered if there is a collision
+     * @param collidee  The rectangle which will not be altered
+     * @param direction The direction of the collision relative to the collider rectangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the rectangles are colliding and the collision was resolved,
+     *                  false if the rectangles are not colliding
+     * 
+     * @atrribute class rectangle
+     */
+    bool resolve_collision(const rectangle& collider, const rectangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a rectangle and a circle by moving the
+     * rectangle to the edge of the circle. The direction of the
+     * resolution is determined by the `direction` parameter. If the rectangle and
+     * circle are not colliding, this function will return false.
+     * 
+     * @param collider  The rectangle which will be altered if there is a collision
+     * @param collidee  The circle which will not be altered
+     * @param direction The direction of the collision relative to the rectangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the rectangle and circle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class rectangle
+     */
+    bool resolve_collision(const rectangle& collider, const circle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a rectangle and a triangle by moving the
+     * rectangle to the edge of the triangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the rectangle and
+     * triangle are not colliding, this function will return false.
+     * 
+     * @param collider  The rectangle which will be altered if there is a collision
+     * @param collidee  The triangle which will not be altered
+     * @param direction The direction of the collision relative to the rectangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the rectangle and triangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class rectangle
+     */
+    bool resolve_collision(const rectangle& collider, const triangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a rectangle and a quad by moving the
+     * rectangle to the edge of the quad. The direction of the
+     * resolution is determined by the `direction` parameter. If the rectangle and
+     * quad are not colliding, this function will return false.
+     * 
+     * @param collider  The rectangle which will be altered if there is a collision
+     * @param collidee  The quad which will not be altered
+     * @param direction The direction of the collision relative to the rectangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the rectangle and quad are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class rectangle
+     */
+    bool resolve_collision(const rectangle& collider, const quad& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a circle and a sprite by moving the
+     * circle to the edge of the sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the circle and
+     * sprite are not colliding, this function will return false.
+     * 
+     * @param collider  The circle which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the circle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the circle and sprite are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class circle
+     */
+    bool resolve_collision(const circle& collider, sprite collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a circle and a rectangle by moving the
+     * circle to the edge of the rectangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the circle and
+     * rectangle are not colliding, this function will return false.
+     * 
+     * @param collider  The circle which will be altered if there is a collision
+     * @param collidee  The rectangle which will not be altered
+     * @param direction The direction of the collision relative to the circle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the circle and rectangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class circle
+     */
+    bool resolve_collision(const circle& collider, const rectangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a collider circle and a collidee circle by moving the
+     * collider circle to the edge of the collidee circle. The direction of the
+     * resolution is determined by the `direction` parameter. If the circles are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The circle which will be altered if there is a collision
+     * @param collidee  The circle which will not be altered
+     * @param direction The direction of the collision relative to the collider circle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the circles are colliding and the collision was resolved,
+     *                  false if the circles are not colliding
+     * 
+     * @atrribute class circle
+     */
+    bool resolve_collision(const circle& collider, const circle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a circle and a triangle by moving the
+     * circle to the edge of the triangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the circle and
+     * triangle are not colliding, this function will return false.
+     * 
+     * @param collider  The circle which will be altered if there is a collision
+     * @param collidee  The triangle which will not be altered
+     * @param direction The direction of the collision relative to the circle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the circle and triangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class circle
+     */
+    bool resolve_collision(const circle& collider, const triangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a circle and a quad by moving the
+     * circle to the edge of the quad. The direction of the
+     * resolution is determined by the `direction` parameter. If the circle and
+     * quad are not colliding, this function will return false.
+     * 
+     * @param collider  The circle which will be altered if there is a collision
+     * @param collidee  The quad which will not be altered
+     * @param direction The direction of the collision relative to the circle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the circle and quad are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class circle
+     */
+    bool resolve_collision(const circle& collider, const quad& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a triangle and a sprite by moving the
+     * triangle to the edge of the sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the triangle and
+     * sprite are not colliding, this function will return false.
+     * 
+     * @param collider  The triangle which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the triangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the triangle and sprite are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class triangle
+     */
+    bool resolve_collision(const triangle& collider, sprite collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a triangle and a rectangle by moving the
+     * triangle to the edge of the rectangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the triangle and
+     * rectangle are not colliding, this function will return false.
+     * 
+     * @param collider  The triangle which will be altered if there is a collision
+     * @param collidee  The rectangle which will not be altered
+     * @param direction The direction of the collision relative to the triangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the triangle and rectangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class triangle
+     */
+    bool resolve_collision(const triangle& collider, const rectangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a triangle and a circle by moving the
+     * triangle to the edge of the circle. The direction of the
+     * resolution is determined by the `direction` parameter. If the triangle and
+     * circle are not colliding, this function will return false.
+     * 
+     * @param collider  The triangle which will be altered if there is a collision
+     * @param collidee  The circle which will not be altered
+     * @param direction The direction of the collision relative to the triangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the triangle and circle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class triangle
+     */
+    bool resolve_collision(const triangle& collider, const circle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a collider triangle and a collidee triangle by moving the
+     * collider triangle to the edge of the collidee triangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the triangles are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The triangle which will be altered if there is a collision
+     * @param collidee  The triangle which will not be altered
+     * @param direction The direction of the collision relative to the collider triangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the triangles are colliding and the collision was resolved,
+     *                  false if the triangles are not colliding
+     * 
+     * @atrribute class triangle
+     */
+    bool resolve_collision(const triangle& collider, const triangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a triangle and a quad by moving the
+     * triangle to the edge of the quad. The direction of the
+     * resolution is determined by the `direction` parameter. If the triangle and
+     * quad are not colliding, this function will return false.
+     * 
+     * @param collider  The triangle which will be altered if there is a collision
+     * @param collidee  The quad which will not be altered
+     * @param direction The direction of the collision relative to the triangle.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the triangle and quad are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class triangle
+     */
+    bool resolve_collision(const triangle& collider, const quad& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a quad and a sprite by moving the
+     * quad to the edge of the sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the quad and
+     * sprite are not colliding, this function will return false.
+     * 
+     * @param collider  The quad which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the quad.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the quad and sprite are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class quad
+     */
+    bool resolve_collision(const quad& collider, sprite collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a quad and a rectangle by moving the
+     * quad to the edge of the rectangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the quad and
+     * rectangle are not colliding, this function will return false.
+     * 
+     * @param collider  The quad which will be altered if there is a collision
+     * @param collidee  The rectangle which will not be altered
+     * @param direction The direction of the collision relative to the quad.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the quad and rectangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class quad
+     */
+    bool resolve_collision(const quad& collider, const rectangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a quad and a circle by moving the
+     * quad to the edge of the circle. The direction of the
+     * resolution is determined by the `direction` parameter. If the quad and
+     * circle are not colliding, this function will return false.
+     * 
+     * @param collider  The quad which will be altered if there is a collision
+     * @param collidee  The circle which will not be altered
+     * @param direction The direction of the collision relative to the quad.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the quad and circle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class quad
+     */
+    bool resolve_collision(const quad& collider, const circle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a quad and a triangle by moving the
+     * quad to the edge of the triangle. The direction of the
+     * resolution is determined by the `direction` parameter. If the quad and
+     * triangle are not colliding, this function will return false.
+     * 
+     * @param collider  The quad which will be altered if there is a collision
+     * @param collidee  The triangle which will not be altered
+     * @param direction The direction of the collision relative to the quad.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the quad and triangle are colliding and the collision
+     *                  was resolved, false if they are not colliding
+     * 
+     * @atrribute class quad
+     */
+    bool resolve_collision(const quad& collider, const triangle& collidee, collision_direction direction);
+
+    /**
+     * Resolves the collision between a collider quad and a collidee quad by moving the
+     * collider quad to the edge of the collidee quad. The direction of the
+     * resolution is determined by the `direction` parameter. If the quads are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The quad which will be altered if there is a collision
+     * @param collidee  The quad which will not be altered
+     * @param direction The direction of the collision relative to the collider quad.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the quads are colliding and the collision was resolved,
+     *                  false if the quads are not colliding
+     * 
+     * @atrribute class quad
+     */
+    bool resolve_collision(const quad& collider, const quad& collidee, collision_direction direction);
 
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -723,7 +723,7 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction calculate_collision_direction(sprite collider, sprite collidee);
+    collision_direction calculate_collision_direction(const sprite collider, const sprite collidee);
 
     /**
      * Returns the direction of the collision between a sprite
@@ -738,7 +738,7 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction calculate_collision_direction(sprite collider, const rectangle& collidee);
+    collision_direction calculate_collision_direction(const sprite collider, const rectangle& collidee);
 
     /**
      * Returns the direction of the collision between a sprite
@@ -753,7 +753,7 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction calculate_collision_direction(sprite collider, const circle& collidee);
+    collision_direction calculate_collision_direction(const sprite collider, const circle& collidee);
 
     /**
      * Returns the direction of the collision between a sprite
@@ -768,7 +768,7 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction calculate_collision_direction(sprite collider, const triangle& collidee);
+    collision_direction calculate_collision_direction(const sprite collider, const triangle& collidee);
 
     /**
      * Returns the direction of the collision between a sprite
@@ -783,7 +783,7 @@ namespace splashkit_lib
      * 
      * @attribute class sprite
      */
-    collision_direction calculate_collision_direction(sprite collider, const quad& collidee);
+    collision_direction calculate_collision_direction(const sprite collider, const quad& collidee);
 
     /**
      * Returns the direction of the collision between a rectangle
@@ -798,7 +798,7 @@ namespace splashkit_lib
      * 
      * @attribute class rectangle
      */
-    collision_direction calculate_collision_direction(const rectangle& collider, sprite collidee);
+    collision_direction calculate_collision_direction(const rectangle& collider, const sprite collidee);
 
     /**
      * Returns the direction of the collision between a collider rectangle
@@ -872,7 +872,7 @@ namespace splashkit_lib
      * 
      * @attribute class circle
      */
-    collision_direction calculate_collision_direction(const circle& collider, sprite collidee);
+    collision_direction calculate_collision_direction(const circle& collider, const sprite collidee);
 
     /**
      * Returns the direction of the collision between a circle
@@ -946,7 +946,7 @@ namespace splashkit_lib
      * 
      * @attribute class triangle
      */
-    collision_direction calculate_collision_direction(const triangle& collider, sprite collidee);
+    collision_direction calculate_collision_direction(const triangle& collider, const sprite collidee);
 
     /**
      * Returns the direction of the collision between a triangle
@@ -1020,7 +1020,7 @@ namespace splashkit_lib
      * 
      * @attribute class quad
      */
-    collision_direction calculate_collision_direction(const quad& collider, sprite collidee);
+    collision_direction calculate_collision_direction(const quad& collider, const sprite collidee);
 
     /**
      * Returns the direction of the collision between a quad
@@ -1096,7 +1096,7 @@ namespace splashkit_lib
      * 
      * @atrribute class sprite
      */
-    bool resolve_collision(sprite collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(sprite collider, const sprite collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a sprite and a rectangle by moving the
@@ -1181,7 +1181,7 @@ namespace splashkit_lib
      * 
      * @atrribute class rectangle
      */
-    bool resolve_collision(const rectangle& collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(rectangle& collider, const sprite collidee, collision_direction direction);
 
     /**
      * Resolves the collision between two rectangles by moving the
@@ -1198,7 +1198,7 @@ namespace splashkit_lib
      * 
      * @atrribute class rectangle
      */
-    bool resolve_collision(const rectangle& collider, const rectangle& collidee, collision_direction direction);
+    bool resolve_collision(rectangle& collider, const rectangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a rectangle and a circle by moving the
@@ -1215,7 +1215,7 @@ namespace splashkit_lib
      * 
      * @atrribute class rectangle
      */
-    bool resolve_collision(const rectangle& collider, const circle& collidee, collision_direction direction);
+    bool resolve_collision(rectangle& collider, const circle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a rectangle and a triangle by moving the
@@ -1232,7 +1232,7 @@ namespace splashkit_lib
      * 
      * @atrribute class rectangle
      */
-    bool resolve_collision(const rectangle& collider, const triangle& collidee, collision_direction direction);
+    bool resolve_collision(rectangle& collider, const triangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a rectangle and a quad by moving the
@@ -1249,7 +1249,7 @@ namespace splashkit_lib
      * 
      * @atrribute class rectangle
      */
-    bool resolve_collision(const rectangle& collider, const quad& collidee, collision_direction direction);
+    bool resolve_collision(rectangle& collider, const quad& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a circle and a sprite by moving the
@@ -1266,7 +1266,7 @@ namespace splashkit_lib
      * 
      * @atrribute class circle
      */
-    bool resolve_collision(const circle& collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(circle& collider, const sprite collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a circle and a rectangle by moving the
@@ -1283,7 +1283,7 @@ namespace splashkit_lib
      * 
      * @atrribute class circle
      */
-    bool resolve_collision(const circle& collider, const rectangle& collidee, collision_direction direction);
+    bool resolve_collision(circle& collider, const rectangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a collider circle and a collidee circle by moving the
@@ -1300,7 +1300,7 @@ namespace splashkit_lib
      * 
      * @atrribute class circle
      */
-    bool resolve_collision(const circle& collider, const circle& collidee, collision_direction direction);
+    bool resolve_collision(circle& collider, const circle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a circle and a triangle by moving the
@@ -1317,7 +1317,7 @@ namespace splashkit_lib
      * 
      * @atrribute class circle
      */
-    bool resolve_collision(const circle& collider, const triangle& collidee, collision_direction direction);
+    bool resolve_collision(circle& collider, const triangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a circle and a quad by moving the
@@ -1334,7 +1334,7 @@ namespace splashkit_lib
      * 
      * @atrribute class circle
      */
-    bool resolve_collision(const circle& collider, const quad& collidee, collision_direction direction);
+    bool resolve_collision(circle& collider, const quad& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a triangle and a sprite by moving the
@@ -1351,7 +1351,7 @@ namespace splashkit_lib
      * 
      * @atrribute class triangle
      */
-    bool resolve_collision(const triangle& collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(triangle& collider, const sprite collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a triangle and a rectangle by moving the
@@ -1368,7 +1368,7 @@ namespace splashkit_lib
      * 
      * @atrribute class triangle
      */
-    bool resolve_collision(const triangle& collider, const rectangle& collidee, collision_direction direction);
+    bool resolve_collision(triangle& collider, const rectangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a triangle and a circle by moving the
@@ -1385,7 +1385,7 @@ namespace splashkit_lib
      * 
      * @atrribute class triangle
      */
-    bool resolve_collision(const triangle& collider, const circle& collidee, collision_direction direction);
+    bool resolve_collision(triangle& collider, const circle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a collider triangle and a collidee triangle by moving the
@@ -1402,7 +1402,7 @@ namespace splashkit_lib
      * 
      * @atrribute class triangle
      */
-    bool resolve_collision(const triangle& collider, const triangle& collidee, collision_direction direction);
+    bool resolve_collision(triangle& collider, const triangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a triangle and a quad by moving the
@@ -1419,7 +1419,7 @@ namespace splashkit_lib
      * 
      * @atrribute class triangle
      */
-    bool resolve_collision(const triangle& collider, const quad& collidee, collision_direction direction);
+    bool resolve_collision(triangle& collider, const quad& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a quad and a sprite by moving the
@@ -1436,7 +1436,7 @@ namespace splashkit_lib
      * 
      * @atrribute class quad
      */
-    bool resolve_collision(const quad& collider, sprite collidee, collision_direction direction);
+    bool resolve_collision(quad& collider, const sprite collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a quad and a rectangle by moving the
@@ -1453,7 +1453,7 @@ namespace splashkit_lib
      * 
      * @atrribute class quad
      */
-    bool resolve_collision(const quad& collider, const rectangle& collidee, collision_direction direction);
+    bool resolve_collision(quad& collider, const rectangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a quad and a circle by moving the
@@ -1470,7 +1470,7 @@ namespace splashkit_lib
      * 
      * @atrribute class quad
      */
-    bool resolve_collision(const quad& collider, const circle& collidee, collision_direction direction);
+    bool resolve_collision(quad& collider, const circle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a quad and a triangle by moving the
@@ -1487,7 +1487,7 @@ namespace splashkit_lib
      * 
      * @atrribute class quad
      */
-    bool resolve_collision(const quad& collider, const triangle& collidee, collision_direction direction);
+    bool resolve_collision(quad& collider, const triangle& collidee, collision_direction direction);
 
     /**
      * Resolves the collision between a collider quad and a collidee quad by moving the
@@ -1504,7 +1504,7 @@ namespace splashkit_lib
      * 
      * @atrribute class quad
      */
-    bool resolve_collision(const quad& collider, const quad& collidee, collision_direction direction);
+    bool resolve_collision(quad& collider, const quad& collidee, collision_direction direction);
 
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -325,6 +325,26 @@ namespace splashkit_lib
      * @attribute method circle_collision
      */
     bool bitmap_circle_collision(bitmap bmp, const point_2d& pt, const circle& circ);
+
+    bool bitmap_triangle_collision(bitmap bmp, int cell, const matrix_2d &translation, const triangle &tri);
+
+    bool bitmap_triangle_collision(bitmap bmp, int cell, const point_2d& pt, const triangle &tri);
+
+    bool bitmap_triangle_collision(bitmap bmp, int cell, double x, double y, const triangle &tri);
+
+    bool bitmap_triangle_collision(bitmap bmp, double x, double y, const triangle &tri);
+
+    bool bitmap_triangle_collision(bitmap bmp, const point_2d& pt, const triangle &tri);
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, const matrix_2d &translation, const quad &q);
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, const point_2d& pt, const quad &q);
+
+    bool bitmap_quad_collision(bitmap bmp, int cell, double x, double y, const quad &q);
+
+    bool bitmap_quad_collision(bitmap bmp, double x, double y, const quad &q);
+
+    bool bitmap_quad_collision(bitmap bmp, const point_2d& pt, const quad &q);
     
     /**
      * Tests if a sprite will collide with a bitmap drawn at the indicated
@@ -402,6 +422,12 @@ namespace splashkit_lib
      * @attribute method rectangle_collision
      */
     bool sprite_rectangle_collision(sprite s, const rectangle& rect);
+
+    bool sprite_circle_collision(sprite s, const circle &c);
+
+    bool sprite_triangle_collision(sprite s, const triangle &t);
+
+    bool sprite_quad_collision(sprite s, const quad &q);
 
     /**
      * Tests if two given sprites `s1` and `s2` are collided
@@ -519,6 +545,14 @@ namespace splashkit_lib
      */
     collision_direction sprite_collision_direction(sprite collider, sprite collidee);
 
+    collision_direction sprite_collision_direction(sprite collider, const rectangle& collidee);
+
+    collision_direction sprite_collision_direction(sprite collider, const circle& collidee);
+
+    collision_direction sprite_collision_direction(sprite collider, const triangle& collidee);
+
+    collision_direction sprite_collision_direction(sprite collider, const quad& collidee);
+
     /**
      * Resolves the collision between two sprites by moving the
      * collider sprite to the edge of the collidee sprite. The direction of the
@@ -535,6 +569,14 @@ namespace splashkit_lib
      * @atrribute class sprite
      */
     bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction);
+
+    bool resolve_sprite_collision(sprite collider, const rectangle& collidee, collision_direction direction);
+
+    bool resolve_sprite_collision(sprite collider, const circle& collidee, collision_direction direction);
+
+    bool resolve_sprite_collision(sprite collider, const triangle& collidee, collision_direction direction);
+
+    bool resolve_sprite_collision(sprite collider, const quad& collidee, collision_direction direction);
 
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/collisions.h
+++ b/coresdk/src/coresdk/collisions.h
@@ -18,6 +18,35 @@
 namespace splashkit_lib
 {
     /**
+     *  This enumeration contains a list of directions that a
+     *  sprite can collide with another sprite. For example, a
+     *  collider sprite which is colliding with another sprite
+     *  on its top edge would have a collision direction of TOP.
+     *  
+     *  @constant TOP           The top of the sprite
+     *  @constant BOTTOM        The bottom of the sprite
+     *  @constant LEFT          The left of the sprite
+     *  @constant RIGHT         The right of the sprite
+     *  @constant TOP_LEFT      The top left of the sprite
+     *  @constant TOP_RIGHT     The top right of the sprite
+     *  @constant BOTTOM_LEFT   The bottom left of the sprite
+     *  @constant BOTTOM_RIGHT  The bottom right of the sprite
+     *  @constant NONE          No collision
+     */
+    enum collision_direction
+    {
+        TOP,
+        BOTTOM,
+        LEFT,
+        RIGHT,
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT,
+        NONE,
+    };
+    
+    /**
      * Tests if a bitmap drawn using the passed in translation matrix would draw a pixel
      * at the passed in point. Use to check collisions between a point and a bitmap.
      *
@@ -476,19 +505,36 @@ namespace splashkit_lib
      */
     bool bitmap_collision(bitmap bmp1, double x1, double y1, bitmap bmp2, double x2, double y2);
 
-    enum collision_resolution_kind
-    {
-        TOP,
-        BOTTOM,
-        LEFT,
-        RIGHT,
-        TOP_LEFT,
-        TOP_RIGHT,
-        BOTTOM_LEFT,
-        BOTTOM_RIGHT
-    };
+    /**
+     * Returns the direction of the collision between two sprites
+     * relative to the collider sprite. If the sprites are not colliding,
+     * this function will return NONE.
+     * 
+     * @param collider  The sprite that is colliding
+     * @param collidee  The sprite that is being collided with
+     * @return          The direction of the collision relative to the collider sprite.
+     *                  If the sprites are not colliding, this function will return NONE.
+     * 
+     * @attribute class sprite
+     */
+    collision_direction sprite_collision_direction(sprite collider, sprite collidee);
 
-    bool resolve_collision(sprite collider, sprite collidee, collision_resolution_kind kind);
+    /**
+     * Resolves the collision between two sprites by moving the
+     * collider sprite to the edge of the collidee sprite. The direction of the
+     * resolution is determined by the `direction` parameter. If the sprites are not
+     * colliding, this function will return false.
+     * 
+     * @param collider  The sprite which will be altered if there is a collision
+     * @param collidee  The sprite which will not be altered
+     * @param direction The direction of the collision relative to the collider sprite.
+     *                  If NONE is passed, the function will not resolve the collision.
+     * @return          True if the sprites are colliding and the collision was resolved,
+     *                  false if the sprites are not colliding
+     * 
+     * @atrribute class sprite
+     */
+    bool resolve_sprite_collision(sprite collider, sprite collidee, collision_direction direction);
 
 }
 #endif /* collisions_h */

--- a/coresdk/src/coresdk/line_geometry.cpp
+++ b/coresdk/src/coresdk/line_geometry.cpp
@@ -173,6 +173,12 @@ namespace splashkit_lib
 
     bool line_intersects_rect(const line &l, const rectangle &rect)
     {
+        // if the line is completely within the rectangle, then it intersects
+        if (point_in_rectangle(l.start_point, rect) && point_in_rectangle(l.end_point, rect))
+        {
+            return true;
+        }
+        
         return line_intersects_lines(l, lines_from(rect));
     }
 

--- a/coresdk/src/coresdk/rectangle_geometry.cpp
+++ b/coresdk/src/coresdk/rectangle_geometry.cpp
@@ -223,4 +223,15 @@ namespace splashkit_lib
 
         return result;
     }
+
+    bool rectangle_circle_intersect(const rectangle &rect, const circle &c)
+    {
+        if (point_in_rectangle(c.center, rect))
+        {
+            return true;
+        }
+        
+        point_2d closest = closest_point_on_rect_from_circle(c, rect);
+        return point_in_circle(closest, c);
+    }
 }

--- a/coresdk/src/coresdk/rectangle_geometry.h
+++ b/coresdk/src/coresdk/rectangle_geometry.h
@@ -178,5 +178,14 @@ namespace splashkit_lib
      */
     rectangle inset_rectangle(const rectangle &rect, float inset_amount);
 
+    /**
+     * Detects if a rectangle intersects with a circle.
+     *
+     * @param  rect The rectangle to test
+     * @param  c    The circle to test
+     * @return      True if the rectangle and circle intersect, false otherwise
+     */
+    bool rectangle_circle_intersect(const rectangle &rect, const circle &c);
+
 }
 #endif /* rectangle_geometry_H */

--- a/coresdk/src/coresdk/shape.h
+++ b/coresdk/src/coresdk/shape.h
@@ -32,7 +32,7 @@ namespace splashkit_lib
         virtual bool intersects(const triangle& other) const = 0;
         virtual bool intersects(const quad& other) const = 0;
         virtual bool AABB_intersects(const shape* other) const;
-        virtual void move_by(const vector_2d& amount);
+        virtual void move_by(const vector_2d& amount) = 0;
     };
 }
 

--- a/coresdk/src/coresdk/shape.h
+++ b/coresdk/src/coresdk/shape.h
@@ -1,0 +1,39 @@
+#ifndef SHAPE_H
+#define SHAPE_H
+
+namespace splashkit_lib
+{
+    enum class shape_type
+    {
+        SPRITE,
+        RECTANGLE,
+        CIRCLE,
+        TRIANGLE,
+        QUAD,
+    };
+    
+    struct rectangle;
+    struct circle;
+    struct triangle;
+    struct quad;
+    struct _sprite_data;
+    struct vector_2d;
+
+    struct shape
+    {
+        virtual ~shape() = default;
+        virtual rectangle get_bounding_box() const = 0;
+        virtual shape_type get_shape_type() const = 0;
+        virtual bool intersects(const shape* other) const;
+        virtual bool intersects(const shape& other) const;
+        virtual bool intersects(const _sprite_data& other) const = 0;
+        virtual bool intersects(const rectangle& other) const = 0;
+        virtual bool intersects(const circle& other) const = 0;
+        virtual bool intersects(const triangle& other) const = 0;
+        virtual bool intersects(const quad& other) const = 0;
+        virtual bool AABB_intersects(const shape* other) const;
+        virtual void move_by(const vector_2d& amount);
+    };
+}
+
+#endif /* SHAPE_H */

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -96,10 +96,6 @@ namespace splashkit_lib
         bool intersects(const circle& other) const override;
         bool intersects(const triangle& other) const override;
         bool intersects(const quad& other) const override;
-
-    // private:
-    //     bool check_collision(const _sprite_data* sprite, const shape& other,
-    //         bool (*specific_collision_func)(const _sprite_data*, const shape&));
     };
 
     rectangle _sprite_data::get_bounding_box() const
@@ -111,19 +107,6 @@ namespace splashkit_lib
     {
         return shape_type::SPRITE;
     }
-
-    // bool _sprite_data::check_collision(const _sprite_data* sprite, const shape& other,
-    //     bool (*specific_collision_func)(const _sprite_data*, const shape&))
-    // {
-    //     bool aabb_collision = sprite->AABB_intersects(&other);
-
-    //     if (sprite->collision_kind == AABB_COLLISIONS || !aabb_collision)
-    //     {
-    //         return aabb_collision;
-    //     }
-
-    //     return specific_collision_func(sprite, other);
-    // }
 
     bool _sprite_data::intersects(const rectangle& other) const
     {

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -48,56 +48,6 @@ namespace splashkit_lib
 #define ROTATION_KEY    "rotation"
 #define MASS_KEY        "mass"
 
-    struct _sprite_data : public shape
-    {
-        pointer_identifier  id;
-        string name;                          // The name of the sprite for resource management
-
-        vector<bitmap>      layers;           // Layers of the sprites
-        map<string, int>    layer_names;
-        vector<int>         visible_layers;   // The indexes of the visible layers
-        vector<vector_2d>   layer_offsets;    // Offsets from drawing the layers
-
-        map<string, float>  values;           // Values associated with this sprite
-
-
-        animation           animation_info;   // The data used to animate this sprite
-        animation_script    script;           // The template for this sprite"s animations
-
-        point_2d            position;         // The game location of the sprite
-        vector_2d           velocity;         // The velocity of the sprite
-
-        collision_test_kind collision_kind;   //The kind of collisions used by this sprite
-        bitmap              collision_bitmap; // The bitmap used for collision testing (default to first image)
-
-        point_2d            anchor_point;
-        bool                position_at_anchor_point;
-        bool                draw_at_anchor_point;
-
-        bool                is_moving;          // Used for events to indicate the sprite is moving
-        point_2d            destination;        // The destination the sprite is moving to
-        vector_2d           moving_vec;         // The sprite"s movement vector
-        float               arrive_in_sec;      // Amount of time in seconds to arrive at point
-        int                 last_update;        // Time of last update
-
-        bool                announced_animation_end; // Used to avoid multiple announcements of an end of an animation
-
-        vector<sprite_event_handler *> evts;    // The call backs listening for sprite events
-
-        vector<void *>      &pack;              // Points the the SpritePack that contains this sprite
-
-        _sprite_data() : pack( current_pack() )
-        {
-        }
-
-        rectangle get_bounding_box() const override;
-        shape_type get_shape_type() const override;
-        bool intersects(const rectangle& other) const override;
-        bool intersects(const circle& other) const override;
-        bool intersects(const triangle& other) const override;
-        bool intersects(const quad& other) const override;
-    };
-
     rectangle _sprite_data::get_bounding_box() const
     {
         return sprite_collision_rectangle(const_cast<sprite>(this));
@@ -106,6 +56,11 @@ namespace splashkit_lib
     shape_type _sprite_data::get_shape_type() const
     {
         return shape_type::SPRITE;
+    }
+
+    bool _sprite_data::intersects(const _sprite_data& other) const
+    {
+        return sprite_collision(const_cast<sprite>(this), const_cast<sprite>(&other));
     }
 
     bool _sprite_data::intersects(const rectangle& other) const
@@ -155,6 +110,12 @@ namespace splashkit_lib
         }
 
         return sprite_quad_collision(const_cast<sprite>(this), other);
+    }
+
+    void _sprite_data::move_by(const vector_2d& amount)
+    {
+        this->position.x += amount.x;
+        this->position.y += amount.y;
     }
 
     //-----------------------------------------------------------------------------

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -48,7 +48,7 @@ namespace splashkit_lib
 #define ROTATION_KEY    "rotation"
 #define MASS_KEY        "mass"
 
-    struct _sprite_data
+    struct _sprite_data : public shape
     {
         pointer_identifier  id;
         string name;                          // The name of the sprite for resource management
@@ -89,7 +89,90 @@ namespace splashkit_lib
         _sprite_data() : pack( current_pack() )
         {
         }
+
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
+
+    // private:
+    //     bool check_collision(const _sprite_data* sprite, const shape& other,
+    //         bool (*specific_collision_func)(const _sprite_data*, const shape&));
     };
+
+    rectangle _sprite_data::get_bounding_box() const
+    {
+        return sprite_collision_rectangle(const_cast<sprite>(this));
+    }
+
+    shape_type _sprite_data::get_shape_type() const
+    {
+        return shape_type::SPRITE;
+    }
+
+    // bool _sprite_data::check_collision(const _sprite_data* sprite, const shape& other,
+    //     bool (*specific_collision_func)(const _sprite_data*, const shape&))
+    // {
+    //     bool aabb_collision = sprite->AABB_intersects(&other);
+
+    //     if (sprite->collision_kind == AABB_COLLISIONS || !aabb_collision)
+    //     {
+    //         return aabb_collision;
+    //     }
+
+    //     return specific_collision_func(sprite, other);
+    // }
+
+    bool _sprite_data::intersects(const rectangle& other) const
+    {
+        bool aabb_collision = this->AABB_intersects(&other);
+
+        if (this->collision_kind == AABB_COLLISIONS || !aabb_collision)
+        {
+            return aabb_collision;
+        }
+
+        return sprite_rectangle_collision(const_cast<sprite>(this), other);
+    }
+
+    bool _sprite_data::intersects(const circle& other) const
+    {
+        bool aabb_collision = this->AABB_intersects(&other);
+
+        if (this->collision_kind == AABB_COLLISIONS || !aabb_collision)
+        {
+            return aabb_collision;
+        }
+
+        return sprite_circle_collision(const_cast<sprite>(this), other);
+    }
+
+    bool _sprite_data::intersects(const triangle& other) const
+    {
+        bool aabb_collision = this->AABB_intersects(&other);
+
+        if (this->collision_kind == AABB_COLLISIONS || !aabb_collision)
+        {
+            return aabb_collision;
+        }
+
+        return sprite_triangle_collision(const_cast<sprite>(this), other);
+    }
+
+    bool _sprite_data::intersects(const quad& other) const
+    {
+        bool aabb_collision = quads_intersect(
+            quad_from(sprite_collision_rectangle(const_cast<sprite>(this))), other);
+
+        if (this->collision_kind == AABB_COLLISIONS || !aabb_collision)
+        {
+            return aabb_collision;
+        }
+
+        return sprite_quad_collision(const_cast<sprite>(this), other);
+    }
 
     //-----------------------------------------------------------------------------
     // Event Utility Code

--- a/coresdk/src/coresdk/sprites.h
+++ b/coresdk/src/coresdk/sprites.h
@@ -88,6 +88,60 @@ namespace splashkit_lib
      */
     typedef void (sprite_float_function)(void *s, float f);
 
+    std::vector<void *> &current_pack();
+
+    struct _sprite_data : public shape
+    {
+        pointer_identifier  id;
+        std::string name;                          // The name of the sprite for resource management
+
+        std::vector<bitmap>      layers;           // Layers of the sprites
+        std::map<std::string, int>    layer_names;
+        std::vector<int>         visible_layers;   // The indexes of the visible layers
+        std::vector<vector_2d>   layer_offsets;    // Offsets from drawing the layers
+
+        std::map<std::string, float>  values;           // Values associated with this sprite
+
+
+        animation           animation_info;   // The data used to animate this sprite
+        animation_script    script;           // The template for this sprite"s animations
+
+        point_2d            position;         // The game location of the sprite
+        vector_2d           velocity;         // The velocity of the sprite
+
+        collision_test_kind collision_kind;   //The kind of collisions used by this sprite
+        bitmap              collision_bitmap; // The bitmap used for collision testing (default to first image)
+
+        point_2d            anchor_point;
+        bool                position_at_anchor_point;
+        bool                draw_at_anchor_point;
+
+        bool                is_moving;          // Used for events to indicate the sprite is moving
+        point_2d            destination;        // The destination the sprite is moving to
+        vector_2d           moving_vec;         // The sprite"s movement vector
+        float               arrive_in_sec;      // Amount of time in seconds to arrive at point
+        int                 last_update;        // Time of last update
+
+        bool                announced_animation_end; // Used to avoid multiple announcements of an end of an animation
+
+        std::vector<sprite_event_handler *> evts;    // The call backs listening for sprite events
+
+        std::vector<void *>      &pack;              // Points the the SpritePack that contains this sprite
+
+        _sprite_data() : pack( current_pack() )
+        {
+        }
+
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const _sprite_data& other) const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
+        void move_by(const vector_2d& amount) override;
+    };
+
     //---------------------------------------------------------------------------
     // sprite creation routines
     //---------------------------------------------------------------------------

--- a/coresdk/src/coresdk/triangle_geometry.cpp
+++ b/coresdk/src/coresdk/triangle_geometry.cpp
@@ -102,6 +102,18 @@ namespace splashkit_lib
             or point_in_triangle(point_at(r, b), tri);
     }
 
+    bool triangle_quad_intersect(const triangle &tri, const quad &q)
+    {
+        vector<triangle> q_tris = triangles_from(q);
+
+        for (size_t i = 0; i < q_tris.size(); i++)
+        {
+            if (triangles_intersect(tri, q_tris[i])) return true;
+        }
+
+        return false;
+    }
+
     bool triangles_intersect(const triangle &t1, const triangle &t2)
     {
         // Test if any of the points lie within the other triangle.

--- a/coresdk/src/coresdk/triangle_geometry.h
+++ b/coresdk/src/coresdk/triangle_geometry.h
@@ -46,6 +46,9 @@ namespace splashkit_lib
      */
     bool triangle_rectangle_intersect(const triangle &tri, const rectangle &rect);
 
+    // TODO
+    bool triangle_quad_intersect(const triangle &tri, const quad &q);
+
     /**
      * Returns true if the two triangles intersect.
      *

--- a/coresdk/src/coresdk/types.cpp
+++ b/coresdk/src/coresdk/types.cpp
@@ -67,6 +67,11 @@ namespace splashkit_lib
         return shape_type::RECTANGLE;
     }
 
+    bool rectangle::intersects(const _sprite_data& other) const
+    {
+        return other.intersects(*this);
+    }
+
     bool rectangle::intersects(const rectangle& other) const
     {
         return rectangles_intersect(*this, other);
@@ -85,6 +90,12 @@ namespace splashkit_lib
     bool rectangle::intersects(const quad& other) const
     {
         return quads_intersect(quad_from(*this), other);
+    }
+
+    void rectangle::move_by(const vector_2d& amount)
+    {
+        x += amount.x;
+        y += amount.y;
     }
 
     quad::quad()
@@ -114,6 +125,11 @@ namespace splashkit_lib
         return shape_type::QUAD;
     }
 
+    bool quad::intersects(const _sprite_data& other) const
+    {
+        return other.intersects(*this);
+    }
+
     bool quad::intersects(const rectangle& other) const
     {
         return other.intersects(*this);
@@ -132,6 +148,15 @@ namespace splashkit_lib
     bool quad::intersects(const quad& other) const
     {
         return other.intersects(*this);
+    }
+
+    void quad::move_by(const vector_2d& amount)
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            points[i].x += amount.x;
+            points[i].y += amount.y;
+        }
     }
 
     circle::circle()
@@ -156,6 +181,11 @@ namespace splashkit_lib
         return shape_type::CIRCLE;
     }
 
+    bool circle::intersects(const _sprite_data& other) const
+    {
+        return other.intersects(*this);
+    }
+
     bool circle::intersects(const rectangle& other) const
     {
         return other.intersects(*this);
@@ -174,6 +204,12 @@ namespace splashkit_lib
     bool circle::intersects(const quad& other) const
     {
         return circle_quad_intersect(*this, other);
+    }
+
+    void circle::move_by(const vector_2d& amount)
+    {
+        center.x += amount.x;
+        center.y += amount.y;
     }
 
     triangle::triangle()
@@ -201,6 +237,11 @@ namespace splashkit_lib
         return shape_type::TRIANGLE;
     }
 
+    bool triangle::intersects(const _sprite_data& other) const
+    {
+        return other.intersects(*this);
+    }
+
     bool triangle::intersects(const rectangle& other) const
     {
         return other.intersects(*this);
@@ -219,5 +260,14 @@ namespace splashkit_lib
     bool triangle::intersects(const quad& other) const
     {
         return triangle_quad_intersect(*this, other);
+    }
+
+    void triangle::move_by(const vector_2d& amount)
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            points[i].x += amount.x;
+            points[i].y += amount.y;
+        }
     }
 }

--- a/coresdk/src/coresdk/types.cpp
+++ b/coresdk/src/coresdk/types.cpp
@@ -7,3 +7,217 @@
 //
 
 #include "types.h"
+#include "collisions.h"
+#include "sprites.h"
+
+namespace splashkit_lib
+{
+    bool shape::intersects(const shape* other) const
+    {
+        switch (other->get_shape_type())
+        {
+            // case shape_type::SPRITE:
+            //     return this->intersects(*dynamic_cast<const _sprite_data*>(other));
+            case shape_type::RECTANGLE:
+                return this->intersects(*dynamic_cast<const rectangle*>(other));
+            case shape_type::CIRCLE:
+                return this->intersects(*dynamic_cast<const circle*>(other));
+            case shape_type::TRIANGLE:
+                return this->intersects(*dynamic_cast<const triangle*>(other));
+            case shape_type::QUAD:
+                return this->intersects(*dynamic_cast<const quad*>(other));
+        };
+
+        return false;
+    }
+
+    bool shape::intersects(const shape& other) const
+    {
+        return this->intersects(&other);
+    }
+
+    bool shape::AABB_intersects(const shape* other) const
+    {
+        return this->get_bounding_box().intersects(other->get_bounding_box());
+    }
+    
+    rectangle::rectangle()
+    {
+        x = 0.0;
+        y = 0.0;
+        width = 0.0;
+        height = 0.0;
+    }
+    
+    rectangle::rectangle(double x, double y, double width, double height)
+    {
+        this->x = x;
+        this->y = y;
+        this->width = width;
+        this->height = height;
+    }
+    
+    rectangle rectangle::get_bounding_box() const
+    {
+        return *this;
+    }
+
+    shape_type rectangle::get_shape_type() const
+    {
+        return shape_type::RECTANGLE;
+    }
+
+    bool rectangle::intersects(const rectangle& other) const
+    {
+        return rectangles_intersect(*this, other);
+    }
+
+    bool rectangle::intersects(const circle& other) const
+    {
+        return rectangle_circle_intersect(*this, other);
+    }
+
+    bool rectangle::intersects(const triangle& other) const
+    {
+        return triangle_rectangle_intersect(other, *this);
+    }
+
+    bool rectangle::intersects(const quad& other) const
+    {
+        return quads_intersect(quad_from(*this), other);
+    }
+
+    quad::quad()
+    {
+        for (int i = 0; i < 4; i++)
+        {
+            points[i] = {0.0, 0.0};
+        }
+    }
+
+    quad::quad(const point_2d& top_left, const point_2d& top_right,
+            const point_2d& bottom_left, const point_2d& bottom_right)
+    {
+        points[0] = top_left;
+        points[1] = top_right;
+        points[2] = bottom_left;
+        points[3] = bottom_right;
+    }
+
+    rectangle quad::get_bounding_box() const
+    {
+        return rectangle_around(*this);
+    }
+
+    shape_type quad::get_shape_type() const
+    {
+        return shape_type::QUAD;
+    }
+
+    bool quad::intersects(const rectangle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool quad::intersects(const circle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool quad::intersects(const triangle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool quad::intersects(const quad& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    circle::circle()
+    {
+        center = {0.0, 0.0};
+        radius = 0.0;
+    }
+
+    circle::circle(const point_2d& center, double radius)
+    {
+        this->center = center;
+        this->radius = radius;
+    }
+
+    rectangle circle::get_bounding_box() const
+    {
+        return rectangle_around(*this);
+    }
+
+    shape_type circle::get_shape_type() const
+    {
+        return shape_type::CIRCLE;
+    }
+
+    bool circle::intersects(const rectangle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool circle::intersects(const circle& other) const
+    {
+        return circles_intersect(*this, other);
+    }
+
+    bool circle::intersects(const triangle& other) const
+    {
+        return circle_triangle_intersect(*this, other);
+    }
+
+    bool circle::intersects(const quad& other) const
+    {
+        return circle_quad_intersect(*this, other);
+    }
+
+    triangle::triangle()
+    {
+        for (int i = 0; i < 3; i++)
+        {
+            points[i] = {0.0, 0.0};
+        }
+    }
+
+    triangle::triangle(const point_2d& p1, const point_2d& p2, const point_2d& p3)
+    {
+        points[0] = p1;
+        points[1] = p2;
+        points[2] = p3;
+    }
+
+    rectangle triangle::get_bounding_box() const
+    {
+        return rectangle_around(*this);
+    }
+
+    shape_type triangle::get_shape_type() const
+    {
+        return shape_type::TRIANGLE;
+    }
+
+    bool triangle::intersects(const rectangle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool triangle::intersects(const circle& other) const
+    {
+        return other.intersects(*this);
+    }
+
+    bool triangle::intersects(const triangle& other) const
+    {
+        return triangles_intersect(*this, other);
+    }
+
+    bool triangle::intersects(const quad& other) const
+    {
+        return triangle_quad_intersect(*this, other);
+    }
+}

--- a/coresdk/src/coresdk/types.cpp
+++ b/coresdk/src/coresdk/types.cpp
@@ -16,8 +16,8 @@ namespace splashkit_lib
     {
         switch (other->get_shape_type())
         {
-            // case shape_type::SPRITE:
-            //     return this->intersects(*dynamic_cast<const _sprite_data*>(other));
+            case shape_type::SPRITE:
+                return other->intersects(*this);
             case shape_type::RECTANGLE:
                 return this->intersects(*dynamic_cast<const rectangle*>(other));
             case shape_type::CIRCLE:

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -154,7 +154,7 @@ namespace splashkit_lib
 
     struct shape
     {
-        //virtual ~shape() = default;
+        virtual ~shape() = default;
         virtual rectangle get_bounding_box() const = 0;
         virtual shape_type get_shape_type() const = 0;
         //virtual collision_test_kind get_collision_kind() const = 0;

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -12,7 +12,6 @@
 #ifndef types_hpp
 #define types_hpp
 
-//#include "collisions.h"
 #include "shape.h"
 #include <cstdint>
 #include <string>

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -12,6 +12,8 @@
 #ifndef types_hpp
 #define types_hpp
 
+//#include "collisions.h"
+#include "shape.h"
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -67,14 +69,14 @@ namespace splashkit_lib
         UNDERLINE_FONT = 4
     };
 
-    enum class shape_type
-    {
-        SPRITE,
-        RECTANGLE,
-        CIRCLE,
-        TRIANGLE,
-        QUAD,
-    };
+    // enum class shape_type
+    // {
+    //     SPRITE,
+    //     RECTANGLE,
+    //     CIRCLE,
+    //     TRIANGLE,
+    //     QUAD,
+    // };
 
     /**
      * Fonts are used to draw text in SplashKit. These can be loaded from file
@@ -147,26 +149,28 @@ namespace splashkit_lib
         double y;
     };
 
-    struct rectangle;
-    struct circle;
-    struct triangle;
-    struct quad;
+    // struct rectangle;
+    // struct circle;
+    // struct triangle;
+    // struct quad;
+    // struct _sprite_data;
 
-    struct shape
-    {
-        virtual ~shape() = default;
-        virtual rectangle get_bounding_box() const = 0;
-        virtual shape_type get_shape_type() const = 0;
-        //virtual collision_test_kind get_collision_kind() const = 0;
-        virtual bool intersects(const shape* other) const;
-        virtual bool intersects(const shape& other) const;
-        //virtual bool intersects(const sprite other) const = 0;
-        virtual bool intersects(const rectangle& other) const = 0;
-        virtual bool intersects(const circle& other) const = 0;
-        virtual bool intersects(const triangle& other) const = 0;
-        virtual bool intersects(const quad& other) const = 0;
-        virtual bool AABB_intersects(const shape* other) const;
-    };
+    // struct shape
+    // {
+    //     virtual ~shape() = default;
+    //     virtual rectangle get_bounding_box() const = 0;
+    //     virtual shape_type get_shape_type() const = 0;
+    //     //virtual collision_test_kind get_collision_kind() const = 0;
+    //     virtual bool intersects(const shape* other) const;
+    //     virtual bool intersects(const shape& other) const;
+    //     virtual bool intersects(const _sprite_data& other) const = 0;
+    //     virtual bool intersects(const rectangle& other) const = 0;
+    //     virtual bool intersects(const circle& other) const = 0;
+    //     virtual bool intersects(const triangle& other) const = 0;
+    //     virtual bool intersects(const quad& other) const = 0;
+    //     virtual bool AABB_intersects(const shape* other) const;
+    //     virtual void move_by(const vector_2d& amount);
+    // };
 
     /**
      * Rectangles are simple rectangle shapes that exist at a point and have a
@@ -189,10 +193,12 @@ namespace splashkit_lib
         rectangle(double x, double y, double width, double height);
         rectangle get_bounding_box() const override;
         shape_type get_shape_type() const override;
+        bool intersects(const _sprite_data& other) const override;
         bool intersects(const rectangle& other) const override;
         bool intersects(const circle& other) const override;
         bool intersects(const triangle& other) const override;
         bool intersects(const quad& other) const override;
+        void move_by(const vector_2d& amount) override;
     };
 
     /**
@@ -215,10 +221,12 @@ namespace splashkit_lib
             const point_2d& bottom_left, const point_2d& bottom_right);
         rectangle get_bounding_box() const override;
         shape_type get_shape_type() const override;
+        bool intersects(const _sprite_data& other) const override;
         bool intersects(const rectangle& other) const override;
         bool intersects(const circle& other) const override;
         bool intersects(const triangle& other) const override;
         bool intersects(const quad& other) const override;
+        void move_by(const vector_2d& amount) override;
     };
 
     /**
@@ -238,10 +246,12 @@ namespace splashkit_lib
         circle(const point_2d& center, double radius);
         rectangle get_bounding_box() const override;
         shape_type get_shape_type() const override;
+        bool intersects(const _sprite_data& other) const override;
         bool intersects(const rectangle& other) const override;
         bool intersects(const circle& other) const override;
         bool intersects(const triangle& other) const override;
         bool intersects(const quad& other) const override;
+        void move_by(const vector_2d& amount) override;
     };
 
     /**
@@ -258,10 +268,12 @@ namespace splashkit_lib
         triangle(const point_2d& p1, const point_2d& p2, const point_2d& p3);
         rectangle get_bounding_box() const override;
         shape_type get_shape_type() const override;
+        bool intersects(const _sprite_data& other) const override;
         bool intersects(const rectangle& other) const override;
         bool intersects(const circle& other) const override;
         bool intersects(const triangle& other) const override;
         bool intersects(const quad& other) const override;
+        void move_by(const vector_2d& amount) override;
     };
 
     /**

--- a/coresdk/src/coresdk/types.h
+++ b/coresdk/src/coresdk/types.h
@@ -67,6 +67,15 @@ namespace splashkit_lib
         UNDERLINE_FONT = 4
     };
 
+    enum class shape_type
+    {
+        SPRITE,
+        RECTANGLE,
+        CIRCLE,
+        TRIANGLE,
+        QUAD,
+    };
+
     /**
      * Fonts are used to draw text in SplashKit. These can be loaded from file
      * or downloaded from the internet. Once you have a font you can use the
@@ -138,6 +147,27 @@ namespace splashkit_lib
         double y;
     };
 
+    struct rectangle;
+    struct circle;
+    struct triangle;
+    struct quad;
+
+    struct shape
+    {
+        //virtual ~shape() = default;
+        virtual rectangle get_bounding_box() const = 0;
+        virtual shape_type get_shape_type() const = 0;
+        //virtual collision_test_kind get_collision_kind() const = 0;
+        virtual bool intersects(const shape* other) const;
+        virtual bool intersects(const shape& other) const;
+        //virtual bool intersects(const sprite other) const = 0;
+        virtual bool intersects(const rectangle& other) const = 0;
+        virtual bool intersects(const circle& other) const = 0;
+        virtual bool intersects(const triangle& other) const = 0;
+        virtual bool intersects(const quad& other) const = 0;
+        virtual bool AABB_intersects(const shape* other) const;
+    };
+
     /**
      * Rectangles are simple rectangle shapes that exist at a point and have a
      * set width and height. This means that the rectangle always has edges that
@@ -150,10 +180,19 @@ namespace splashkit_lib
      * @field width The width of the rectangle
      * @field height The height of the rectangle
      */
-    struct rectangle
+    struct rectangle : public shape
     {
         double x, y;
         double width, height;
+        
+        rectangle();
+        rectangle(double x, double y, double width, double height);
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
     };
 
     /**
@@ -167,9 +206,19 @@ namespace splashkit_lib
      * @field points The array of points: top left, top right, bottom left,
      *                bottom right
      */
-    struct quad
+    struct quad : public shape
     {
         point_2d points[4];
+
+        quad();
+        quad(const point_2d& top_left, const point_2d& top_right,
+            const point_2d& bottom_left, const point_2d& bottom_right);
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
     };
 
     /**
@@ -180,10 +229,19 @@ namespace splashkit_lib
      * @field center  The center point of the circle
      * @field radius  The radius of the circle
      */
-    struct circle
+    struct circle : public shape
     {
         point_2d center;
         double radius;
+
+        circle();
+        circle(const point_2d& center, double radius);
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
     };
 
     /**
@@ -192,9 +250,18 @@ namespace splashkit_lib
      *
      * @field points  The points of the triangle
      */
-    struct triangle
+    struct triangle : public shape
     {
         point_2d points[3];
+
+        triangle();
+        triangle(const point_2d& p1, const point_2d& p2, const point_2d& p3);
+        rectangle get_bounding_box() const override;
+        shape_type get_shape_type() const override;
+        bool intersects(const rectangle& other) const override;
+        bool intersects(const circle& other) const override;
+        bool intersects(const triangle& other) const override;
+        bool intersects(const quad& other) const override;
     };
 
     /**

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -346,8 +346,11 @@ void sprite_collision_resolution_test()
         draw_rectangle(COLOR_RED, sprite_collision_rectangle(sprt_AABB));
         fill_rectangle(COLOR_GREEN, rect);
         fill_circle(COLOR_GREEN, circ);
+        draw_rectangle(COLOR_GREEN, rectangle_around(circ));
         fill_triangle(COLOR_GREEN, tri);
+        draw_rectangle(COLOR_GREEN, rectangle_around(tri));
         fill_quad(COLOR_GREEN, q);
+        draw_rectangle(COLOR_GREEN, rectangle_around(q));
         draw_sprite(sprt_pixel);
         draw_sprite(sprt_AABB);
 
@@ -1020,11 +1023,11 @@ void sprite_quad_collision_resolution_direction_test()
 
 void run_sprite_test()
 {
-    sprite_test();
+    // sprite_test();
     sprite_collision_resolution_test();
-    sprite_sprite_collision_resolution_direction_test();
-    sprite_rectangle_collision_resolution_direction_test();
-    sprite_circle_collision_resolution_direction_test();
-    sprite_triangle_collision_resolution_direction_test();
-    sprite_quad_collision_resolution_direction_test();
+    // sprite_sprite_collision_resolution_direction_test();
+    // sprite_rectangle_collision_resolution_direction_test();
+    // sprite_circle_collision_resolution_direction_test();
+    // sprite_triangle_collision_resolution_direction_test();
+    // sprite_quad_collision_resolution_direction_test();
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -34,43 +34,45 @@ enum class sprite_perimeter_segment
 
 void draw_sprite_perimeter_segment(sprite s, sprite_perimeter_segment segment, color clr, int line_width)
 {
+    rectangle r = sprite_collision_rectangle(s);
+    
     switch (segment)
     {
     case sprite_perimeter_segment::TOP_LEFT:
-        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        draw_line(clr, r.x, r.y, r.x + r.width / 3.0, r.y, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::TOP_CENTER:
-        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        draw_line(clr, r.x + r.width / 3.0, r.y, r.x + r.width * 2.0 / 3.0, r.y, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::TOP_RIGHT:
-        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s), option_line_width(line_width));
+        draw_line(clr, r.x + r.width * 2.0 / 3.0, r.y, r.x + r.width, r.y, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::BOTTOM_LEFT:
-        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        draw_line(clr, r.x, r.y + r.height, r.x + r.width / 3.0, r.y + r.height, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::BOTTOM_CENTER:
-        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        draw_line(clr, r.x + r.width / 3.0, r.y + r.height, r.x + r.width * 2.0 / 3.0, r.y + r.height, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::BOTTOM_RIGHT:
-        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        draw_line(clr, r.x + r.width * 2.0 / 3.0, r.y + r.height, r.x + r.width, r.y + r.height, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::LEFT_TOP:
-        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        draw_line(clr, r.x, r.y, r.x, r.y + r.height / 3.0, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::LEFT_CENTER:
-        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        draw_line(clr, r.x, r.y + r.height / 3.0, r.x, r.y + r.height * 2.0 / 3.0, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::LEFT_BOTTOM:
-        draw_line(clr, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        draw_line(clr, r.x, r.y + r.height * 2.0 / 3.0, r.x, r.y + r.height, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::RIGHT_TOP:
-        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        draw_line(clr, r.x + r.width, r.y, r.x + r.width, r.y + r.height / 3.0, option_line_width(line_width));
         break;
     case sprite_perimeter_segment::RIGHT_CENTER:
-        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        draw_line(clr, r.x + r.width, r.y + r.height / 3.0, r.x + r.width, r.y + r.height * 2.0 / 3.0, option_line_width(line_width));
         break;
-    default: // case sprite_perimeter_segment::RIGHT_BOTTOM:
-        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+    case sprite_perimeter_segment::RIGHT_BOTTOM:
+        draw_line(clr, r.x + r.width, r.y + r.height * 2.0 / 3.0, r.x + r.width, r.y + r.height, option_line_width(line_width));
         break;
     };
 }
@@ -118,7 +120,7 @@ void draw_sprite_perimeter_by_collision(sprite s, collision_direction direction,
     };
 }
 
-void run_sprite_test()
+void sprite_test()
 {
     sprite sprt, s2, s3, s4;
     triangle tri, init_tri;
@@ -150,7 +152,6 @@ void run_sprite_test()
     sprite_set_x(s4, 400);
     sprite_set_y(s4, 400);
     sprite_set_collision_kind(s4, AABB_COLLISIONS);
-    sprite_set_scale(s4, 2.0f);
 
     r = rectangle_from(400, 100, 100, 50);
     q = quad_from(r);
@@ -252,14 +253,14 @@ void run_sprite_test()
         {
             collision_direction dir = sprite_collision_direction(sprt, s3);
             resolve_sprite_collision(sprt, s3, dir);
-            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 4);
         }
 
         if (sprite_collision(sprt, s4))
         {
             collision_direction dir = sprite_collision_direction(sprt, s4);
             resolve_sprite_collision(sprt, s4, dir);
-            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 4);
         }
 
         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(sprt));
@@ -273,4 +274,757 @@ void run_sprite_test()
     show_mouse();
     
     close_all_windows();
+}
+
+void sprite_collision_resolution_test()
+{
+    sprite collider, sprt_pixel, sprt_AABB;
+    bitmap bmp;
+    rectangle rect;
+    circle circ;
+    triangle tri;
+    quad q;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    sprt_pixel = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_pixel, 100.0);
+    sprite_set_y(sprt_pixel, 100.0);
+    sprite_set_collision_kind(sprt_pixel, PIXEL_COLLISIONS);
+
+    sprt_AABB = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_AABB, 100.0);
+    sprite_set_y(sprt_AABB, 400.0);
+    sprite_set_collision_kind(sprt_AABB, AABB_COLLISIONS);
+
+    rect = rectangle_from(400.0, 450.0, 100.0, 50.0);
+    circ = circle_at(400.0, 300.0, 50.0);
+    tri = triangle_from(400.0, 100.0, 500.0, 100.0, 450.0, 50.0);
+
+    rectangle r = rectangle_from(400, 100, 100, 50);
+    q = quad_from(r);
+    apply_matrix(matrix_multiply(translation_matrix(0.0, 50.0), rotation_matrix(45.0)), q);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        draw_rectangle(COLOR_RED, sprite_collision_rectangle(sprt_AABB));
+        fill_rectangle(COLOR_GREEN, rect);
+        fill_circle(COLOR_GREEN, circ);
+        fill_triangle(COLOR_GREEN, tri);
+        fill_quad(COLOR_GREEN, q);
+        draw_sprite(sprt_pixel);
+        draw_sprite(sprt_AABB);
+
+        if (sprite_collision(collider, sprt_pixel))
+        {
+            collision_direction dir = sprite_collision_direction(collider, sprt_pixel);
+            resolve_sprite_collision(collider, sprt_pixel, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_AABB))
+        {
+            collision_direction dir = sprite_collision_direction(collider, sprt_AABB);
+            resolve_sprite_collision(collider, sprt_AABB, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect))
+        {
+            collision_direction dir = sprite_collision_direction(collider, rect);
+            resolve_sprite_collision(collider, rect, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ))
+        {
+            collision_direction dir = sprite_collision_direction(collider, circ);
+            resolve_sprite_collision(collider, circ, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri))
+        {
+            collision_direction dir = sprite_collision_direction(collider, tri);
+            resolve_sprite_collision(collider, tri, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, q))
+        {
+            collision_direction dir = sprite_collision_direction(collider, q);
+            resolve_sprite_collision(collider, q, dir);
+            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void sprite_sprite_collision_resolution_direction_test()
+{
+    sprite collider, sprt_TOP, sprt_BOTTOM, sprt_LEFT, sprt_RIGHT, sprt_TOP_LEFT,
+        sprt_TOP_RIGHT, sprt_BOTTOM_LEFT, sprt_BOTTOM_RIGHT;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    sprt_TOP = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_TOP, 300.0);
+    sprite_set_y(sprt_TOP, 100.0);
+    sprite_set_collision_kind(sprt_TOP, PIXEL_COLLISIONS);
+
+    sprt_BOTTOM = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_BOTTOM, 300.0);
+    sprite_set_y(sprt_BOTTOM, 500.0);
+    sprite_set_collision_kind(sprt_BOTTOM, PIXEL_COLLISIONS);
+
+    sprt_LEFT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_LEFT, 100.0);
+    sprite_set_y(sprt_LEFT, 300.0);
+    sprite_set_collision_kind(sprt_LEFT, PIXEL_COLLISIONS);
+
+    sprt_RIGHT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_RIGHT, 500.0);
+    sprite_set_y(sprt_RIGHT, 300.0);
+    sprite_set_collision_kind(sprt_RIGHT, PIXEL_COLLISIONS);
+
+    sprt_TOP_LEFT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_TOP_LEFT, 100.0);
+    sprite_set_y(sprt_TOP_LEFT, 100.0);
+    sprite_set_collision_kind(sprt_TOP_LEFT, PIXEL_COLLISIONS);
+
+    sprt_TOP_RIGHT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_TOP_RIGHT, 500.0);
+    sprite_set_y(sprt_TOP_RIGHT, 100.0);
+    sprite_set_collision_kind(sprt_TOP_RIGHT, PIXEL_COLLISIONS);
+
+    sprt_BOTTOM_LEFT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_BOTTOM_LEFT, 100.0);
+    sprite_set_y(sprt_BOTTOM_LEFT, 500.0);
+    sprite_set_collision_kind(sprt_BOTTOM_LEFT, PIXEL_COLLISIONS);
+
+    sprt_BOTTOM_RIGHT = create_sprite("rocket_sprt.png");
+    sprite_set_x(sprt_BOTTOM_RIGHT, 500.0);
+    sprite_set_y(sprt_BOTTOM_RIGHT, 500.0);
+    sprite_set_collision_kind(sprt_BOTTOM_RIGHT, PIXEL_COLLISIONS);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        draw_sprite(sprt_TOP);
+        draw_sprite(sprt_BOTTOM);
+        draw_sprite(sprt_LEFT);
+        draw_sprite(sprt_RIGHT);
+        draw_sprite(sprt_TOP_LEFT);
+        draw_sprite(sprt_TOP_RIGHT);
+        draw_sprite(sprt_BOTTOM_LEFT);
+        draw_sprite(sprt_BOTTOM_RIGHT);
+
+        if (sprite_collision(collider, sprt_TOP))
+        {
+            resolve_sprite_collision(collider, sprt_TOP, collision_direction::TOP);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_BOTTOM))
+        {
+            resolve_sprite_collision(collider, sprt_BOTTOM, collision_direction::BOTTOM);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_LEFT))
+        {
+            resolve_sprite_collision(collider, sprt_LEFT, collision_direction::LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_RIGHT))
+        {
+            resolve_sprite_collision(collider, sprt_RIGHT, collision_direction::RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_TOP_LEFT))
+        {
+            resolve_sprite_collision(collider, sprt_TOP_LEFT, collision_direction::TOP_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_TOP_RIGHT))
+        {
+            resolve_sprite_collision(collider, sprt_TOP_RIGHT, collision_direction::TOP_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_BOTTOM_LEFT))
+        {
+            resolve_sprite_collision(collider, sprt_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_collision(collider, sprt_BOTTOM_RIGHT))
+        {
+            resolve_sprite_collision(collider, sprt_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void sprite_rectangle_collision_resolution_direction_test()
+{
+    sprite collider;
+    rectangle rect_TOP, rect_BOTTOM, rect_LEFT, rect_RIGHT, rect_TOP_LEFT,
+        rect_TOP_RIGHT, rect_BOTTOM_LEFT, rect_BOTTOM_RIGHT;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    rect_TOP = rectangle_from(300.0, 100.0, 100.0, 50.0);
+    rect_BOTTOM = rectangle_from(300.0, 500.0, 100.0, 50.0);
+    rect_LEFT = rectangle_from(100.0, 300.0, 50.0, 100.0);
+    rect_RIGHT = rectangle_from(500.0, 300.0, 50.0, 100.0);
+    rect_TOP_LEFT = rectangle_from(100.0, 100.0, 50.0, 50.0);
+    rect_TOP_RIGHT = rectangle_from(500.0, 100.0, 50.0, 50.0);
+    rect_BOTTOM_LEFT = rectangle_from(100.0, 500.0, 50.0, 50.0);
+    rect_BOTTOM_RIGHT = rectangle_from(500.0, 500.0, 50.0, 50.0);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        fill_rectangle(COLOR_GREEN, rect_TOP);
+        fill_rectangle(COLOR_GREEN, rect_BOTTOM);
+        fill_rectangle(COLOR_GREEN, rect_LEFT);
+        fill_rectangle(COLOR_GREEN, rect_RIGHT);
+        fill_rectangle(COLOR_GREEN, rect_TOP_LEFT);
+        fill_rectangle(COLOR_GREEN, rect_TOP_RIGHT);
+        fill_rectangle(COLOR_GREEN, rect_BOTTOM_LEFT);
+        fill_rectangle(COLOR_GREEN, rect_BOTTOM_RIGHT);
+
+        if (sprite_rectangle_collision(collider, rect_TOP))
+        {
+            resolve_sprite_collision(collider, rect_TOP, collision_direction::TOP);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_BOTTOM))
+        {
+            resolve_sprite_collision(collider, rect_BOTTOM, collision_direction::BOTTOM);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_LEFT))
+        {
+            resolve_sprite_collision(collider, rect_LEFT, collision_direction::LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_RIGHT))
+        {
+            resolve_sprite_collision(collider, rect_RIGHT, collision_direction::RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_TOP_LEFT))
+        {
+            resolve_sprite_collision(collider, rect_TOP_LEFT, collision_direction::TOP_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_TOP_RIGHT))
+        {
+            resolve_sprite_collision(collider, rect_TOP_RIGHT, collision_direction::TOP_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_BOTTOM_LEFT))
+        {
+            resolve_sprite_collision(collider, rect_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_rectangle_collision(collider, rect_BOTTOM_RIGHT))
+        {
+            resolve_sprite_collision(collider, rect_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void sprite_circle_collision_resolution_direction_test()
+{
+    sprite collider;
+    circle circ_TOP, circ_BOTTOM, circ_LEFT, circ_RIGHT, circ_TOP_LEFT,
+        circ_TOP_RIGHT, circ_BOTTOM_LEFT, circ_BOTTOM_RIGHT;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    circ_TOP = circle_at(300.0, 100.0, 50.0);
+    circ_BOTTOM = circle_at(300.0, 500.0, 50.0);
+    circ_LEFT = circle_at(100.0, 300.0, 50.0);
+    circ_RIGHT = circle_at(500.0, 300.0, 50.0);
+    circ_TOP_LEFT = circle_at(100.0, 100.0, 50.0);
+    circ_TOP_RIGHT = circle_at(500.0, 100.0, 50.0);
+    circ_BOTTOM_LEFT = circle_at(100.0, 500.0, 50.0);
+    circ_BOTTOM_RIGHT = circle_at(500.0, 500.0, 50.0);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        fill_circle(COLOR_GREEN, circ_TOP);
+        fill_circle(COLOR_GREEN, circ_BOTTOM);
+        fill_circle(COLOR_GREEN, circ_LEFT);
+        fill_circle(COLOR_GREEN, circ_RIGHT);
+        fill_circle(COLOR_GREEN, circ_TOP_LEFT);
+        fill_circle(COLOR_GREEN, circ_TOP_RIGHT);
+        fill_circle(COLOR_GREEN, circ_BOTTOM_LEFT);
+        fill_circle(COLOR_GREEN, circ_BOTTOM_RIGHT);
+
+        if (sprite_circle_collision(collider, circ_TOP))
+        {
+            resolve_sprite_collision(collider, circ_TOP, collision_direction::TOP);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_BOTTOM))
+        {
+            resolve_sprite_collision(collider, circ_BOTTOM, collision_direction::BOTTOM);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_LEFT))
+        {
+            resolve_sprite_collision(collider, circ_LEFT, collision_direction::LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_RIGHT))
+        {
+            resolve_sprite_collision(collider, circ_RIGHT, collision_direction::RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_TOP_LEFT))
+        {
+            resolve_sprite_collision(collider, circ_TOP_LEFT, collision_direction::TOP_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_TOP_RIGHT))
+        {
+            resolve_sprite_collision(collider, circ_TOP_RIGHT, collision_direction::TOP_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_BOTTOM_LEFT))
+        {
+            resolve_sprite_collision(collider, circ_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_circle_collision(collider, circ_BOTTOM_RIGHT))
+        {
+            resolve_sprite_collision(collider, circ_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void sprite_triangle_collision_resolution_direction_test()
+{
+    sprite collider;
+    triangle tri_TOP, tri_BOTTOM, tri_LEFT, tri_RIGHT, tri_TOP_LEFT,
+        tri_TOP_RIGHT, tri_BOTTOM_LEFT, tri_BOTTOM_RIGHT;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    tri_TOP = triangle_from(300.0, 100.0, 400.0, 100.0, 350.0, 150.0);
+    tri_BOTTOM = triangle_from(300.0, 500.0, 400.0, 500.0, 350.0, 450.0);
+    tri_LEFT = triangle_from(100.0, 300.0, 100.0, 400.0, 150.0, 350.0);
+    tri_RIGHT = triangle_from(500.0, 300.0, 500.0, 400.0, 450.0, 350.0);
+    tri_TOP_LEFT = triangle_from(100.0, 150.0, 150.0, 100.0, 150.0, 150.0);
+    tri_TOP_RIGHT = triangle_from(500.0, 150.0, 450.0, 100.0, 450.0, 150.0);
+    tri_BOTTOM_LEFT = triangle_from(100.0, 450.0, 150.0, 500.0, 150.0, 450.0);
+    tri_BOTTOM_RIGHT = triangle_from(500.0, 450.0, 450.0, 500.0, 450.0, 450.0);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        fill_triangle(COLOR_GREEN, tri_TOP);
+        fill_triangle(COLOR_GREEN, tri_BOTTOM);
+        fill_triangle(COLOR_GREEN, tri_LEFT);
+        fill_triangle(COLOR_GREEN, tri_RIGHT);
+        fill_triangle(COLOR_GREEN, tri_TOP_LEFT);
+        fill_triangle(COLOR_GREEN, tri_TOP_RIGHT);
+        fill_triangle(COLOR_GREEN, tri_BOTTOM_LEFT);
+        fill_triangle(COLOR_GREEN, tri_BOTTOM_RIGHT);
+
+        if (sprite_triangle_collision(collider, tri_TOP))
+        {
+            resolve_sprite_collision(collider, tri_TOP, collision_direction::TOP);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_BOTTOM))
+        {
+            resolve_sprite_collision(collider, tri_BOTTOM, collision_direction::BOTTOM);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_LEFT))
+        {
+            resolve_sprite_collision(collider, tri_LEFT, collision_direction::LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_RIGHT))
+        {
+            resolve_sprite_collision(collider, tri_RIGHT, collision_direction::RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_TOP_LEFT))
+        {
+            resolve_sprite_collision(collider, tri_TOP_LEFT, collision_direction::TOP_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_TOP_RIGHT))
+        {
+            resolve_sprite_collision(collider, tri_TOP_RIGHT, collision_direction::TOP_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_BOTTOM_LEFT))
+        {
+            resolve_sprite_collision(collider, tri_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_triangle_collision(collider, tri_BOTTOM_RIGHT))
+        {
+            resolve_sprite_collision(collider, tri_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void sprite_quad_collision_resolution_direction_test()
+{
+    sprite collider;
+    quad quad_TOP, quad_BOTTOM, quad_LEFT, quad_RIGHT, quad_TOP_LEFT,
+        quad_TOP_RIGHT, quad_BOTTOM_LEFT, quad_BOTTOM_RIGHT;
+
+    open_window("Sprite Collision Resolution", 600, 600);
+
+    hide_mouse();
+
+    collider = create_sprite("rocket_sprt.png");
+    sprite_set_x(collider, 300.0);
+    sprite_set_y(collider, 300.0);
+    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+    rectangle r = rectangle_from(0.0, 0.0, 100.0, 50.0);
+    quad_TOP = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 20.0)), quad_TOP);
+    quad_BOTTOM = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 470.0)), quad_BOTTOM);
+    quad_LEFT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 270.0)), quad_LEFT);
+    quad_RIGHT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 270.0)), quad_RIGHT);
+    quad_TOP_LEFT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 20.0)), quad_TOP_LEFT);
+    quad_TOP_RIGHT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 20.0)), quad_TOP_RIGHT);
+    quad_BOTTOM_LEFT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 470.0)), quad_BOTTOM_LEFT);
+    quad_BOTTOM_RIGHT = quad_from(r);
+    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 470.0)), quad_BOTTOM_RIGHT);
+
+    while (! quit_requested())
+    {
+        process_events();
+
+        clear_screen(COLOR_WHITE);
+
+        if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+        if ( key_down(RIGHT_KEY) )
+            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+        }
+        else
+        {
+            if ( key_down(UP_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+            if ( key_down(DOWN_KEY) )
+                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+        }
+
+        update_sprite(collider);
+
+        fill_quad(COLOR_GREEN, quad_TOP);
+        fill_quad(COLOR_GREEN, quad_BOTTOM);
+        fill_quad(COLOR_GREEN, quad_LEFT);
+        fill_quad(COLOR_GREEN, quad_RIGHT);
+        fill_quad(COLOR_GREEN, quad_TOP_LEFT);
+        fill_quad(COLOR_GREEN, quad_TOP_RIGHT);
+        fill_quad(COLOR_GREEN, quad_BOTTOM_LEFT);
+        fill_quad(COLOR_GREEN, quad_BOTTOM_RIGHT);
+
+        if (sprite_quad_collision(collider, quad_TOP))
+        {
+            resolve_sprite_collision(collider, quad_TOP, collision_direction::TOP);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_BOTTOM))
+        {
+            resolve_sprite_collision(collider, quad_BOTTOM, collision_direction::BOTTOM);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_LEFT))
+        {
+            resolve_sprite_collision(collider, quad_LEFT, collision_direction::LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_RIGHT))
+        {
+            resolve_sprite_collision(collider, quad_RIGHT, collision_direction::RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_TOP_LEFT))
+        {
+            resolve_sprite_collision(collider, quad_TOP_LEFT, collision_direction::TOP_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_TOP_RIGHT))
+        {
+            resolve_sprite_collision(collider, quad_TOP_RIGHT, collision_direction::TOP_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_BOTTOM_LEFT))
+        {
+            resolve_sprite_collision(collider, quad_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+        }
+        if (sprite_quad_collision(collider, quad_BOTTOM_RIGHT))
+        {
+            resolve_sprite_collision(collider, quad_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+        }
+
+        draw_sprite(collider);
+        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+        refresh_screen(60);
+    }
+
+    show_mouse();
+
+    close_all_windows();
+}
+
+void run_sprite_test()
+{
+    sprite_test();
+    sprite_collision_resolution_test();
+    sprite_sprite_collision_resolution_direction_test();
+    sprite_rectangle_collision_resolution_direction_test();
+    sprite_circle_collision_resolution_direction_test();
+    sprite_triangle_collision_resolution_direction_test();
+    sprite_quad_collision_resolution_direction_test();
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -322,7 +322,7 @@ void reset_quad(quad &q)
 {
     rectangle r = rectangle_from(300, 300, 100, 50);
     q = quad_from(r);
-    apply_matrix(matrix_multiply(translation_matrix(200.0, 50.0), rotation_matrix(45.0)), q);
+    apply_matrix(matrix_multiply(translation_matrix(0.0, -150.0), rotation_matrix(45.0)), q);
 }
 
 void resolve_and_draw(void* collider, const void* collidee,  object_type collider_type,
@@ -334,6 +334,7 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
     }
 
     rectangle perimeter;
+    bool collision = false;
     
     switch (collider_type)
     {
@@ -345,19 +346,19 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
         switch (collidee_type)
         {
         case object_type::SPRITE:
-            resolve_collision(s, *static_cast<const sprite*>(collidee), direction);
+            collision = resolve_collision(s, *static_cast<const sprite*>(collidee), direction);
             break;
         case object_type::RECTANGLE:
-            resolve_collision(s, *static_cast<const rectangle*>(collidee), direction);
+            collision = resolve_collision(s, *static_cast<const rectangle*>(collidee), direction);
             break;
         case object_type::CIRCLE:
-            resolve_collision(s, *static_cast<const circle*>(collidee), direction);
+            collision = resolve_collision(s, *static_cast<const circle*>(collidee), direction);
             break;
         case object_type::TRIANGLE:
-            resolve_collision(s, *static_cast<const triangle*>(collidee), direction);
+            collision = resolve_collision(s, *static_cast<const triangle*>(collidee), direction);
             break;
         case object_type::QUAD:
-            resolve_collision(s, *static_cast<const quad*>(collidee), direction);
+            collision = resolve_collision(s, *static_cast<const quad*>(collidee), direction);
             break;
         };
         break;
@@ -370,19 +371,19 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
         switch (collidee_type)
         {
         case object_type::SPRITE:
-            resolve_collision(*r, *static_cast<const sprite*>(collidee), direction);
+            collision = resolve_collision(*r, *static_cast<const sprite*>(collidee), direction);
             break;
         case object_type::RECTANGLE:
-            resolve_collision(*r, *static_cast<const rectangle*>(collidee), direction);
+            collision = resolve_collision(*r, *static_cast<const rectangle*>(collidee), direction);
             break;
         case object_type::CIRCLE:
-            resolve_collision(*r, *static_cast<const circle*>(collidee), direction);
+            collision = resolve_collision(*r, *static_cast<const circle*>(collidee), direction);
             break;
         case object_type::TRIANGLE:
-            resolve_collision(*r, *static_cast<const triangle*>(collidee), direction);
+            collision = resolve_collision(*r, *static_cast<const triangle*>(collidee), direction);
             break;
         case object_type::QUAD:
-            resolve_collision(*r, *static_cast<const quad*>(collidee), direction);
+            collision = resolve_collision(*r, *static_cast<const quad*>(collidee), direction);
             break;
         };
         break;
@@ -395,19 +396,19 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
         switch (collidee_type)
         {
         case object_type::SPRITE:
-            resolve_collision(*c, *static_cast<const sprite*>(collidee), direction);
+            collision = resolve_collision(*c, *static_cast<const sprite*>(collidee), direction);
             break;
         case object_type::RECTANGLE:
-            resolve_collision(*c, *static_cast<const rectangle*>(collidee), direction);
+            collision = resolve_collision(*c, *static_cast<const rectangle*>(collidee), direction);
             break;
         case object_type::CIRCLE:
-            resolve_collision(*c, *static_cast<const circle*>(collidee), direction);
+            collision = resolve_collision(*c, *static_cast<const circle*>(collidee), direction);
             break;
         case object_type::TRIANGLE:
-            resolve_collision(*c, *static_cast<const triangle*>(collidee), direction);
+            collision = resolve_collision(*c, *static_cast<const triangle*>(collidee), direction);
             break;
         case object_type::QUAD:
-            resolve_collision(*c, *static_cast<const quad*>(collidee), direction);
+            collision = resolve_collision(*c, *static_cast<const quad*>(collidee), direction);
             break;
         };
         break;
@@ -420,19 +421,19 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
         switch (collidee_type)
         {
         case object_type::SPRITE:
-            resolve_collision(*t, *static_cast<const sprite*>(collidee), direction);
+            collision = resolve_collision(*t, *static_cast<const sprite*>(collidee), direction);
             break;
         case object_type::RECTANGLE:
-            resolve_collision(*t, *static_cast<const rectangle*>(collidee), direction);
+            collision = resolve_collision(*t, *static_cast<const rectangle*>(collidee), direction);
             break;
         case object_type::CIRCLE:
-            resolve_collision(*t, *static_cast<const circle*>(collidee), direction);
+            collision = resolve_collision(*t, *static_cast<const circle*>(collidee), direction);
             break;
         case object_type::TRIANGLE:
-            resolve_collision(*t, *static_cast<const triangle*>(collidee), direction);
+            collision = resolve_collision(*t, *static_cast<const triangle*>(collidee), direction);
             break;
         case object_type::QUAD:
-            resolve_collision(*t, *static_cast<const quad*>(collidee), direction);
+            collision = resolve_collision(*t, *static_cast<const quad*>(collidee), direction);
             break;
         };
         break;
@@ -445,26 +446,29 @@ void resolve_and_draw(void* collider, const void* collidee,  object_type collide
         switch (collidee_type)
         {
         case object_type::SPRITE:
-            resolve_collision(*q, *static_cast<const sprite*>(collidee), direction);
+            collision = resolve_collision(*q, *static_cast<const sprite*>(collidee), direction);
             break;
         case object_type::RECTANGLE:
-            resolve_collision(*q, *static_cast<const rectangle*>(collidee), direction);
+            collision = resolve_collision(*q, *static_cast<const rectangle*>(collidee), direction);
             break;
         case object_type::CIRCLE:
-            resolve_collision(*q, *static_cast<const circle*>(collidee), direction);
+            collision = resolve_collision(*q, *static_cast<const circle*>(collidee), direction);
             break;
         case object_type::TRIANGLE:
-            resolve_collision(*q, *static_cast<const triangle*>(collidee), direction);
+            collision = resolve_collision(*q, *static_cast<const triangle*>(collidee), direction);
             break;
         case object_type::QUAD:
-            resolve_collision(*q, *static_cast<const quad*>(collidee), direction);
+            collision = resolve_collision(*q, *static_cast<const quad*>(collidee), direction);
             break;
         };
         break;
     }
     };
 
-    draw_rect_perimeter_by_collision(perimeter, direction, COLOR_RED, COLLISION_INDICATOR_WIDTH);
+    if (collision)
+    {
+        draw_rect_perimeter_by_collision(perimeter, direction, COLOR_RED, COLLISION_INDICATOR_WIDTH);
+    }
 }
 
 void multi_object_collision_resolution_test()

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -16,9 +16,111 @@
 
 using namespace splashkit_lib;
 
+enum class sprite_perimeter_segment
+{
+    TOP_LEFT,
+    TOP_CENTER,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_CENTER,
+    BOTTOM_RIGHT,
+    LEFT_TOP,
+    LEFT_CENTER,
+    LEFT_BOTTOM,
+    RIGHT_TOP,
+    RIGHT_CENTER,
+    RIGHT_BOTTOM,
+};
+
+void draw_sprite_perimeter_segment(sprite s, sprite_perimeter_segment segment, color clr, int line_width)
+{
+    switch (segment)
+    {
+    case sprite_perimeter_segment::TOP_LEFT:
+        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::TOP_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::TOP_RIGHT:
+        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_LEFT:
+        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::BOTTOM_RIGHT:
+        draw_line(clr, sprite_x(s) + 2 * sprite_width(s) / 3, sprite_y(s) + sprite_height(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_TOP:
+        draw_line(clr, sprite_x(s), sprite_y(s), sprite_x(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_CENTER:
+        draw_line(clr, sprite_x(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::LEFT_BOTTOM:
+        draw_line(clr, sprite_x(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::RIGHT_TOP:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s), sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    case sprite_perimeter_segment::RIGHT_CENTER:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, option_line_width(line_width));
+        break;
+    default: // case sprite_perimeter_segment::RIGHT_BOTTOM:
+        draw_line(clr, sprite_x(s) + sprite_width(s), sprite_y(s) + 2 * sprite_height(s) / 3, sprite_x(s) + sprite_width(s), sprite_y(s) + sprite_height(s), option_line_width(line_width));
+        break;
+    };
+}
+
+void draw_sprite_perimeter_by_collision(sprite s, collision_direction direction, color clr, int line_width)
+{
+    switch (direction)
+    {
+    case collision_direction::TOP:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
+        break;
+    case collision_direction::BOTTOM:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
+        break;
+    case collision_direction::LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_CENTER, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::TOP_LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
+        break;
+    case collision_direction::TOP_RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
+        break;
+    case collision_direction::BOTTOM_LEFT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        break;
+    case collision_direction::BOTTOM_RIGHT:
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
+        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        break;
+    };
+}
+
 void run_sprite_test()
 {
-    sprite sprt, s2;
+    sprite sprt, s2, s3, s4;
     triangle tri, init_tri;
     triangle tri_b, init_tri_b;
     rectangle r;
@@ -37,6 +139,18 @@ void run_sprite_test()
     sprite_set_move_from_anchor_point(s2, true);
     sprite_set_x(s2, 100);
     sprite_set_y(s2, 100);
+
+    s3 = create_sprite(bitmap_named("rocket_sprt.png"));
+    sprite_set_move_from_anchor_point(s3, true);
+    sprite_set_x(s3, 100);
+    sprite_set_y(s3, 400);
+
+    s4 = create_sprite(bitmap_named("rocket_sprt.png"));
+    sprite_set_move_from_anchor_point(s4, true);
+    sprite_set_x(s4, 400);
+    sprite_set_y(s4, 400);
+    sprite_set_collision_kind(s4, AABB_COLLISIONS);
+    sprite_set_scale(s4, 2.0f);
 
     r = rectangle_from(400, 100, 100, 50);
     q = quad_from(r);
@@ -97,6 +211,8 @@ void run_sprite_test()
 
         draw_sprite(sprt);
         draw_sprite(s2);
+        draw_sprite(s3);
+        draw_sprite(s4);
         
         if (sprite_rectangle_collision(sprt, r))
 		{
@@ -132,7 +248,22 @@ void run_sprite_test()
             draw_circle(COLOR_RED, sprite_collision_circle(s2));
 		}
 
+        if (sprite_collision(sprt, s3))
+        {
+            collision_direction dir = sprite_collision_direction(sprt, s3);
+            resolve_sprite_collision(sprt, s3, dir);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+        }
+
+        if (sprite_collision(sprt, s4))
+        {
+            collision_direction dir = sprite_collision_direction(sprt, s4);
+            resolve_sprite_collision(sprt, s4, dir);
+            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 3);
+        }
+
         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(sprt));
+        draw_rectangle(COLOR_RED, sprite_collision_rectangle(s4));
 
         draw_line(COLOR_GREEN, line_from(center_point(sprt), matrix_multiply(rotation_matrix(sprite_rotation(sprt)), vector_multiply(sprite_velocity(sprt), 30.0))));
 

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -300,7 +300,7 @@ void sprite_collision_resolution_test()
     sprite_set_collision_kind(sprt_pixel, PIXEL_COLLISIONS);
 
     sprt_AABB = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_AABB, 100.0);
+    sprite_set_x(sprt_AABB, 50.0);
     sprite_set_y(sprt_AABB, 400.0);
     sprite_set_collision_kind(sprt_AABB, AABB_COLLISIONS);
 
@@ -346,11 +346,8 @@ void sprite_collision_resolution_test()
         draw_rectangle(COLOR_RED, sprite_collision_rectangle(sprt_AABB));
         fill_rectangle(COLOR_GREEN, rect);
         fill_circle(COLOR_GREEN, circ);
-        draw_rectangle(COLOR_GREEN, rectangle_around(circ));
         fill_triangle(COLOR_GREEN, tri);
-        draw_rectangle(COLOR_GREEN, rectangle_around(tri));
         fill_quad(COLOR_GREEN, q);
-        draw_rectangle(COLOR_GREEN, rectangle_around(q));
         draw_sprite(sprt_pixel);
         draw_sprite(sprt_AABB);
 
@@ -407,7 +404,7 @@ void sprite_sprite_collision_resolution_direction_test()
     sprite collider, sprt_TOP, sprt_BOTTOM, sprt_LEFT, sprt_RIGHT, sprt_TOP_LEFT,
         sprt_TOP_RIGHT, sprt_BOTTOM_LEFT, sprt_BOTTOM_RIGHT;
 
-    open_window("Sprite Collision Resolution", 600, 600);
+    open_window("Sprite-Sprite Collision Resolution Fixed Direction", 600, 600);
 
     hide_mouse();
 
@@ -554,7 +551,7 @@ void sprite_rectangle_collision_resolution_direction_test()
     rectangle rect_TOP, rect_BOTTOM, rect_LEFT, rect_RIGHT, rect_TOP_LEFT,
         rect_TOP_RIGHT, rect_BOTTOM_LEFT, rect_BOTTOM_RIGHT;
 
-    open_window("Sprite Collision Resolution", 600, 600);
+    open_window("Sprite-Rectangle Collision Resolution Fixed Direction", 600, 600);
 
     hide_mouse();
 
@@ -670,7 +667,7 @@ void sprite_circle_collision_resolution_direction_test()
     circle circ_TOP, circ_BOTTOM, circ_LEFT, circ_RIGHT, circ_TOP_LEFT,
         circ_TOP_RIGHT, circ_BOTTOM_LEFT, circ_BOTTOM_RIGHT;
 
-    open_window("Sprite Collision Resolution", 600, 600);
+    open_window("Sprite-Circle Collision Resolution Fixed Direction", 600, 600);
 
     hide_mouse();
 
@@ -786,7 +783,7 @@ void sprite_triangle_collision_resolution_direction_test()
     triangle tri_TOP, tri_BOTTOM, tri_LEFT, tri_RIGHT, tri_TOP_LEFT,
         tri_TOP_RIGHT, tri_BOTTOM_LEFT, tri_BOTTOM_RIGHT;
 
-    open_window("Sprite Collision Resolution", 600, 600);
+    open_window("Sprite-Triangle Collision Resolution Fixed Direction", 600, 600);
 
     hide_mouse();
 
@@ -902,7 +899,7 @@ void sprite_quad_collision_resolution_direction_test()
     quad quad_TOP, quad_BOTTOM, quad_LEFT, quad_RIGHT, quad_TOP_LEFT,
         quad_TOP_RIGHT, quad_BOTTOM_LEFT, quad_BOTTOM_RIGHT;
 
-    open_window("Sprite Collision Resolution", 600, 600);
+    open_window("Sprite-Quad Collision Resolution Fixed Direction", 600, 600);
 
     hide_mouse();
 
@@ -1025,9 +1022,9 @@ void run_sprite_test()
 {
     // sprite_test();
     sprite_collision_resolution_test();
-    // sprite_sprite_collision_resolution_direction_test();
-    // sprite_rectangle_collision_resolution_direction_test();
-    // sprite_circle_collision_resolution_direction_test();
-    // sprite_triangle_collision_resolution_direction_test();
-    // sprite_quad_collision_resolution_direction_test();
+    sprite_sprite_collision_resolution_direction_test();
+    sprite_rectangle_collision_resolution_direction_test();
+    sprite_circle_collision_resolution_direction_test();
+    sprite_triangle_collision_resolution_direction_test();
+    sprite_quad_collision_resolution_direction_test();
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -13,8 +13,18 @@
 #include "input.h"
 #include "sprites.h"
 #include "window_manager.h"
+#include <iostream>
 
 using namespace splashkit_lib;
+
+enum class object_type
+{
+    SPRITE,
+    RECTANGLE,
+    CIRCLE,
+    TRIANGLE,
+    QUAD,
+};
 
 enum class sprite_perimeter_segment
 {
@@ -32,10 +42,8 @@ enum class sprite_perimeter_segment
     RIGHT_BOTTOM,
 };
 
-void draw_sprite_perimeter_segment(sprite s, sprite_perimeter_segment segment, color clr, int line_width)
+void draw_rect_perimeter_segment(const rectangle& r, sprite_perimeter_segment segment, color clr, int line_width)
 {
-    rectangle r = sprite_collision_rectangle(s);
-    
     switch (segment)
     {
     case sprite_perimeter_segment::TOP_LEFT:
@@ -77,45 +85,41 @@ void draw_sprite_perimeter_segment(sprite s, sprite_perimeter_segment segment, c
     };
 }
 
-void draw_sprite_perimeter_by_collision(sprite s, collision_direction direction, color clr, int line_width)
+void draw_rect_perimeter_segments(const rectangle& r, const std::vector<sprite_perimeter_segment>& segments, color clr, int line_width)
+{
+    for (const auto& segment : segments)
+    {
+        draw_rect_perimeter_segment(r, segment, clr, line_width);
+    }
+}
+
+void draw_rect_perimeter_by_collision(const rectangle& r, collision_direction direction, color clr, int line_width)
 {
     switch (direction)
     {
     case collision_direction::TOP:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_CENTER, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::TOP_LEFT, sprite_perimeter_segment::TOP_CENTER, sprite_perimeter_segment::TOP_RIGHT}, clr, line_width);
         break;
     case collision_direction::BOTTOM:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_CENTER, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::BOTTOM_LEFT, sprite_perimeter_segment::BOTTOM_CENTER, sprite_perimeter_segment::BOTTOM_RIGHT}, clr, line_width);
         break;
     case collision_direction::LEFT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_CENTER, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::LEFT_TOP, sprite_perimeter_segment::LEFT_CENTER, sprite_perimeter_segment::LEFT_BOTTOM}, clr, line_width);
         break;
     case collision_direction::RIGHT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_CENTER, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::RIGHT_TOP, sprite_perimeter_segment::RIGHT_CENTER, sprite_perimeter_segment::RIGHT_BOTTOM}, clr, line_width);
         break;
     case collision_direction::TOP_LEFT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_LEFT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_TOP, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::TOP_LEFT, sprite_perimeter_segment::LEFT_TOP}, clr, line_width);
         break;
     case collision_direction::TOP_RIGHT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::TOP_RIGHT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_TOP, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::TOP_RIGHT, sprite_perimeter_segment::RIGHT_TOP}, clr, line_width);
         break;
     case collision_direction::BOTTOM_LEFT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_LEFT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::LEFT_BOTTOM, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::BOTTOM_LEFT, sprite_perimeter_segment::LEFT_BOTTOM}, clr, line_width);
         break;
     case collision_direction::BOTTOM_RIGHT:
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::BOTTOM_RIGHT, clr, line_width);
-        draw_sprite_perimeter_segment(s, sprite_perimeter_segment::RIGHT_BOTTOM, clr, line_width);
+        draw_rect_perimeter_segments(r, {sprite_perimeter_segment::BOTTOM_RIGHT, sprite_perimeter_segment::RIGHT_BOTTOM}, clr, line_width);
         break;
     };
 }
@@ -251,16 +255,16 @@ void sprite_test()
 
         if (sprite_collision(sprt, s3))
         {
-            collision_direction dir = sprite_collision_direction(sprt, s3);
-            resolve_sprite_collision(sprt, s3, dir);
-            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 4);
+            collision_direction dir = calculate_collision_direction(sprt, s3);
+            resolve_collision(sprt, s3, dir);
+            draw_rect_perimeter_by_collision(sprite_collision_rectangle(sprt), dir, COLOR_RED, 4);
         }
 
         if (sprite_collision(sprt, s4))
         {
-            collision_direction dir = sprite_collision_direction(sprt, s4);
-            resolve_sprite_collision(sprt, s4, dir);
-            draw_sprite_perimeter_by_collision(sprt, dir, COLOR_RED, 4);
+            collision_direction dir = calculate_collision_direction(sprt, s4);
+            resolve_collision(sprt, s4, dir);
+            draw_rect_perimeter_by_collision(sprite_collision_rectangle(sprt), dir, COLOR_RED, 4);
         }
 
         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(sprt));
@@ -276,23 +280,59 @@ void sprite_test()
     close_all_windows();
 }
 
-void sprite_collision_resolution_test()
+void reset_sprite(sprite s)
 {
-    sprite collider, sprt_pixel, sprt_AABB;
+    sprite_set_x(s, 300.0);
+    sprite_set_y(s, 300.0);
+    sprite_set_rotation(s, 0.0f);
+    sprite_set_scale(s, 1.0f);
+    sprite_set_dx(s, 0.0);
+    sprite_set_dy(s, 0.0);
+    sprite_set_collision_kind(s, PIXEL_COLLISIONS);
+}
+
+void reset_rectangle(rectangle &r)
+{
+    r = rectangle_from(300.0, 300.0, 150.0, 50.0);
+}
+
+void reset_circle(circle &c)
+{
+    c = circle_at(300.0, 300.0, 40.0);
+}
+
+void reset_triangle(triangle &t)
+{
+    t = triangle_from(300.0, 300.0, 400.0, 300.0, 350.0, 250.0);
+}
+
+void reset_quad(quad &q)
+{
+    rectangle r = rectangle_from(300, 300, 100, 50);
+    q = quad_from(r);
+    apply_matrix(matrix_multiply(translation_matrix(200.0, 50.0), rotation_matrix(45.0)), q);
+}
+
+void multi_object_collision_resolution_test()
+{
+    object_type collider_type = object_type::SPRITE;
+    sprite collider_sprt, sprt_pixel, sprt_AABB;
     bitmap bmp;
-    rectangle rect;
-    circle circ;
-    triangle tri;
-    quad q;
+    rectangle collider_rect, rect;
+    circle collider_circ, circ;
+    triangle collider_tri, tri;
+    quad collider_quad, q;
 
     open_window("Sprite Collision Resolution", 600, 600);
 
     hide_mouse();
 
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+    collider_sprt = create_sprite("rocket_sprt.png");
+    reset_sprite(collider_sprt);
+    reset_rectangle(collider_rect);
+    reset_circle(collider_circ);
+    reset_triangle(collider_tri);
+    reset_quad(collider_quad);
 
     sprt_pixel = create_sprite("rocket_sprt.png");
     sprite_set_x(sprt_pixel, 100.0);
@@ -318,30 +358,146 @@ void sprite_collision_resolution_test()
 
         clear_screen(COLOR_WHITE);
 
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+        // Change the object type with number keys
+        if (key_typed(NUM_1_KEY))
         {
+            collider_type = object_type::SPRITE;
+            reset_sprite(collider_sprt);
+        }
+        if (key_typed(NUM_2_KEY))
+        {
+            collider_type = object_type::RECTANGLE;
+            reset_rectangle(collider_rect);
+        }
+        if (key_typed(NUM_3_KEY))
+        {
+            collider_type = object_type::CIRCLE;
+            reset_circle(collider_circ);
+        }
+        if (key_typed(NUM_4_KEY))
+        {
+            collider_type = object_type::TRIANGLE;
+            reset_triangle(collider_tri);
+        }
+        if (key_typed(NUM_5_KEY))
+        {
+            collider_type = object_type::QUAD;
+            reset_quad(collider_quad);
+        }
+
+        if (collider_type == object_type::SPRITE)
+        {
+            if ( key_down(LEFT_KEY) )
+            sprite_set_rotation(collider_sprt, sprite_rotation(collider_sprt) - 5.0);
+
+            if ( key_down(RIGHT_KEY) )
+                sprite_set_rotation(collider_sprt, sprite_rotation(collider_sprt) + 5.0);
+
+            if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+            {
+                if ( key_down(UP_KEY) )
+                    sprite_set_scale(collider_sprt, sprite_scale(collider_sprt) + 0.1);
+
+                if ( key_down(DOWN_KEY) )
+                    sprite_set_scale(collider_sprt, sprite_scale(collider_sprt) - 0.1);
+            }
+            else
+            {
+                if ( key_down(UP_KEY) )
+                    sprite_set_dy(collider_sprt, sprite_dy(collider_sprt) - 0.1);
+
+                if ( key_down(DOWN_KEY) )
+                    sprite_set_dy(collider_sprt, sprite_dy(collider_sprt) + 0.1);
+            }
+
+            update_sprite(collider_sprt);
+        }
+        else if (collider_type == object_type::RECTANGLE)
+        {
+            if ( key_down(LEFT_KEY) )
+                collider_rect.x -= 1.0;
+
+            if ( key_down(RIGHT_KEY) )
+                collider_rect.x += 1.0;
+
             if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+                collider_rect.y -= 1.0;
 
             if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+                collider_rect.y += 1.0;
         }
-        else
+        else if (collider_type == object_type::CIRCLE)
         {
+            if ( key_down(LEFT_KEY) )
+                collider_circ.center.x -= 1.0;
+
+            if ( key_down(RIGHT_KEY) )
+                collider_circ.center.x += 1.0;
+
             if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+                collider_circ.center.y -= 1.0;
 
             if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+                collider_circ.center.y += 1.0;
         }
-
-        update_sprite(collider);
+        else if (collider_type == object_type::TRIANGLE)
+        {
+            if ( key_down(LEFT_KEY) )
+            {
+                collider_tri.points[0].x -= 1.0;
+                collider_tri.points[1].x -= 1.0;
+                collider_tri.points[2].x -= 1.0;
+            }
+            if ( key_down(RIGHT_KEY) )
+            {
+                collider_tri.points[0].x += 1.0;
+                collider_tri.points[1].x += 1.0;
+                collider_tri.points[2].x += 1.0;
+            }
+            if ( key_down(UP_KEY) )
+            {
+                collider_tri.points[0].y -= 1.0;
+                collider_tri.points[1].y -= 1.0;
+                collider_tri.points[2].y -= 1.0;
+            }
+            if ( key_down(DOWN_KEY) )
+            {
+                collider_tri.points[0].y += 1.0;
+                collider_tri.points[1].y += 1.0;
+                collider_tri.points[2].y += 1.0;
+            }
+        }
+        else if (collider_type == object_type::QUAD)
+        {
+            if ( key_down(LEFT_KEY) )
+            {
+                collider_quad.points[0].x -= 1.0;
+                collider_quad.points[1].x -= 1.0;
+                collider_quad.points[2].x -= 1.0;
+                collider_quad.points[3].x -= 1.0;
+            }
+            if ( key_down(RIGHT_KEY) )
+            {
+                collider_quad.points[0].x += 1.0;
+                collider_quad.points[1].x += 1.0;
+                collider_quad.points[2].x += 1.0;
+                collider_quad.points[3].x += 1.0;
+            }
+            if ( key_down(UP_KEY) )
+            {
+                collider_quad.points[0].y -= 1.0;
+                collider_quad.points[1].y -= 1.0;
+                collider_quad.points[2].y -= 1.0;
+                collider_quad.points[3].y -= 1.0;
+            }
+            if ( key_down(DOWN_KEY) )
+            {
+                collider_quad.points[0].y += 1.0;
+                collider_quad.points[1].y += 1.0;
+                collider_quad.points[2].y += 1.0;
+                collider_quad.points[3].y += 1.0;
+            }
+        }
 
         draw_rectangle(COLOR_RED, sprite_collision_rectangle(sprt_AABB));
         fill_rectangle(COLOR_GREEN, rect);
@@ -351,45 +507,210 @@ void sprite_collision_resolution_test()
         draw_sprite(sprt_pixel);
         draw_sprite(sprt_AABB);
 
-        if (sprite_collision(collider, sprt_pixel))
+        if (collider_type == object_type::SPRITE)
         {
-            collision_direction dir = sprite_collision_direction(collider, sprt_pixel);
-            resolve_sprite_collision(collider, sprt_pixel, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_AABB))
-        {
-            collision_direction dir = sprite_collision_direction(collider, sprt_AABB);
-            resolve_sprite_collision(collider, sprt_AABB, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect))
-        {
-            collision_direction dir = sprite_collision_direction(collider, rect);
-            resolve_sprite_collision(collider, rect, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ))
-        {
-            collision_direction dir = sprite_collision_direction(collider, circ);
-            resolve_sprite_collision(collider, circ, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri))
-        {
-            collision_direction dir = sprite_collision_direction(collider, tri);
-            resolve_sprite_collision(collider, tri, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, q))
-        {
-            collision_direction dir = sprite_collision_direction(collider, q);
-            resolve_sprite_collision(collider, q, dir);
-            draw_sprite_perimeter_by_collision(collider, dir, COLOR_RED, 4);
-        }
+            collision_direction dir = calculate_collision_direction(collider_sprt, sprt_pixel);
+            if (resolve_collision(collider_sprt, sprt_pixel, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
 
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+            dir = calculate_collision_direction(collider_sprt, sprt_AABB);
+            if (resolve_collision(collider_sprt, sprt_AABB, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_sprt, rect);
+            if (resolve_collision(collider_sprt, rect, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_sprt, circ);
+            if (resolve_collision(collider_sprt, circ, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_sprt, tri);
+            if (resolve_collision(collider_sprt, tri, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_sprt, q);
+            if (resolve_collision(collider_sprt, q, dir))
+            {
+                draw_rect_perimeter_by_collision(sprite_collision_rectangle(collider_sprt), dir, COLOR_RED, 4);
+            }
+
+            draw_sprite(collider_sprt);
+            draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider_sprt));
+        }
+        else if (collider_type == object_type::RECTANGLE)
+        {
+            collision_direction dir = calculate_collision_direction(collider_rect, sprt_pixel);
+            if (resolve_collision(collider_rect, sprt_pixel, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_rect, sprt_AABB);
+            if (resolve_collision(collider_rect, sprt_AABB, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_rect, rect);
+            if (resolve_collision(collider_rect, rect, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_rect, circ);
+            if (resolve_collision(collider_rect, circ, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_rect, tri);
+            if (resolve_collision(collider_rect, tri, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_rect, q);
+            if (resolve_collision(collider_rect, q, dir))
+            {
+                draw_rect_perimeter_by_collision(collider_rect, dir, COLOR_RED, 4);
+            }
+
+            fill_rectangle(COLOR_ORANGE, collider_rect);
+        }
+        else if (collider_type == object_type::CIRCLE)
+        {
+            collision_direction dir = calculate_collision_direction(collider_circ, sprt_pixel);
+            if (resolve_collision(collider_circ, sprt_pixel, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_circ, sprt_AABB);
+            if (resolve_collision(collider_circ, sprt_AABB, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_circ, rect);
+            if (resolve_collision(collider_circ, rect, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_circ, circ);
+            if (resolve_collision(collider_circ, circ, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_circ, tri);
+            if (resolve_collision(collider_circ, tri, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_circ, q);
+            if (resolve_collision(collider_circ, q, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_circ), dir, COLOR_RED, 4);
+            }
+
+            fill_circle(COLOR_ORANGE, collider_circ);
+            draw_rectangle(COLOR_GREEN, rectangle_around(collider_circ));
+        }
+        else if (collider_type == object_type::TRIANGLE)
+        {
+            collision_direction dir = calculate_collision_direction(collider_tri, sprt_pixel);
+            if (resolve_collision(collider_tri, sprt_pixel, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_tri, sprt_AABB);
+            if (resolve_collision(collider_tri, sprt_AABB, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_tri, rect);
+            if (resolve_collision(collider_tri, rect, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_tri, circ);
+            if (resolve_collision(collider_tri, circ, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_tri, tri);
+            if (resolve_collision(collider_tri, tri, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_tri, q);
+            if (resolve_collision(collider_tri, q, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_tri), dir, COLOR_RED, 4);
+            }
+
+            fill_triangle(COLOR_ORANGE, collider_tri);
+            draw_rectangle(COLOR_GREEN, rectangle_around(collider_tri));
+        }
+        else if (collider_type == object_type::QUAD)
+        {
+            collision_direction dir = calculate_collision_direction(collider_quad, sprt_pixel);
+            if (resolve_collision(collider_quad, sprt_pixel, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_quad, sprt_AABB);
+            if (resolve_collision(collider_quad, sprt_AABB, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_quad, rect);
+            if (resolve_collision(collider_quad, rect, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_quad, circ);
+            if (resolve_collision(collider_quad, circ, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_quad, tri);
+            if (resolve_collision(collider_quad, tri, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            dir = calculate_collision_direction(collider_quad, q);
+            if (resolve_collision(collider_quad, q, dir))
+            {
+                draw_rect_perimeter_by_collision(rectangle_around(collider_quad), dir, COLOR_RED, 4);
+            }
+
+            fill_quad(COLOR_ORANGE, collider_quad);
+            draw_rectangle(COLOR_GREEN, rectangle_around(collider_quad));
+        }
 
         refresh_screen(60);
     }
@@ -399,632 +720,633 @@ void sprite_collision_resolution_test()
     close_all_windows();
 }
 
-void sprite_sprite_collision_resolution_direction_test()
-{
-    sprite collider, sprt_TOP, sprt_BOTTOM, sprt_LEFT, sprt_RIGHT, sprt_TOP_LEFT,
-        sprt_TOP_RIGHT, sprt_BOTTOM_LEFT, sprt_BOTTOM_RIGHT;
-
-    open_window("Sprite-Sprite Collision Resolution Fixed Direction", 600, 600);
-
-    hide_mouse();
-
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
-
-    sprt_TOP = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_TOP, 300.0);
-    sprite_set_y(sprt_TOP, 100.0);
-    sprite_set_collision_kind(sprt_TOP, PIXEL_COLLISIONS);
-
-    sprt_BOTTOM = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_BOTTOM, 300.0);
-    sprite_set_y(sprt_BOTTOM, 500.0);
-    sprite_set_collision_kind(sprt_BOTTOM, PIXEL_COLLISIONS);
-
-    sprt_LEFT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_LEFT, 100.0);
-    sprite_set_y(sprt_LEFT, 300.0);
-    sprite_set_collision_kind(sprt_LEFT, PIXEL_COLLISIONS);
-
-    sprt_RIGHT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_RIGHT, 500.0);
-    sprite_set_y(sprt_RIGHT, 300.0);
-    sprite_set_collision_kind(sprt_RIGHT, PIXEL_COLLISIONS);
-
-    sprt_TOP_LEFT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_TOP_LEFT, 100.0);
-    sprite_set_y(sprt_TOP_LEFT, 100.0);
-    sprite_set_collision_kind(sprt_TOP_LEFT, PIXEL_COLLISIONS);
-
-    sprt_TOP_RIGHT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_TOP_RIGHT, 500.0);
-    sprite_set_y(sprt_TOP_RIGHT, 100.0);
-    sprite_set_collision_kind(sprt_TOP_RIGHT, PIXEL_COLLISIONS);
-
-    sprt_BOTTOM_LEFT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_BOTTOM_LEFT, 100.0);
-    sprite_set_y(sprt_BOTTOM_LEFT, 500.0);
-    sprite_set_collision_kind(sprt_BOTTOM_LEFT, PIXEL_COLLISIONS);
-
-    sprt_BOTTOM_RIGHT = create_sprite("rocket_sprt.png");
-    sprite_set_x(sprt_BOTTOM_RIGHT, 500.0);
-    sprite_set_y(sprt_BOTTOM_RIGHT, 500.0);
-    sprite_set_collision_kind(sprt_BOTTOM_RIGHT, PIXEL_COLLISIONS);
-
-    while (! quit_requested())
-    {
-        process_events();
-
-        clear_screen(COLOR_WHITE);
-
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
-        }
-        else
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
-        }
-
-        update_sprite(collider);
-
-        draw_sprite(sprt_TOP);
-        draw_sprite(sprt_BOTTOM);
-        draw_sprite(sprt_LEFT);
-        draw_sprite(sprt_RIGHT);
-        draw_sprite(sprt_TOP_LEFT);
-        draw_sprite(sprt_TOP_RIGHT);
-        draw_sprite(sprt_BOTTOM_LEFT);
-        draw_sprite(sprt_BOTTOM_RIGHT);
-
-        if (sprite_collision(collider, sprt_TOP))
-        {
-            resolve_sprite_collision(collider, sprt_TOP, collision_direction::TOP);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_BOTTOM))
-        {
-            resolve_sprite_collision(collider, sprt_BOTTOM, collision_direction::BOTTOM);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_LEFT))
-        {
-            resolve_sprite_collision(collider, sprt_LEFT, collision_direction::LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_RIGHT))
-        {
-            resolve_sprite_collision(collider, sprt_RIGHT, collision_direction::RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_TOP_LEFT))
-        {
-            resolve_sprite_collision(collider, sprt_TOP_LEFT, collision_direction::TOP_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_TOP_RIGHT))
-        {
-            resolve_sprite_collision(collider, sprt_TOP_RIGHT, collision_direction::TOP_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_BOTTOM_LEFT))
-        {
-            resolve_sprite_collision(collider, sprt_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_collision(collider, sprt_BOTTOM_RIGHT))
-        {
-            resolve_sprite_collision(collider, sprt_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
-        }
-
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
-
-        refresh_screen(60);
-    }
-
-    show_mouse();
-
-    close_all_windows();
-}
-
-void sprite_rectangle_collision_resolution_direction_test()
-{
-    sprite collider;
-    rectangle rect_TOP, rect_BOTTOM, rect_LEFT, rect_RIGHT, rect_TOP_LEFT,
-        rect_TOP_RIGHT, rect_BOTTOM_LEFT, rect_BOTTOM_RIGHT;
-
-    open_window("Sprite-Rectangle Collision Resolution Fixed Direction", 600, 600);
-
-    hide_mouse();
-
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
-
-    rect_TOP = rectangle_from(300.0, 100.0, 100.0, 50.0);
-    rect_BOTTOM = rectangle_from(300.0, 500.0, 100.0, 50.0);
-    rect_LEFT = rectangle_from(100.0, 300.0, 50.0, 100.0);
-    rect_RIGHT = rectangle_from(500.0, 300.0, 50.0, 100.0);
-    rect_TOP_LEFT = rectangle_from(100.0, 100.0, 50.0, 50.0);
-    rect_TOP_RIGHT = rectangle_from(500.0, 100.0, 50.0, 50.0);
-    rect_BOTTOM_LEFT = rectangle_from(100.0, 500.0, 50.0, 50.0);
-    rect_BOTTOM_RIGHT = rectangle_from(500.0, 500.0, 50.0, 50.0);
-
-    while (! quit_requested())
-    {
-        process_events();
-
-        clear_screen(COLOR_WHITE);
-
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
-        }
-        else
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
-        }
-
-        update_sprite(collider);
-
-        fill_rectangle(COLOR_GREEN, rect_TOP);
-        fill_rectangle(COLOR_GREEN, rect_BOTTOM);
-        fill_rectangle(COLOR_GREEN, rect_LEFT);
-        fill_rectangle(COLOR_GREEN, rect_RIGHT);
-        fill_rectangle(COLOR_GREEN, rect_TOP_LEFT);
-        fill_rectangle(COLOR_GREEN, rect_TOP_RIGHT);
-        fill_rectangle(COLOR_GREEN, rect_BOTTOM_LEFT);
-        fill_rectangle(COLOR_GREEN, rect_BOTTOM_RIGHT);
-
-        if (sprite_rectangle_collision(collider, rect_TOP))
-        {
-            resolve_sprite_collision(collider, rect_TOP, collision_direction::TOP);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_BOTTOM))
-        {
-            resolve_sprite_collision(collider, rect_BOTTOM, collision_direction::BOTTOM);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_LEFT))
-        {
-            resolve_sprite_collision(collider, rect_LEFT, collision_direction::LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_RIGHT))
-        {
-            resolve_sprite_collision(collider, rect_RIGHT, collision_direction::RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_TOP_LEFT))
-        {
-            resolve_sprite_collision(collider, rect_TOP_LEFT, collision_direction::TOP_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_TOP_RIGHT))
-        {
-            resolve_sprite_collision(collider, rect_TOP_RIGHT, collision_direction::TOP_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_BOTTOM_LEFT))
-        {
-            resolve_sprite_collision(collider, rect_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_rectangle_collision(collider, rect_BOTTOM_RIGHT))
-        {
-            resolve_sprite_collision(collider, rect_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
-        }
-
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
-
-        refresh_screen(60);
-    }
-
-    show_mouse();
-
-    close_all_windows();
-}
-
-void sprite_circle_collision_resolution_direction_test()
-{
-    sprite collider;
-    circle circ_TOP, circ_BOTTOM, circ_LEFT, circ_RIGHT, circ_TOP_LEFT,
-        circ_TOP_RIGHT, circ_BOTTOM_LEFT, circ_BOTTOM_RIGHT;
-
-    open_window("Sprite-Circle Collision Resolution Fixed Direction", 600, 600);
-
-    hide_mouse();
-
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
-
-    circ_TOP = circle_at(300.0, 100.0, 50.0);
-    circ_BOTTOM = circle_at(300.0, 500.0, 50.0);
-    circ_LEFT = circle_at(100.0, 300.0, 50.0);
-    circ_RIGHT = circle_at(500.0, 300.0, 50.0);
-    circ_TOP_LEFT = circle_at(100.0, 100.0, 50.0);
-    circ_TOP_RIGHT = circle_at(500.0, 100.0, 50.0);
-    circ_BOTTOM_LEFT = circle_at(100.0, 500.0, 50.0);
-    circ_BOTTOM_RIGHT = circle_at(500.0, 500.0, 50.0);
-
-    while (! quit_requested())
-    {
-        process_events();
-
-        clear_screen(COLOR_WHITE);
-
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
-        }
-        else
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
-        }
-
-        update_sprite(collider);
-
-        fill_circle(COLOR_GREEN, circ_TOP);
-        fill_circle(COLOR_GREEN, circ_BOTTOM);
-        fill_circle(COLOR_GREEN, circ_LEFT);
-        fill_circle(COLOR_GREEN, circ_RIGHT);
-        fill_circle(COLOR_GREEN, circ_TOP_LEFT);
-        fill_circle(COLOR_GREEN, circ_TOP_RIGHT);
-        fill_circle(COLOR_GREEN, circ_BOTTOM_LEFT);
-        fill_circle(COLOR_GREEN, circ_BOTTOM_RIGHT);
-
-        if (sprite_circle_collision(collider, circ_TOP))
-        {
-            resolve_sprite_collision(collider, circ_TOP, collision_direction::TOP);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_BOTTOM))
-        {
-            resolve_sprite_collision(collider, circ_BOTTOM, collision_direction::BOTTOM);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_LEFT))
-        {
-            resolve_sprite_collision(collider, circ_LEFT, collision_direction::LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_RIGHT))
-        {
-            resolve_sprite_collision(collider, circ_RIGHT, collision_direction::RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_TOP_LEFT))
-        {
-            resolve_sprite_collision(collider, circ_TOP_LEFT, collision_direction::TOP_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_TOP_RIGHT))
-        {
-            resolve_sprite_collision(collider, circ_TOP_RIGHT, collision_direction::TOP_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_BOTTOM_LEFT))
-        {
-            resolve_sprite_collision(collider, circ_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_circle_collision(collider, circ_BOTTOM_RIGHT))
-        {
-            resolve_sprite_collision(collider, circ_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
-        }
-
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
-
-        refresh_screen(60);
-    }
-
-    show_mouse();
-
-    close_all_windows();
-}
-
-void sprite_triangle_collision_resolution_direction_test()
-{
-    sprite collider;
-    triangle tri_TOP, tri_BOTTOM, tri_LEFT, tri_RIGHT, tri_TOP_LEFT,
-        tri_TOP_RIGHT, tri_BOTTOM_LEFT, tri_BOTTOM_RIGHT;
-
-    open_window("Sprite-Triangle Collision Resolution Fixed Direction", 600, 600);
-
-    hide_mouse();
-
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
-
-    tri_TOP = triangle_from(300.0, 100.0, 400.0, 100.0, 350.0, 150.0);
-    tri_BOTTOM = triangle_from(300.0, 500.0, 400.0, 500.0, 350.0, 450.0);
-    tri_LEFT = triangle_from(100.0, 300.0, 100.0, 400.0, 150.0, 350.0);
-    tri_RIGHT = triangle_from(500.0, 300.0, 500.0, 400.0, 450.0, 350.0);
-    tri_TOP_LEFT = triangle_from(100.0, 150.0, 150.0, 100.0, 150.0, 150.0);
-    tri_TOP_RIGHT = triangle_from(500.0, 150.0, 450.0, 100.0, 450.0, 150.0);
-    tri_BOTTOM_LEFT = triangle_from(100.0, 450.0, 150.0, 500.0, 150.0, 450.0);
-    tri_BOTTOM_RIGHT = triangle_from(500.0, 450.0, 450.0, 500.0, 450.0, 450.0);
-
-    while (! quit_requested())
-    {
-        process_events();
-
-        clear_screen(COLOR_WHITE);
-
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
-        }
-        else
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
-        }
-
-        update_sprite(collider);
-
-        fill_triangle(COLOR_GREEN, tri_TOP);
-        fill_triangle(COLOR_GREEN, tri_BOTTOM);
-        fill_triangle(COLOR_GREEN, tri_LEFT);
-        fill_triangle(COLOR_GREEN, tri_RIGHT);
-        fill_triangle(COLOR_GREEN, tri_TOP_LEFT);
-        fill_triangle(COLOR_GREEN, tri_TOP_RIGHT);
-        fill_triangle(COLOR_GREEN, tri_BOTTOM_LEFT);
-        fill_triangle(COLOR_GREEN, tri_BOTTOM_RIGHT);
-
-        if (sprite_triangle_collision(collider, tri_TOP))
-        {
-            resolve_sprite_collision(collider, tri_TOP, collision_direction::TOP);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_BOTTOM))
-        {
-            resolve_sprite_collision(collider, tri_BOTTOM, collision_direction::BOTTOM);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_LEFT))
-        {
-            resolve_sprite_collision(collider, tri_LEFT, collision_direction::LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_RIGHT))
-        {
-            resolve_sprite_collision(collider, tri_RIGHT, collision_direction::RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_TOP_LEFT))
-        {
-            resolve_sprite_collision(collider, tri_TOP_LEFT, collision_direction::TOP_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_TOP_RIGHT))
-        {
-            resolve_sprite_collision(collider, tri_TOP_RIGHT, collision_direction::TOP_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_BOTTOM_LEFT))
-        {
-            resolve_sprite_collision(collider, tri_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_triangle_collision(collider, tri_BOTTOM_RIGHT))
-        {
-            resolve_sprite_collision(collider, tri_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
-        }
-
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
-
-        refresh_screen(60);
-    }
-
-    show_mouse();
-
-    close_all_windows();
-}
-
-void sprite_quad_collision_resolution_direction_test()
-{
-    sprite collider;
-    quad quad_TOP, quad_BOTTOM, quad_LEFT, quad_RIGHT, quad_TOP_LEFT,
-        quad_TOP_RIGHT, quad_BOTTOM_LEFT, quad_BOTTOM_RIGHT;
-
-    open_window("Sprite-Quad Collision Resolution Fixed Direction", 600, 600);
-
-    hide_mouse();
-
-    collider = create_sprite("rocket_sprt.png");
-    sprite_set_x(collider, 300.0);
-    sprite_set_y(collider, 300.0);
-    sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
-
-    rectangle r = rectangle_from(0.0, 0.0, 100.0, 50.0);
-    quad_TOP = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 20.0)), quad_TOP);
-    quad_BOTTOM = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 470.0)), quad_BOTTOM);
-    quad_LEFT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 270.0)), quad_LEFT);
-    quad_RIGHT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 270.0)), quad_RIGHT);
-    quad_TOP_LEFT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 20.0)), quad_TOP_LEFT);
-    quad_TOP_RIGHT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 20.0)), quad_TOP_RIGHT);
-    quad_BOTTOM_LEFT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 470.0)), quad_BOTTOM_LEFT);
-    quad_BOTTOM_RIGHT = quad_from(r);
-    apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 470.0)), quad_BOTTOM_RIGHT);
-
-    while (! quit_requested())
-    {
-        process_events();
-
-        clear_screen(COLOR_WHITE);
-
-        if ( key_down(LEFT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
-
-        if ( key_down(RIGHT_KEY) )
-            sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
-
-        if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) + 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_scale(collider, sprite_scale(collider) - 0.1);
-        }
-        else
-        {
-            if ( key_down(UP_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) - 0.1);
-
-            if ( key_down(DOWN_KEY) )
-                sprite_set_dy(collider, sprite_dy(collider) + 0.1);
-        }
-
-        update_sprite(collider);
-
-        fill_quad(COLOR_GREEN, quad_TOP);
-        fill_quad(COLOR_GREEN, quad_BOTTOM);
-        fill_quad(COLOR_GREEN, quad_LEFT);
-        fill_quad(COLOR_GREEN, quad_RIGHT);
-        fill_quad(COLOR_GREEN, quad_TOP_LEFT);
-        fill_quad(COLOR_GREEN, quad_TOP_RIGHT);
-        fill_quad(COLOR_GREEN, quad_BOTTOM_LEFT);
-        fill_quad(COLOR_GREEN, quad_BOTTOM_RIGHT);
-
-        if (sprite_quad_collision(collider, quad_TOP))
-        {
-            resolve_sprite_collision(collider, quad_TOP, collision_direction::TOP);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_BOTTOM))
-        {
-            resolve_sprite_collision(collider, quad_BOTTOM, collision_direction::BOTTOM);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_LEFT))
-        {
-            resolve_sprite_collision(collider, quad_LEFT, collision_direction::LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_RIGHT))
-        {
-            resolve_sprite_collision(collider, quad_RIGHT, collision_direction::RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_TOP_LEFT))
-        {
-            resolve_sprite_collision(collider, quad_TOP_LEFT, collision_direction::TOP_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_TOP_RIGHT))
-        {
-            resolve_sprite_collision(collider, quad_TOP_RIGHT, collision_direction::TOP_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_BOTTOM_LEFT))
-        {
-            resolve_sprite_collision(collider, quad_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
-        }
-        if (sprite_quad_collision(collider, quad_BOTTOM_RIGHT))
-        {
-            resolve_sprite_collision(collider, quad_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
-            draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
-        }
-
-        draw_sprite(collider);
-        draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
-
-        refresh_screen(60);
-    }
-
-    show_mouse();
-
-    close_all_windows();
-}
+// void sprite_sprite_collision_resolution_direction_test()
+// {
+//     sprite collider, sprt_TOP, sprt_BOTTOM, sprt_LEFT, sprt_RIGHT, sprt_TOP_LEFT,
+//         sprt_TOP_RIGHT, sprt_BOTTOM_LEFT, sprt_BOTTOM_RIGHT;
+
+//     open_window("Sprite-Sprite Collision Resolution Fixed Direction", 600, 600);
+
+//     hide_mouse();
+
+//     collider = create_sprite("rocket_sprt.png");
+//     sprite_set_x(collider, 300.0);
+//     sprite_set_y(collider, 300.0);
+//     sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+//     sprt_TOP = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_TOP, 300.0);
+//     sprite_set_y(sprt_TOP, 100.0);
+//     sprite_set_collision_kind(sprt_TOP, PIXEL_COLLISIONS);
+
+//     sprt_BOTTOM = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_BOTTOM, 300.0);
+//     sprite_set_y(sprt_BOTTOM, 500.0);
+//     sprite_set_collision_kind(sprt_BOTTOM, PIXEL_COLLISIONS);
+
+//     sprt_LEFT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_LEFT, 100.0);
+//     sprite_set_y(sprt_LEFT, 300.0);
+//     sprite_set_collision_kind(sprt_LEFT, PIXEL_COLLISIONS);
+
+//     sprt_RIGHT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_RIGHT, 500.0);
+//     sprite_set_y(sprt_RIGHT, 300.0);
+//     sprite_set_collision_kind(sprt_RIGHT, PIXEL_COLLISIONS);
+
+//     sprt_TOP_LEFT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_TOP_LEFT, 100.0);
+//     sprite_set_y(sprt_TOP_LEFT, 100.0);
+//     sprite_set_collision_kind(sprt_TOP_LEFT, PIXEL_COLLISIONS);
+
+//     sprt_TOP_RIGHT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_TOP_RIGHT, 500.0);
+//     sprite_set_y(sprt_TOP_RIGHT, 100.0);
+//     sprite_set_collision_kind(sprt_TOP_RIGHT, PIXEL_COLLISIONS);
+
+//     sprt_BOTTOM_LEFT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_BOTTOM_LEFT, 100.0);
+//     sprite_set_y(sprt_BOTTOM_LEFT, 500.0);
+//     sprite_set_collision_kind(sprt_BOTTOM_LEFT, PIXEL_COLLISIONS);
+
+//     sprt_BOTTOM_RIGHT = create_sprite("rocket_sprt.png");
+//     sprite_set_x(sprt_BOTTOM_RIGHT, 500.0);
+//     sprite_set_y(sprt_BOTTOM_RIGHT, 500.0);
+//     sprite_set_collision_kind(sprt_BOTTOM_RIGHT, PIXEL_COLLISIONS);
+
+//     while (! quit_requested())
+//     {
+//         process_events();
+
+//         clear_screen(COLOR_WHITE);
+
+//         if ( key_down(LEFT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+//         if ( key_down(RIGHT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+//         if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+//         }
+//         else
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+//         }
+
+//         update_sprite(collider);
+
+//         draw_sprite(sprt_TOP);
+//         draw_sprite(sprt_BOTTOM);
+//         draw_sprite(sprt_LEFT);
+//         draw_sprite(sprt_RIGHT);
+//         draw_sprite(sprt_TOP_LEFT);
+//         draw_sprite(sprt_TOP_RIGHT);
+//         draw_sprite(sprt_BOTTOM_LEFT);
+//         draw_sprite(sprt_BOTTOM_RIGHT);
+
+//         if (sprite_collision(collider, sprt_TOP))
+//         {
+//             resolve_collision(collider, sprt_TOP, collision_direction::TOP);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_BOTTOM))
+//         {
+//             resolve_collision(collider, sprt_BOTTOM, collision_direction::BOTTOM);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_LEFT))
+//         {
+//             resolve_collision(collider, sprt_LEFT, collision_direction::LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_RIGHT))
+//         {
+//             resolve_collision(collider, sprt_RIGHT, collision_direction::RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_TOP_LEFT))
+//         {
+//             resolve_collision(collider, sprt_TOP_LEFT, collision_direction::TOP_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_TOP_RIGHT))
+//         {
+//             resolve_collision(collider, sprt_TOP_RIGHT, collision_direction::TOP_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_BOTTOM_LEFT))
+//         {
+//             resolve_collision(collider, sprt_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_collision(collider, sprt_BOTTOM_RIGHT))
+//         {
+//             resolve_collision(collider, sprt_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+//         }
+
+//         draw_sprite(collider);
+//         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+//         refresh_screen(60);
+//     }
+
+//     show_mouse();
+
+//     close_all_windows();
+// }
+
+// void sprite_rectangle_collision_resolution_direction_test()
+// {
+//     sprite collider;
+//     rectangle rect_TOP, rect_BOTTOM, rect_LEFT, rect_RIGHT, rect_TOP_LEFT,
+//         rect_TOP_RIGHT, rect_BOTTOM_LEFT, rect_BOTTOM_RIGHT;
+
+//     open_window("Sprite-Rectangle Collision Resolution Fixed Direction", 600, 600);
+
+//     hide_mouse();
+
+//     collider = create_sprite("rocket_sprt.png");
+//     sprite_set_x(collider, 300.0);
+//     sprite_set_y(collider, 300.0);
+//     sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+//     rect_TOP = rectangle_from(300.0, 100.0, 100.0, 50.0);
+//     rect_BOTTOM = rectangle_from(300.0, 500.0, 100.0, 50.0);
+//     rect_LEFT = rectangle_from(100.0, 300.0, 50.0, 100.0);
+//     rect_RIGHT = rectangle_from(500.0, 300.0, 50.0, 100.0);
+//     rect_TOP_LEFT = rectangle_from(100.0, 100.0, 50.0, 50.0);
+//     rect_TOP_RIGHT = rectangle_from(500.0, 100.0, 50.0, 50.0);
+//     rect_BOTTOM_LEFT = rectangle_from(100.0, 500.0, 50.0, 50.0);
+//     rect_BOTTOM_RIGHT = rectangle_from(500.0, 500.0, 50.0, 50.0);
+
+//     while (! quit_requested())
+//     {
+//         process_events();
+
+//         clear_screen(COLOR_WHITE);
+
+//         if ( key_down(LEFT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+//         if ( key_down(RIGHT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+//         if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+//         }
+//         else
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+//         }
+
+//         update_sprite(collider);
+
+//         fill_rectangle(COLOR_GREEN, rect_TOP);
+//         fill_rectangle(COLOR_GREEN, rect_BOTTOM);
+//         fill_rectangle(COLOR_GREEN, rect_LEFT);
+//         fill_rectangle(COLOR_GREEN, rect_RIGHT);
+//         fill_rectangle(COLOR_GREEN, rect_TOP_LEFT);
+//         fill_rectangle(COLOR_GREEN, rect_TOP_RIGHT);
+//         fill_rectangle(COLOR_GREEN, rect_BOTTOM_LEFT);
+//         fill_rectangle(COLOR_GREEN, rect_BOTTOM_RIGHT);
+
+//         if (sprite_rectangle_collision(collider, rect_TOP))
+//         {
+//             resolve_collision(collider, rect_TOP, collision_direction::TOP);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_BOTTOM))
+//         {
+//             resolve_collision(collider, rect_BOTTOM, collision_direction::BOTTOM);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_LEFT))
+//         {
+//             resolve_collision(collider, rect_LEFT, collision_direction::LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_RIGHT))
+//         {
+//             resolve_collision(collider, rect_RIGHT, collision_direction::RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_TOP_LEFT))
+//         {
+//             resolve_collision(collider, rect_TOP_LEFT, collision_direction::TOP_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_TOP_RIGHT))
+//         {
+//             resolve_collision(collider, rect_TOP_RIGHT, collision_direction::TOP_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_BOTTOM_LEFT))
+//         {
+//             resolve_collision(collider, rect_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_rectangle_collision(collider, rect_BOTTOM_RIGHT))
+//         {
+//             resolve_collision(collider, rect_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+//         }
+
+//         draw_sprite(collider);
+//         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+//         refresh_screen(60);
+//     }
+
+//     show_mouse();
+
+//     close_all_windows();
+// }
+
+// void sprite_circle_collision_resolution_direction_test()
+// {
+//     sprite collider;
+//     circle circ_TOP, circ_BOTTOM, circ_LEFT, circ_RIGHT, circ_TOP_LEFT,
+//         circ_TOP_RIGHT, circ_BOTTOM_LEFT, circ_BOTTOM_RIGHT;
+
+//     open_window("Sprite-Circle Collision Resolution Fixed Direction", 600, 600);
+
+//     hide_mouse();
+
+//     collider = create_sprite("rocket_sprt.png");
+//     sprite_set_x(collider, 300.0);
+//     sprite_set_y(collider, 300.0);
+//     sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+//     circ_TOP = circle_at(300.0, 100.0, 50.0);
+//     circ_BOTTOM = circle_at(300.0, 500.0, 50.0);
+//     circ_LEFT = circle_at(100.0, 300.0, 50.0);
+//     circ_RIGHT = circle_at(500.0, 300.0, 50.0);
+//     circ_TOP_LEFT = circle_at(100.0, 100.0, 50.0);
+//     circ_TOP_RIGHT = circle_at(500.0, 100.0, 50.0);
+//     circ_BOTTOM_LEFT = circle_at(100.0, 500.0, 50.0);
+//     circ_BOTTOM_RIGHT = circle_at(500.0, 500.0, 50.0);
+
+//     while (! quit_requested())
+//     {
+//         process_events();
+
+//         clear_screen(COLOR_WHITE);
+
+//         if ( key_down(LEFT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+//         if ( key_down(RIGHT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+//         if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+//         }
+//         else
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+//         }
+
+//         update_sprite(collider);
+
+//         fill_circle(COLOR_GREEN, circ_TOP);
+//         fill_circle(COLOR_GREEN, circ_BOTTOM);
+//         fill_circle(COLOR_GREEN, circ_LEFT);
+//         fill_circle(COLOR_GREEN, circ_RIGHT);
+//         fill_circle(COLOR_GREEN, circ_TOP_LEFT);
+//         fill_circle(COLOR_GREEN, circ_TOP_RIGHT);
+//         fill_circle(COLOR_GREEN, circ_BOTTOM_LEFT);
+//         fill_circle(COLOR_GREEN, circ_BOTTOM_RIGHT);
+
+//         if (sprite_circle_collision(collider, circ_TOP))
+//         {
+//             resolve_collision(collider, circ_TOP, collision_direction::TOP);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_BOTTOM))
+//         {
+//             resolve_collision(collider, circ_BOTTOM, collision_direction::BOTTOM);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_LEFT))
+//         {
+//             resolve_collision(collider, circ_LEFT, collision_direction::LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_RIGHT))
+//         {
+//             resolve_collision(collider, circ_RIGHT, collision_direction::RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_TOP_LEFT))
+//         {
+//             resolve_collision(collider, circ_TOP_LEFT, collision_direction::TOP_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_TOP_RIGHT))
+//         {
+//             resolve_collision(collider, circ_TOP_RIGHT, collision_direction::TOP_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_BOTTOM_LEFT))
+//         {
+//             resolve_collision(collider, circ_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_circle_collision(collider, circ_BOTTOM_RIGHT))
+//         {
+//             resolve_collision(collider, circ_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+//         }
+
+//         draw_sprite(collider);
+//         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+//         refresh_screen(60);
+//     }
+
+//     show_mouse();
+
+//     close_all_windows();
+// }
+
+// void sprite_triangle_collision_resolution_direction_test()
+// {
+//     sprite collider;
+//     triangle tri_TOP, tri_BOTTOM, tri_LEFT, tri_RIGHT, tri_TOP_LEFT,
+//         tri_TOP_RIGHT, tri_BOTTOM_LEFT, tri_BOTTOM_RIGHT;
+
+//     open_window("Sprite-Triangle Collision Resolution Fixed Direction", 600, 600);
+
+//     hide_mouse();
+
+//     collider = create_sprite("rocket_sprt.png");
+//     sprite_set_x(collider, 300.0);
+//     sprite_set_y(collider, 300.0);
+//     sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+//     tri_TOP = triangle_from(300.0, 100.0, 400.0, 100.0, 350.0, 150.0);
+//     tri_BOTTOM = triangle_from(300.0, 500.0, 400.0, 500.0, 350.0, 450.0);
+//     tri_LEFT = triangle_from(100.0, 300.0, 100.0, 400.0, 150.0, 350.0);
+//     tri_RIGHT = triangle_from(500.0, 300.0, 500.0, 400.0, 450.0, 350.0);
+//     tri_TOP_LEFT = triangle_from(100.0, 150.0, 150.0, 100.0, 150.0, 150.0);
+//     tri_TOP_RIGHT = triangle_from(500.0, 150.0, 450.0, 100.0, 450.0, 150.0);
+//     tri_BOTTOM_LEFT = triangle_from(100.0, 450.0, 150.0, 500.0, 150.0, 450.0);
+//     tri_BOTTOM_RIGHT = triangle_from(500.0, 450.0, 450.0, 500.0, 450.0, 450.0);
+
+//     while (! quit_requested())
+//     {
+//         process_events();
+
+//         clear_screen(COLOR_WHITE);
+
+//         if ( key_down(LEFT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+//         if ( key_down(RIGHT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+//         if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+//         }
+//         else
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+//         }
+
+//         update_sprite(collider);
+
+//         fill_triangle(COLOR_GREEN, tri_TOP);
+//         fill_triangle(COLOR_GREEN, tri_BOTTOM);
+//         fill_triangle(COLOR_GREEN, tri_LEFT);
+//         fill_triangle(COLOR_GREEN, tri_RIGHT);
+//         fill_triangle(COLOR_GREEN, tri_TOP_LEFT);
+//         fill_triangle(COLOR_GREEN, tri_TOP_RIGHT);
+//         fill_triangle(COLOR_GREEN, tri_BOTTOM_LEFT);
+//         fill_triangle(COLOR_GREEN, tri_BOTTOM_RIGHT);
+
+//         if (sprite_triangle_collision(collider, tri_TOP))
+//         {
+//             resolve_collision(collider, tri_TOP, collision_direction::TOP);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_BOTTOM))
+//         {
+//             resolve_collision(collider, tri_BOTTOM, collision_direction::BOTTOM);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_LEFT))
+//         {
+//             resolve_collision(collider, tri_LEFT, collision_direction::LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_RIGHT))
+//         {
+//             resolve_collision(collider, tri_RIGHT, collision_direction::RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_TOP_LEFT))
+//         {
+//             resolve_collision(collider, tri_TOP_LEFT, collision_direction::TOP_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_TOP_RIGHT))
+//         {
+//             resolve_collision(collider, tri_TOP_RIGHT, collision_direction::TOP_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_BOTTOM_LEFT))
+//         {
+//             resolve_collision(collider, tri_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_triangle_collision(collider, tri_BOTTOM_RIGHT))
+//         {
+//             resolve_collision(collider, tri_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+//         }
+
+//         draw_sprite(collider);
+//         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+//         refresh_screen(60);
+//     }
+
+//     show_mouse();
+
+//     close_all_windows();
+// }
+
+// void sprite_quad_collision_resolution_direction_test()
+// {
+//     sprite collider;
+//     quad quad_TOP, quad_BOTTOM, quad_LEFT, quad_RIGHT, quad_TOP_LEFT,
+//         quad_TOP_RIGHT, quad_BOTTOM_LEFT, quad_BOTTOM_RIGHT;
+
+//     open_window("Sprite-Quad Collision Resolution Fixed Direction", 600, 600);
+
+//     hide_mouse();
+
+//     collider = create_sprite("rocket_sprt.png");
+//     sprite_set_x(collider, 300.0);
+//     sprite_set_y(collider, 300.0);
+//     sprite_set_collision_kind(collider, PIXEL_COLLISIONS);
+
+//     rectangle r = rectangle_from(0.0, 0.0, 100.0, 50.0);
+//     quad_TOP = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 20.0)), quad_TOP);
+//     quad_BOTTOM = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(300.0, 470.0)), quad_BOTTOM);
+//     quad_LEFT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 270.0)), quad_LEFT);
+//     quad_RIGHT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 270.0)), quad_RIGHT);
+//     quad_TOP_LEFT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 20.0)), quad_TOP_LEFT);
+//     quad_TOP_RIGHT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 20.0)), quad_TOP_RIGHT);
+//     quad_BOTTOM_LEFT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(50.0, 470.0)), quad_BOTTOM_LEFT);
+//     quad_BOTTOM_RIGHT = quad_from(r);
+//     apply_matrix(matrix_multiply(rotation_matrix(45.0), translation_matrix(500.0, 470.0)), quad_BOTTOM_RIGHT);
+
+//     while (! quit_requested())
+//     {
+//         process_events();
+
+//         clear_screen(COLOR_WHITE);
+
+//         if ( key_down(LEFT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) - 5.0);
+
+//         if ( key_down(RIGHT_KEY) )
+//             sprite_set_rotation(collider, sprite_rotation(collider) + 5.0);
+
+//         if ( key_down(LEFT_SHIFT_KEY) or key_down(RIGHT_SHIFT_KEY) )
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) + 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_scale(collider, sprite_scale(collider) - 0.1);
+//         }
+//         else
+//         {
+//             if ( key_down(UP_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) - 0.1);
+
+//             if ( key_down(DOWN_KEY) )
+//                 sprite_set_dy(collider, sprite_dy(collider) + 0.1);
+//         }
+
+//         update_sprite(collider);
+
+//         fill_quad(COLOR_GREEN, quad_TOP);
+//         fill_quad(COLOR_GREEN, quad_BOTTOM);
+//         fill_quad(COLOR_GREEN, quad_LEFT);
+//         fill_quad(COLOR_GREEN, quad_RIGHT);
+//         fill_quad(COLOR_GREEN, quad_TOP_LEFT);
+//         fill_quad(COLOR_GREEN, quad_TOP_RIGHT);
+//         fill_quad(COLOR_GREEN, quad_BOTTOM_LEFT);
+//         fill_quad(COLOR_GREEN, quad_BOTTOM_RIGHT);
+
+//         if (sprite_quad_collision(collider, quad_TOP))
+//         {
+//             resolve_collision(collider, quad_TOP, collision_direction::TOP);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_BOTTOM))
+//         {
+//             resolve_collision(collider, quad_BOTTOM, collision_direction::BOTTOM);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_LEFT))
+//         {
+//             resolve_collision(collider, quad_LEFT, collision_direction::LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_RIGHT))
+//         {
+//             resolve_collision(collider, quad_RIGHT, collision_direction::RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_TOP_LEFT))
+//         {
+//             resolve_collision(collider, quad_TOP_LEFT, collision_direction::TOP_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_TOP_RIGHT))
+//         {
+//             resolve_collision(collider, quad_TOP_RIGHT, collision_direction::TOP_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::TOP_RIGHT, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_BOTTOM_LEFT))
+//         {
+//             resolve_collision(collider, quad_BOTTOM_LEFT, collision_direction::BOTTOM_LEFT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_LEFT, COLOR_RED, 4);
+//         }
+//         if (sprite_quad_collision(collider, quad_BOTTOM_RIGHT))
+//         {
+//             resolve_collision(collider, quad_BOTTOM_RIGHT, collision_direction::BOTTOM_RIGHT);
+//             draw_sprite_perimeter_by_collision(collider, collision_direction::BOTTOM_RIGHT, COLOR_RED, 4);
+//         }
+
+//         draw_sprite(collider);
+//         draw_rectangle(COLOR_GREEN, sprite_collision_rectangle(collider));
+
+//         refresh_screen(60);
+//     }
+
+//     show_mouse();
+
+//     close_all_windows();
+// }
 
 void run_sprite_test()
 {
-    // sprite_test();
-    sprite_collision_resolution_test();
-    sprite_sprite_collision_resolution_direction_test();
-    sprite_rectangle_collision_resolution_direction_test();
-    sprite_circle_collision_resolution_direction_test();
-    sprite_triangle_collision_resolution_direction_test();
-    sprite_quad_collision_resolution_direction_test();
+    sprite_test();
+    multi_object_collision_resolution_test();
+    // sprite_collision_resolution_test();
+    // sprite_sprite_collision_resolution_direction_test();
+    // sprite_rectangle_collision_resolution_direction_test();
+    // sprite_circle_collision_resolution_direction_test();
+    // sprite_triangle_collision_resolution_direction_test();
+    // sprite_quad_collision_resolution_direction_test();
 }

--- a/coresdk/src/test/unit_tests/unit_test_geometry.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_geometry.cpp
@@ -13,10 +13,14 @@ constexpr double EPSILON = 1.0E-13;
 
 TEST_CASE("can perform circle geometry", "[geometry]")
 {
-   SECTION("can detect circle quad intersection")
+   SECTION("can detect circle-quad intersection")
    {
         circle c = circle_at(100.0, 100.0, 50.0);
         quad q = quad_from(rectangle_from(50.0, 50.0, 100.0, 100.0));
+        REQUIRE(circle_quad_intersect(c, q));
+        q = quad_from(rectangle_from(0.0, 0.0, 500.0, 500.0));
+        REQUIRE(circle_quad_intersect(c, q));
+        q = quad_from(rectangle_from(99.0, 99.0, 5.0, 5.0));
         REQUIRE(circle_quad_intersect(c, q));
         q = quad_from(rectangle_from(200.0, 200.0, 100.0, 100.0));
         REQUIRE_FALSE(circle_quad_intersect(c, q));
@@ -24,23 +28,44 @@ TEST_CASE("can perform circle geometry", "[geometry]")
 }
 TEST_CASE("can perform rectangle geometry", "[rectangle]")
 {
-    SECTION("can detect rectangle circle intersection")
+    SECTION("can detect rectangle-circle intersection")
     {
         rectangle r = rectangle_from(100.0, 100.0, 100.0, 100.0);
         circle c = circle_at(150.0, 150.0, 50.0);
         REQUIRE(rectangle_circle_intersect(r, c));
-        c = circle_at(200.0, 200.0, 50.0);
+        c = circle_at(150.0, 150.0, 1.0);
+        REQUIRE(rectangle_circle_intersect(r, c));
+        c = circle_at(150.0, 150.0, 500.0);
+        REQUIRE(rectangle_circle_intersect(r, c));
+        c = circle_at(300.0, 300.0, 50.0);
         REQUIRE_FALSE(rectangle_circle_intersect(r, c));
     }
 }
 TEST_CASE("can perform triangle geometry", "[triangle]")
 {
-    SECTION("can detect triangle quad intersection")
+    SECTION("can detect triangle-quad intersection")
     {
         triangle t = triangle_from(100.0, 100.0, 200.0, 100.0, 150.0, 150.0);
-        quad q = quad_from(50.0, 50.0, 150.0, 50.0, 50.0, 150.0, 150.0, 150.0);
+        quad q = quad_from(rectangle_from(50.0, 50.0, 100.0, 100.0));
         REQUIRE(triangle_quad_intersect(t, q));
-        q = quad_from(200.0, 200.0, 300.0, 200.0, 200.0, 300.0, 300.0, 300.0);
+        q = quad_from(rectangle_from(0.0, 0.0, 500.0, 500.0));
+        REQUIRE(triangle_quad_intersect(t, q)); 
+        q = quad_from(rectangle_from(150.0, 101.0, 5.0, 5.0));
+        REQUIRE(triangle_quad_intersect(t, q));
+        q = quad_from(rectangle_from(200.0, 200.0, 100.0, 100.0));
         REQUIRE_FALSE(triangle_quad_intersect(t, q));
+    }
+}
+TEST_CASE("can perform line geometry", "[line]")
+{
+    SECTION("can detect line-rectangle intersection")
+    {
+        line l = line_from(100.0, 100.0, 200.0, 200.0);
+        rectangle r = rectangle_from(150.0, 150.0, 100.0, 100.0);
+        REQUIRE(line_intersects_rect(l, r));
+        r = rectangle_from(90.0, 90.0, 200.0, 200.0);
+        REQUIRE(line_intersects_rect(l, r));
+        r = rectangle_from(250.0, 250.0, 100.0, 100.0);
+        REQUIRE_FALSE(line_intersects_rect(l, r));
     }
 }

--- a/coresdk/src/test/unit_tests/unit_test_geometry.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_geometry.cpp
@@ -9,8 +9,6 @@
 
 using namespace splashkit_lib;
 
-constexpr double EPSILON = 1.0E-13;
-
 TEST_CASE("can perform circle geometry", "[geometry]")
 {
    SECTION("can detect circle-quad intersection")

--- a/coresdk/src/test/unit_tests/unit_test_geometry.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_geometry.cpp
@@ -1,0 +1,46 @@
+/**
+ * Geometry Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "types.h"
+#include "point_geometry.h"
+
+using namespace splashkit_lib;
+
+constexpr double EPSILON = 1.0E-13;
+
+TEST_CASE("can perform circle geometry", "[geometry]")
+{
+   SECTION("can detect circle quad intersection")
+   {
+        circle c = circle_at(100.0, 100.0, 50.0);
+        quad q = quad_from(rectangle_from(50.0, 50.0, 100.0, 100.0));
+        REQUIRE(circle_quad_intersect(c, q));
+        q = quad_from(rectangle_from(200.0, 200.0, 100.0, 100.0));
+        REQUIRE_FALSE(circle_quad_intersect(c, q));
+   }
+}
+TEST_CASE("can perform rectangle geometry", "[rectangle]")
+{
+    SECTION("can detect rectangle circle intersection")
+    {
+        rectangle r = rectangle_from(100.0, 100.0, 100.0, 100.0);
+        circle c = circle_at(150.0, 150.0, 50.0);
+        REQUIRE(rectangle_circle_intersect(r, c));
+        c = circle_at(200.0, 200.0, 50.0);
+        REQUIRE_FALSE(rectangle_circle_intersect(r, c));
+    }
+}
+TEST_CASE("can perform triangle geometry", "[triangle]")
+{
+    SECTION("can detect triangle quad intersection")
+    {
+        triangle t = triangle_from(100.0, 100.0, 200.0, 100.0, 150.0, 150.0);
+        quad q = quad_from(50.0, 50.0, 150.0, 50.0, 50.0, 150.0, 150.0, 150.0);
+        REQUIRE(triangle_quad_intersect(t, q));
+        q = quad_from(200.0, 200.0, 300.0, 200.0, 200.0, 300.0, 300.0, 300.0);
+        REQUIRE_FALSE(triangle_quad_intersect(t, q));
+    }
+}


### PR DESCRIPTION
# Description

This PR is a refactoring of an existing PR: https://github.com/thoth-tech/splashkit-core/pull/83. It eliminates the need for void and function pointers by having sprites, rectangles, circles, triangles and quads inherit from the abstract class `shape`. Unfortunately, I was unable to get the program to compile. I am fairly certain that it is due to circular dependencies.

The major issue is that `_sprite_data` is abstracted entirely from students by being declared in `sprite.cpp`. However, moving `_sprite_data` from `sprites.cpp` to `sprites.h` leads to circular dependencies between `collision.h`, `types.h`, `sprites.h` and `backend_types.h`.

I am sure that the compilation errors could be resolved, however it would be a difficult process. My plan would be to split larger header files such as `types.h` into smaller files for each struct. There would be then be a `rectangle.h`, `circle.h` and so on.

Similarly, `backend_types.h` would be split into many smaller header files. This would allow for fine-grain control of includes which will make diagnosing and rectifying the circular dependencies easier.

By moving to an OOP approach, the code can be more understood, debugged and maintained.

### The UML class design for the shapes:
![1](https://github.com/user-attachments/assets/d30566ce-57c0-4693-a22b-8e09dd56dbea)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)

## How Has This Been Tested?

No testing has been performed as I was unable to compile.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code