### PR TITLE
Fixed txt file for cmake RPi

### DIFF
--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -18,8 +18,18 @@ if (WIN32 OR MSYS OR MINGW)
 endif()
 
 # Check for Raspberry Pi
+execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+if (EXISTS "/sys/firmware/devicetree/base/model")
+    file(READ "/sys/firmware/devicetree/base/model" DEVICE_MODEL)
+endif()
+
+if (ARCH MATCHES "armv7l|aarch64|armv6l" OR DEVICE_MODEL MATCHES "Raspberry Pi")
+    message(STATUS "Raspberry Pi detected: ${ARCH} ${DEVICE_MODEL}")
+    set(IS_RASPBERRY_PI TRUE)
+    add_definitions(-DRASPBERRY_PI)
+endif()
+
 include(CheckIncludeFile)
-find_path(BCM_HOST_INCLUDE_DIR bcm_host.h PATHS "/opt/vc/include")
 #### SETUP ####
 if (APPLE)
     # MAC OS PROJECT FLAGS
@@ -105,6 +115,11 @@ else()
                    -ldl \
                    -lstdc++fs")
 endif()
+
+find_path(BCM_HOST_INCLUDE_DIR bcm_host.h 
+    HINTS /usr/include /usr/local/include /opt/vc/include 
+    PATH_SUFFIXES interface/vcos/pthreads interface/vmcs_host/linux
+)
 
 if (BCM_HOST_INCLUDE_DIR)
     message("Raspberry Pi detected")
@@ -287,3 +302,4 @@ set_target_properties(skunit_tests
 
 install(TARGETS SplashKitBackend DESTINATION lib)
 install(FILES ${INCLUDE_FILES} DESTINATION include/SplashKitBackend)
+


### PR DESCRIPTION
# Description

This is a bug fix for the cmake functionality of SplashKIt core.

This is because with the code that exists, whenever I load up cmake on my RPi, it doesn't recognise that it's using a RPi. This is because it's lookin in the opt/vc/include folder which no longer exists so when I look up the RPi using BCM_HOST_INCLUDE_DIR, I've included two other file locations so that on newer RPi models, it can find the RPi model in cmake.

Fixes # (issue)
CMake not recognising RPi

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Built and run skunit tests on the RPi successfully

## Testing Checklist

- [ ] Tested with sktest

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
