### PR TITLE
Bugfix/logging

### DIFF
--- a/coresdk/src/coresdk/logging.cpp
+++ b/coresdk/src/coresdk/logging.cpp
@@ -65,7 +65,7 @@ namespace splashkit_lib
             {
                 write("INFO: ");
             }
-            else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+            if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
             {
                 custom_log_file << "INFO: ";
             }
@@ -79,7 +79,7 @@ namespace splashkit_lib
             {
                 write("DEBUG: ");
             }
-            else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+            if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
             {
                 custom_log_file << "DEBUG: ";
             }
@@ -93,7 +93,7 @@ namespace splashkit_lib
             {
                 write("WARNING: ");
             }
-            else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+            if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
             {
                 custom_log_file << "WARNING: ";
             }
@@ -107,7 +107,7 @@ namespace splashkit_lib
             {
                 write("ERROR: ");
             }
-            else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+            if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
             {
                 custom_log_file << "ERROR: ";
             }
@@ -117,7 +117,7 @@ namespace splashkit_lib
             {
                 write("FATAL: ");
             }
-            else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+            if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
             {
                 custom_log_file << "FATAL: ";
             }
@@ -134,7 +134,7 @@ namespace splashkit_lib
             write(" ");
             write_line(message);
         }
-        else if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
+        if (_log_mode == LOG_FILE_ONLY || _log_mode == LOG_CONSOLE_AND_FILE)
         {
             custom_log_file << str_time.substr(0, str_time.length() - 1);
             custom_log_file << " ";


### PR DESCRIPTION
# Description

The update addresses a bug in the logging system where dual logging functionality was not working as intended.

## Fix Details

1. **Dual Logging Issue**:
   - **Problem**: When the `_log_mode` passed to log was `LOG_CONSOLE_AND_FILE`, only the console logging condition was executed, while the file logging condition was skipped. As a result, both console and file logging could not occur simultaneously, which was the intended behaviour.
   - **Fix**: The code was updated to separate the logging conditions into independent `if` statements. This means that both console and file logging are performed when `_log_mode` is set to `LOG_CONSOLE_AND_FILE`, regardless of the log level (`INFO`, `DEBUG`, `WARNING`, `ERROR`, `FATAL`).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified that log messages are correctly sent to both the console and the file when `_log_mode` is set to `LOG_CONSOLE_AND_FILE`.
- Tested for all log levels (`INFO`, `DEBUG`, `WARNING`, `ERROR`, `FATAL`) to ensure logging behaviour is consistent and matches the intended functionality.

## Testing Checklist

- [x] Tested with my test generator and all tests pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
