### PR TITLE
Bugfix/graphics and rendering

### DIFF
--- a/coresdk/src/backend/graphics_driver.cpp
+++ b/coresdk/src/backend/graphics_driver.cpp
@@ -179,7 +179,7 @@ namespace splashkit_lib
 
         _sk_initial_window->window = SDL_CreateWindow("SplashKit",
                                                       SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 200, 200,
-                                                      SDL_WINDOW_ALLOW_HIGHDPI );
+                                                      SDL_WINDOW_HIDDEN | SDL_WINDOW_ALLOW_HIGHDPI );
 
         if ( ! _sk_initial_window->window )
         {

--- a/coresdk/src/backend/graphics_driver.h
+++ b/coresdk/src/backend/graphics_driver.h
@@ -104,6 +104,7 @@ namespace splashkit_lib
 
     sk_window_be *_sk_get_window_with_id(unsigned int window_id);
     sk_window_be *_sk_get_window_with_pointer(pointer p);
+    void _sk_destroy_initial_window();
     
     
     unsigned int _sk_renderer_count(sk_drawing_surface *surface);

--- a/coresdk/src/backend/text_driver.cpp
+++ b/coresdk/src/backend/text_driver.cpp
@@ -241,6 +241,7 @@ namespace splashkit_lib
                               sk_color clr )
     {
         internal_sk_init();
+        gfxPrimitivesSetFont(nullptr, 0, 0);
         unsigned int count = _sk_renderer_count(surface);
 
         for (unsigned int i = 0; i < count; i++)

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -1023,8 +1023,8 @@ namespace splashkit_lib
 
         if (s->position_at_anchor_point)
         {
-            s->position.x += s->anchor_point.x;
-            s->position.y += s->anchor_point.y;
+            s->position.x -= s->anchor_point.x;
+            s->position.y -= s->anchor_point.y;
         }
     }
 

--- a/coresdk/src/coresdk/sprites.cpp
+++ b/coresdk/src/coresdk/sprites.cpp
@@ -231,7 +231,7 @@ namespace splashkit_lib
         result->last_update = timer_ticks(_sprite_timer);
 
         // Write_ln("adding for ", name, " ", Hex_str(obj));
-        _sprites[name] = result;
+        _sprites[sn] = result;
 
         current_pack().push_back(result);
 
@@ -1023,8 +1023,8 @@ namespace splashkit_lib
 
         if (s->position_at_anchor_point)
         {
-            s->position.x -= s->anchor_point.x;
-            s->position.y -= s->anchor_point.y;
+            s->position.x += s->anchor_point.x;
+            s->position.y += s->anchor_point.y;
         }
     }
 
@@ -1558,6 +1558,10 @@ namespace splashkit_lib
         // TODO: Temporarily do not call due to 70c30d4
         vector<void *> &pack = _sprite_packs[name];
         _call_for_all_sprites(pack, &_free_sprite);
+        if (name == _current_pack)
+        {
+            _current_pack = INITIAL_PACK_NAME;
+        }
 
         _sprite_packs.erase(name);
     }

--- a/coresdk/src/coresdk/window_manager.cpp
+++ b/coresdk/src/coresdk/window_manager.cpp
@@ -183,6 +183,7 @@ namespace splashkit_lib
     void close_all_windows()
     {
         FREE_ALL_FROM_MAP(_windows, WINDOW_PTR, close_window);
+        _sk_destroy_initial_window();
     }
 
     bool has_window(string caption)


### PR DESCRIPTION
# Description

I have addressed several issues related to window and sprite management, bitmap text rendering, and collision detection across tests. Below is a breakdown of the problems encountered and how I fixed them:


## Fix Details

1. **_sk_create_initial_window**:
   - **Problem**: The _sk_create_initial_window function was intended to create a hidden window, but the `SDL_WINDOW_HIDDEN` flag was missing.
   - **Fix**: I updated the function to include the `SDL_WINDOW_HIDDEN` flag in the `SDL_CreateWindow` .

