### PR TITLE
Bugfix/terminal

### DIFF
--- a/coresdk/src/coresdk/terminal.cpp
+++ b/coresdk/src/coresdk/terminal.cpp
@@ -65,7 +65,7 @@ namespace splashkit_lib
 
     void write_line(char data)
     {
-        write_line(std::to_string(data));
+        write_line(std::string(1, data));
     }
 
     string read_line()

--- a/coresdk/src/coresdk/terminal.cpp
+++ b/coresdk/src/coresdk/terminal.cpp
@@ -71,6 +71,8 @@ namespace splashkit_lib
     string read_line()
     {
         string result;
+        cin.clear(); 
+        cin.sync();
         getline(std::cin, result);
         return result;
     }
@@ -78,7 +80,10 @@ namespace splashkit_lib
     char read_char()
     {
         char result = 0;
+        cin.clear();  
+        cin.sync();
         cin >> result;
+        cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
         return result;
     }
 


### PR DESCRIPTION
# Description

This update addresses issues in the terminal input handling, including input stream state failures and leftover characters in the input buffer.

## Fix Details

1. **Failed Input Stream State**:
   - **Problem**: Errors in previous input operations left the `cin` input stream in a failed state, blocking subsequent input operations. This commonly occurred due to mismatched input types or interrupted input.
   - **Fix**: Added `cin.clear()` to clear error flags.

2. **Leftover Characters in the Input Buffer**:
   - **Problem**: When part of the user input was read, leftover characters in the input buffer interfered with subsequent reads, leading to incorrect or unexpected input handling.
   - **Fixes**:
     - Added `cin.sync()` to synchronise and discard unread characters from the input buffer.
     - Used `cin.ignore()` in `read_char()` to discard extra characters up to the next newline.
     
3. **ASCII values instead of char**
   - **Problem**: `write_line_char` was printing the ASCII value instead of the string representation.
   - **Fix**: Update the funciton to use `write_line(std::string(1, data));`.


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested scenarios where mismatched input types are provided (e.g., entering text when a number is expected).
- Simulated interrupted input and verified that subsequent input operations worked correctly.
- Validated `read_char()` functionality by testing cases where additional characters are entered but only a single character is expected.

## Testing Checklist

- [x] Tested with my test generator and all tests pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
