### PR TITLE
Bugfix/utilities

### DIFF
--- a/coresdk/src/coresdk/utils.cpp
+++ b/coresdk/src/coresdk/utils.cpp
@@ -27,7 +27,7 @@ namespace splashkit_lib
     // from window manager
     unsigned int number_open_windows();
 
-     void delay(int milliseconds)
+    void delay(int milliseconds)
     {
         if (milliseconds > 0)
         {

--- a/coresdk/src/coresdk/utils.cpp
+++ b/coresdk/src/coresdk/utils.cpp
@@ -27,7 +27,7 @@ namespace splashkit_lib
     // from window manager
     unsigned int number_open_windows();
 
-    void delay(int milliseconds)
+     void delay(int milliseconds)
     {
         if (milliseconds > 0)
         {
@@ -36,7 +36,7 @@ namespace splashkit_lib
             else
             {
                 unsigned int t;
-                for (t = 1; t < milliseconds / 50; t++)
+                for (t = 0; t < milliseconds / 50; t++)
                 {
                     if ( number_open_windows() > 0 )
                     {


### PR DESCRIPTION
# Description

This update addresses an issue in the `delay` function where the first 50 milliseconds of the delay were skipped.

## Fix Details

1. **delay**:
   - **Problem**: The `delay` function's `for` loop incorrectly started at `t = 1`. As a result, when a delay of more than 50 milliseconds was requested, the first 50 milliseconds were skipped.
   - **Fix**: The loop was adjusted to begin at `t = 0`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Simulated various delay durations (e.g., 10ms, 50ms, 100ms) and verified the timing accuracy using a timer.

## Testing Checklist

- [x] Tested with my test generator and all tests pass.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