2. **create_sprite**:
   - **Problem**: When creating multiple sprites with the same name, the first sprite would be stored in the dictionary under its original name, e.g., "sprite". When the second sprite with the same name was created, a unique name such as "sprite0" was generated for the internal reference of the sprite, but the sprite was still stored in the dictionary under the original name, causing the first sprite to be overwritten. This resulted in the second sprite overwriting the first one in memory. When free_all_sprites was called, it couldn't find the sprite using the internal name, leading to a memory leak because it wasn't properly freed.
   - **Fix**: I modified the dictionary to use the unique internal name of the sprite (s->name) as the key.

3. **free_sprite_pack**:
   - **Problem**: When freeing a sprite pack that was currently active, the active sprite pack was not reverted to the default pack, leading to current_pack returning an already freed resource
   - **Fix**: I updated the function to check if the sprite pack being deleted was the active pack. If it was, the active sprite pack would be reverted to the default pack.

4. **_sk_draw_bitmap_text**:
   - **Problem**: Call chain: `draw_text_no_font`,  `sk_draw_text`, `_sk_draw_bitmap_text`, `stringRGBA`. When no font is given and you use `stringRGBA` to draw text across multiple windows or renderers or a newly opened window after closing one, the text rendering fails due to SDL2_gfx's reliance on static global variables for managing font state. This means that the font state is shared across all rendering contexts. As a result, when you switch to a new window or renderer, the static global variables no longer represent valid font data for the new context, causing the text
1.	First Window: Initializes the global font state for SDL2_gfx.
2.	Second Window: Attempts to use the same font state but fails because the global state from the first window is incompatible with the second renderer's context.

   - **Fix**: I added a call to `gfxPrimitivesSetFont(nullptr, 0, 0)` before each stringRGBA call to reset the font state. This ensures that each window or renderer has a fresh, valid font state.

5. **bitmap_point_collision**:
   - **Problem**: Bitmap collision detection fails due to improper management of the initial window and its renderer, leading to an old renderer being reused when it should not be.

   - **Flow**:
     1. **Initial Window Creation**: When a bitmap collision occurs and pixel reading is required, `sk_read_pixel` is called. Since no window exists (i.e., `sk_num_open_windows = 0`), it creates an initial window via `_sk_create_initial_window()`. This creates both an SDL window and renderer, which are stored in `_sk_initial_window` and added to `_sk_open_windows[0]`.
     2. **Bitmap and Texture Creation**: New bitmaps are created, with textures. These textures are specifically created for and tied to the renderer created in the initial window. The renderer "owns" these textures, which makes them valid render targets for pixel reading.
     3. **Renderer Cleanup**: When `close_all_windows()` and `free_all_bitmaps()` are called. The initial window is not in the windows map, and it doesn’t get cleaned up. The old renderer remains intact, and `_sk_num_open_windows` stays at 1 but all of the bitmaps and their textures were freed.
     4. **Subsequent Operation**: New bitmaps and textures are created. When `sk_read_pixel` is called, it sees `sk_num_open_windows = 1` and assumes the previous window and renderer are still valid, skipping the creation of a new initial window.
     5. **Problem with New Textures**: The new bitmaps and their textures are not paired with the old renderer, as they were created for a new operation. When `sk_prepared_renderer` tries to set one of these new textures as the render target for pixel reading, it fails because the old renderer does not "own" the new textures. As a result, the pixel reading fails and returns invalid (garbage or black) values because the render target is not valid.

- **Fix**: To resolve this, I included `_sk_destroy_initial_window()` in `close_all_windows()`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Created multiple sprites with the same name to ensure no overwriting occurs.
- Ensured that the correct font state is used when rendering text across multiple windows or renderers.
- Verified that the active sprite pack is reverted to the default pack when freed, and no invalid references remain.
- Validated that bitmap collision detection works correctly across multiple windows without interference from previous renderers.

## Testing Checklist

- [x] Tested with my test generator and all tests pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
