### PR TITLE
Bugfix/input handling

### DIFF
--- a/coresdk/src/backend/input_driver.cpp
+++ b/coresdk/src/backend/input_driver.cpp
@@ -17,8 +17,6 @@
 #include "graphics_driver.h"
 #include "window_manager.h"
 #include "interface_driver.h"
-#include <iostream> 
-#include <ostream> 
 
 namespace splashkit_lib
 {

--- a/coresdk/src/backend/input_driver.cpp
+++ b/coresdk/src/backend/input_driver.cpp
@@ -17,11 +17,13 @@
 #include "graphics_driver.h"
 #include "window_manager.h"
 #include "interface_driver.h"
+#include <iostream> 
+#include <ostream> 
 
 namespace splashkit_lib
 {
     sk_input_callbacks _input_callbacks = { nullptr };
-
+    
     bool _sk_quit = false;
     extern map<string, window> _windows;
 
@@ -791,7 +793,7 @@ namespace splashkit_lib
                 window_be = static_cast<sk_window_be *>(surface->_data);
                 
                 SDL_SetWindowPosition(window_be->window, x, y);
-                
+                            
                 return;
             }
                 
@@ -825,6 +827,8 @@ namespace splashkit_lib
     
     bool sk_show_mouse(int visible)
     {
+        if (visible == -1)
+            return SDL_ShowCursor(-1) != 0;
         return SDL_ShowCursor(visible ? 1: 0) != 0;
     }
     

--- a/coresdk/src/backend/input_driver.cpp
+++ b/coresdk/src/backend/input_driver.cpp
@@ -21,7 +21,7 @@
 namespace splashkit_lib
 {
     sk_input_callbacks _input_callbacks = { nullptr };
-    
+
     bool _sk_quit = false;
     extern map<string, window> _windows;
 
@@ -791,7 +791,7 @@ namespace splashkit_lib
                 window_be = static_cast<sk_window_be *>(surface->_data);
                 
                 SDL_SetWindowPosition(window_be->window, x, y);
-                            
+
                 return;
             }
                 

--- a/coresdk/src/backend/input_driver.h
+++ b/coresdk/src/backend/input_driver.h
@@ -16,6 +16,7 @@ namespace splashkit_lib
     typedef struct _window_data *window;
 
     extern bool _sk_quit;
+    extern bool _mouse_visible;
 
     typedef void (sk_empty_procedure)( void );
     typedef void (sk_intp_proc)( int ms );
@@ -59,6 +60,7 @@ namespace splashkit_lib
     void sk_move_window(sk_drawing_surface *surface, int x, int y);
 
     void sk_start_reading_text(window wind, double x, double y, double width, double height, string initial_text);
+    string sk_end_reading_text();
 
     void sk_mouse_position(double &x, double &y);
     void sk_mouse_movement(double &x, double &y);

--- a/coresdk/src/backend/input_driver.h
+++ b/coresdk/src/backend/input_driver.h
@@ -16,7 +16,6 @@ namespace splashkit_lib
     typedef struct _window_data *window;
 
     extern bool _sk_quit;
-    extern bool _mouse_visible;
 
     typedef void (sk_empty_procedure)( void );
     typedef void (sk_intp_proc)( int ms );

--- a/coresdk/src/backend/input_driver.h
+++ b/coresdk/src/backend/input_driver.h
@@ -59,7 +59,7 @@ namespace splashkit_lib
     void sk_move_window(sk_drawing_surface *surface, int x, int y);
 
     void sk_start_reading_text(window wind, double x, double y, double width, double height, string initial_text);
-    string sk_end_reading_text();
+    void _stop_reading_text(window wind);
 
     void sk_mouse_position(double &x, double &y);
     void sk_mouse_movement(double &x, double &y);

--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -92,6 +92,7 @@ namespace splashkit_lib
             _keys_just_typed[keycode] = true;
             _raise_key_event(_on_key_typed, keycode);
         }
+         _key_pressed = true; 
         _raise_key_event(_on_key_down, keycode);
     }
 

--- a/coresdk/src/coresdk/keyboard_input.cpp
+++ b/coresdk/src/coresdk/keyboard_input.cpp
@@ -88,11 +88,11 @@ namespace splashkit_lib
         key_code keycode = static_cast<key_code>(code);
         if(not key_down(keycode))
         {
+            _key_pressed = true; 
             _keys_down[keycode] = true;
             _keys_just_typed[keycode] = true;
             _raise_key_event(_on_key_typed, keycode);
         }
-         _key_pressed = true; 
         _raise_key_event(_on_key_down, keycode);
     }
 

--- a/coresdk/src/coresdk/text_input.cpp
+++ b/coresdk/src/coresdk/text_input.cpp
@@ -124,7 +124,7 @@ namespace splashkit_lib
             LOG(WARNING) << "Ending reading text with invalid window";
             return;
         }
-        
+        sk_end_reading_text();
         wind->reading_text = false;
     }
 }

--- a/coresdk/src/coresdk/text_input.cpp
+++ b/coresdk/src/coresdk/text_input.cpp
@@ -124,7 +124,6 @@ namespace splashkit_lib
             LOG(WARNING) << "Ending reading text with invalid window";
             return;
         }
-        sk_end_reading_text();
-        wind->reading_text = false;
+        _stop_reading_text(wind);
     }
 }


### PR DESCRIPTION
# Description

I have addressed several issues related to input handling, mouse, keyboard, and text input functionality. Below is a breakdown of the problems and the corresponding fixes:

## Fix Details

1. **mouse_shown**:
   - **Problem**: The `mouse_shown()` function was passing `-1` to the `sk_show_mouse()` function. In C++, `-1` is treated as a truthy value, which led to the `visible ? 1 : 0` expression always returning `1`. This caused the cursor to always be shown by calling `SDL_ShowCursor(1)`, disregarding its actual state.
   - **Fix**: I updated the `sk_show_mouse()` function to handle the `-1` argument by calling `SDL_ShowCursor(-1)`, which queries the current visibility state of the mouse.

2. **_key_pressed**:
   - **Problem**: The global variable `_key_pressed` was not being updated when the `_handle_key_down_callback` was called.
   - **Fix**: I updated the it so that the `_key_pressed` variable is updated whenever the `_handle_key_down_callback` is triggered. 

3. **end_reading_text**:
   - **Problem**: The function `end_reading_text` did not clean up the SDL text input state after finishing text input. It was only setting the window's `reading_text` flag to false, but the SDL text input state wasnt being cleaned up. This caused issues when trying to start reading text again later.
   - **Fix**: I updated the function to call `_stop_reading_text()` so that both the window's state and the SDL text input state are properly cleared and reset. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that the mouse visibility is correctly handled and no longer forced to appear when it shouldn't be.
- Ensured that the key state is correctly updated and reflected when key events are processed.
- Checked that the SDL text input state is properly cleaned up after text input and that future text input operations work without issues.

## Testing Checklist

- [x] Tested with my test generator and all tests pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
