### PR TITLE
Remove Unnecessary GetPixel Overloads

### DIFF
--- a/coresdk/src/coresdk/point_drawing.cpp
+++ b/coresdk/src/coresdk/point_drawing.cpp
@@ -42,22 +42,6 @@ namespace splashkit_lib
         draw_pixel(clr, pt.x, pt.y, opts);
     }
 
-    color get_pixel(bitmap bmp, double x, double y)
-    {
-        if ( INVALID_PTR(bmp, BITMAP_PTR) )
-        {
-            LOG(WARNING) << "Attempting to get pixel from invalid bitmap";
-            return COLOR_WHITE;
-        }
-
-        return sk_read_pixel(&bmp->image.surface, static_cast<int>(x), static_cast<int>(y));
-    }
-
-    color get_pixel(bitmap bmp, const point_2d &pt)
-    {
-        return get_pixel(bmp, pt.x, pt.y);
-    }
-
     color get_pixel(window wnd, double x, double y)
     {
         if ( INVALID_PTR(wnd, WINDOW_PTR) )
@@ -132,5 +116,21 @@ namespace splashkit_lib
     color get_pixel_from_window(window destination, const point_2d &pt)
     {
         return get_pixel(destination, pt.x, pt.y);
+    }
+
+    color get_pixel_from_bitmap(bitmap bmp, double x, double y)
+    {
+        if ( INVALID_PTR(bmp, BITMAP_PTR) )
+        {
+            LOG(WARNING) << "Attempting to get pixel from invalid bitmap";
+            return COLOR_WHITE;
+        }
+
+        return sk_read_pixel(&bmp->image.surface, static_cast<int>(x), static_cast<int>(y));
+    }
+
+    color get_pixel_from_bitmap(bitmap bmp, const point_2d &pt)
+    {
+        return get_pixel_from_bitmap(bmp, pt.x, pt.y);
     }
 }

--- a/coresdk/src/coresdk/point_drawing.cpp
+++ b/coresdk/src/coresdk/point_drawing.cpp
@@ -41,31 +41,15 @@ namespace splashkit_lib
     {
         draw_pixel(clr, pt.x, pt.y, opts);
     }
-
-    color get_pixel(window wnd, double x, double y)
-    {
-        if ( INVALID_PTR(wnd, WINDOW_PTR) )
-        {
-            LOG(WARNING) << "Attempting to get pixel from invalid window";
-            return COLOR_WHITE;
-        }
-
-        return sk_read_pixel(&wnd->image.surface, static_cast<int>(x), static_cast<int>(y));
-    }
-
-    color get_pixel(window wnd, const point_2d &pt)
-    {
-        return get_pixel(wnd, pt.x, pt.y);
-    }
     
     color get_pixel(double x, double y)
     {
-        return get_pixel(current_window(), x, y);
+        return get_pixel_from_window(current_window(), x, y);
     }
     
     color get_pixel(const point_2d &pt)
     {
-        return get_pixel(current_window(), pt.x, pt.y);
+        return get_pixel_from_window(current_window(), pt.x, pt.y);
     }
     
     void draw_pixel_on_window(window destination, color clr, double x, double y)
@@ -110,12 +94,18 @@ namespace splashkit_lib
     
     color get_pixel_from_window(window destination, double x, double y)
     {
-        return get_pixel(destination, x, y);
+        if ( INVALID_PTR(destination, WINDOW_PTR) )
+        {
+            LOG(WARNING) << "Attempting to get pixel from invalid window";
+            return COLOR_WHITE;
+        }
+
+        return sk_read_pixel(&destination->image.surface, static_cast<int>(x), static_cast<int>(y));
     }
     
     color get_pixel_from_window(window destination, const point_2d &pt)
     {
-        return get_pixel(destination, pt.x, pt.y);
+        return get_pixel_from_window(destination, pt.x, pt.y);
     }
 
     color get_pixel_from_bitmap(bitmap bmp, double x, double y)

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -58,32 +58,6 @@ namespace splashkit_lib
     void draw_pixel(color clr, const point_2d &pt, drawing_options opts);
 
     /**
-     * Returns the color of the pixel at the x,y location on the supplied
-     * window.
-     *
-     * @param  wnd The window to get the color from
-     * @param  x   The distance from the left edge of the window to the pixel
-     *             to read
-     * @param  y   The distance from the top of the window to the pixel to read
-     * @return     The color of the pixel at the supplied location
-     *
-     * @attribute suffix  from_window
-     */
-    color get_pixel(window wnd, double x, double y);
-
-    /**
-     * Returns the color of the pixel at the location on the supplied
-     * window.
-     *
-     * @param  wnd The window to get the color from
-     * @param  pt  The position of the pixel
-     * @return     The color of the pixel at the supplied location
-     *
-     * @attribute suffix  from_window_at_point
-     */
-    color get_pixel(window wnd, const point_2d &pt);
-
-    /**
      * Returns the color of the pixel at the x,y location on the current
      * window.
      *
@@ -171,7 +145,7 @@ namespace splashkit_lib
      * @return     The color of the pixel at the supplied location
      *
      * @attribute class  window
-     * @attribute suffix  from_window
+     * @attribute method get_pixel
      */
     color get_pixel_from_window(window destination, double x, double y);
     
@@ -183,7 +157,9 @@ namespace splashkit_lib
      * @param  pt  The position of the pixel
      * @return     The color of the pixel at the supplied location
      *
-     * @attribute suffix  at_point_from_window
+     * @attribute class   window
+     * @attribute suffix  at_point
+     * @attribute method  get_pixel
      */
     color get_pixel_from_window(window destination, const point_2d &pt);
     

--- a/coresdk/src/coresdk/point_drawing.h
+++ b/coresdk/src/coresdk/point_drawing.h
@@ -59,32 +59,6 @@ namespace splashkit_lib
 
     /**
      * Returns the color of the pixel at the x,y location on the supplied
-     * bitmap.
-     *
-     * @param  bmp The bitmap to get the color from
-     * @param  x   The distance from the left edge of the bitmap to the pixel
-     *             to read
-     * @param  y   The distance from the top of the bitmap to the pixel to read
-     * @return     The color of the pixel at the supplied location
-     *
-     * @attribute suffix  from_bitmap
-     */
-    color get_pixel(bitmap bmp, double x, double y);
-
-    /**
-     * Returns the color of the pixel at the location on the supplied
-     * bitmap.
-     *
-     * @param  bmp The bitmap to get the color from
-     * @param  pt  The position of the pixel
-     * @return     The color of the pixel at the supplied location
-     *
-     * @attribute suffix  from_bitmap_at_point
-     */
-    color get_pixel(bitmap bmp, const point_2d &pt);
-
-    /**
-     * Returns the color of the pixel at the x,y location on the supplied
      * window.
      *
      * @param  wnd The window to get the color from
@@ -271,5 +245,34 @@ namespace splashkit_lib
      * @attribute method  draw_pixel
      */
     void draw_pixel_on_bitmap(bitmap destination, color clr, const point_2d &pt, drawing_options opts);
+
+    /**
+     * Returns the color of the pixel at the x,y location on the supplied
+     * bitmap.
+     *
+     * @param  bmp The bitmap to get the color from
+     * @param  x   The distance from the left edge of the bitmap to the pixel
+     *             to read
+     * @param  y   The distance from the top of the bitmap to the pixel to read
+     * @return     The color of the pixel at the supplied location
+     *
+     * @attribute class  bitmap
+     * @attribute method get_pixel
+     */
+    color get_pixel_from_bitmap(bitmap bmp, double x, double y);
+
+    /**
+     * Returns the color of the pixel at the location on the supplied
+     * bitmap.
+     *
+     * @param  bmp The bitmap to get the color from
+     * @param  pt  The position of the pixel
+     * @return     The color of the pixel at the supplied location
+     *
+     * @attribute class   bitmap
+     * @attribute suffix  at_point
+     * @attribute method  get_pixel
+     */
+    color get_pixel_from_bitmap(bitmap bmp, const point_2d &pt);
 }
 #endif /* point_drawing_h */

--- a/generated/clib/sk_clib.cpp
+++ b/generated/clib/sk_clib.cpp
@@ -4575,19 +4575,6 @@ void __sklib__draw_pixel_on_window__window__color__double__double__drawing_optio
     drawing_options __skparam__opts = __sklib__to_drawing_options(opts);
     draw_pixel_on_window(__skparam__destination, __skparam__clr, __skparam__x, __skparam__y, __skparam__opts);
 }
-__sklib_color __sklib__get_pixel__bitmap__point_2d_ref(__sklib_bitmap bmp, const __sklib_point_2d pt) {
-    bitmap __skparam__bmp = __sklib__to_bitmap(bmp);
-    point_2d __skparam__pt = __sklib__to_point_2d(pt);
-    color __skreturn = get_pixel(__skparam__bmp, __skparam__pt);
-    return __sklib__to_sklib_color(__skreturn);
-}
-__sklib_color __sklib__get_pixel__bitmap__double__double(__sklib_bitmap bmp, double x, double y) {
-    bitmap __skparam__bmp = __sklib__to_bitmap(bmp);
-    double __skparam__x = __sklib__to_double(x);
-    double __skparam__y = __sklib__to_double(y);
-    color __skreturn = get_pixel(__skparam__bmp, __skparam__x, __skparam__y);
-    return __sklib__to_sklib_color(__skreturn);
-}
 __sklib_color __sklib__get_pixel__point_2d_ref(const __sklib_point_2d pt) {
     point_2d __skparam__pt = __sklib__to_point_2d(pt);
     color __skreturn = get_pixel(__skparam__pt);
@@ -4599,17 +4586,17 @@ __sklib_color __sklib__get_pixel__double__double(double x, double y) {
     color __skreturn = get_pixel(__skparam__x, __skparam__y);
     return __sklib__to_sklib_color(__skreturn);
 }
-__sklib_color __sklib__get_pixel__window__point_2d_ref(__sklib_window wnd, const __sklib_point_2d pt) {
-    window __skparam__wnd = __sklib__to_window(wnd);
+__sklib_color __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__sklib_bitmap bmp, const __sklib_point_2d pt) {
+    bitmap __skparam__bmp = __sklib__to_bitmap(bmp);
     point_2d __skparam__pt = __sklib__to_point_2d(pt);
-    color __skreturn = get_pixel(__skparam__wnd, __skparam__pt);
+    color __skreturn = get_pixel_from_bitmap(__skparam__bmp, __skparam__pt);
     return __sklib__to_sklib_color(__skreturn);
 }
-__sklib_color __sklib__get_pixel__window__double__double(__sklib_window wnd, double x, double y) {
-    window __skparam__wnd = __sklib__to_window(wnd);
+__sklib_color __sklib__get_pixel_from_bitmap__bitmap__double__double(__sklib_bitmap bmp, double x, double y) {
+    bitmap __skparam__bmp = __sklib__to_bitmap(bmp);
     double __skparam__x = __sklib__to_double(x);
     double __skparam__y = __sklib__to_double(y);
-    color __skreturn = get_pixel(__skparam__wnd, __skparam__x, __skparam__y);
+    color __skreturn = get_pixel_from_bitmap(__skparam__bmp, __skparam__x, __skparam__y);
     return __sklib__to_sklib_color(__skreturn);
 }
 __sklib_color __sklib__get_pixel_from_window__window__point_2d_ref(__sklib_window destination, const __sklib_point_2d pt) {

--- a/generated/clib/sk_clib.h
+++ b/generated/clib/sk_clib.h
@@ -1017,12 +1017,10 @@ void __sklib__draw_pixel_on_window__window__color__point_2d_ref(__sklib_window d
 void __sklib__draw_pixel_on_window__window__color__point_2d_ref__drawing_options(__sklib_window destination, __sklib_color clr, const __sklib_point_2d pt, __sklib_drawing_options opts);
 void __sklib__draw_pixel_on_window__window__color__double__double(__sklib_window destination, __sklib_color clr, double x, double y);
 void __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__sklib_window destination, __sklib_color clr, double x, double y, __sklib_drawing_options opts);
-__sklib_color __sklib__get_pixel__bitmap__point_2d_ref(__sklib_bitmap bmp, const __sklib_point_2d pt);
-__sklib_color __sklib__get_pixel__bitmap__double__double(__sklib_bitmap bmp, double x, double y);
 __sklib_color __sklib__get_pixel__point_2d_ref(const __sklib_point_2d pt);
 __sklib_color __sklib__get_pixel__double__double(double x, double y);
-__sklib_color __sklib__get_pixel__window__point_2d_ref(__sklib_window wnd, const __sklib_point_2d pt);
-__sklib_color __sklib__get_pixel__window__double__double(__sklib_window wnd, double x, double y);
+__sklib_color __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__sklib_bitmap bmp, const __sklib_point_2d pt);
+__sklib_color __sklib__get_pixel_from_bitmap__bitmap__double__double(__sklib_bitmap bmp, double x, double y);
 __sklib_color __sklib__get_pixel_from_window__window__point_2d_ref(__sklib_window destination, const __sklib_point_2d pt);
 __sklib_color __sklib__get_pixel_from_window__window__double__double(__sklib_window destination, double x, double y);
 __sklib_point_2d __sklib__point_at__double__double(double x, double y);

--- a/generated/cpp/point_drawing.h
+++ b/generated/cpp/point_drawing.h
@@ -27,12 +27,10 @@ void draw_pixel_on_window(window destination, color clr, const point_2d &pt);
 void draw_pixel_on_window(window destination, color clr, const point_2d &pt, drawing_options opts);
 void draw_pixel_on_window(window destination, color clr, double x, double y);
 void draw_pixel_on_window(window destination, color clr, double x, double y, drawing_options opts);
-color get_pixel(bitmap bmp, const point_2d &pt);
-color get_pixel(bitmap bmp, double x, double y);
 color get_pixel(const point_2d &pt);
 color get_pixel(double x, double y);
-color get_pixel(window wnd, const point_2d &pt);
-color get_pixel(window wnd, double x, double y);
+color get_pixel_from_bitmap(bitmap bmp, const point_2d &pt);
+color get_pixel_from_bitmap(bitmap bmp, double x, double y);
 color get_pixel_from_window(window destination, const point_2d &pt);
 color get_pixel_from_window(window destination, double x, double y);
 

--- a/generated/cpp/splashkit.cpp
+++ b/generated/cpp/splashkit.cpp
@@ -4767,19 +4767,6 @@ void draw_pixel_on_window(window destination, color clr, double x, double y, dra
     __sklib_drawing_options __skparam__opts = __skadapter__to_sklib_drawing_options(opts);
     __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__skparam__destination, __skparam__clr, __skparam__x, __skparam__y, __skparam__opts);
 }
-color get_pixel(bitmap bmp, const point_2d &pt) {
-    __sklib_bitmap __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
-    const __sklib_point_2d __skparam__pt = __skadapter__to_sklib_point_2d(pt);
-    __sklib_color __skreturn = __sklib__get_pixel__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
-    return __skadapter__to_color(__skreturn);
-}
-color get_pixel(bitmap bmp, double x, double y) {
-    __sklib_bitmap __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
-    double __skparam__x = __skadapter__to_double(x);
-    double __skparam__y = __skadapter__to_double(y);
-    __sklib_color __skreturn = __sklib__get_pixel__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
-    return __skadapter__to_color(__skreturn);
-}
 color get_pixel(const point_2d &pt) {
     const __sklib_point_2d __skparam__pt = __skadapter__to_sklib_point_2d(pt);
     __sklib_color __skreturn = __sklib__get_pixel__point_2d_ref(__skparam__pt);
@@ -4791,17 +4778,17 @@ color get_pixel(double x, double y) {
     __sklib_color __skreturn = __sklib__get_pixel__double__double(__skparam__x, __skparam__y);
     return __skadapter__to_color(__skreturn);
 }
-color get_pixel(window wnd, const point_2d &pt) {
-    __sklib_window __skparam__wnd = __skadapter__to_sklib_window(wnd);
+color get_pixel_from_bitmap(bitmap bmp, const point_2d &pt) {
+    __sklib_bitmap __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
     const __sklib_point_2d __skparam__pt = __skadapter__to_sklib_point_2d(pt);
-    __sklib_color __skreturn = __sklib__get_pixel__window__point_2d_ref(__skparam__wnd, __skparam__pt);
+    __sklib_color __skreturn = __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
     return __skadapter__to_color(__skreturn);
 }
-color get_pixel(window wnd, double x, double y) {
-    __sklib_window __skparam__wnd = __skadapter__to_sklib_window(wnd);
+color get_pixel_from_bitmap(bitmap bmp, double x, double y) {
+    __sklib_bitmap __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
     double __skparam__x = __skadapter__to_double(x);
     double __skparam__y = __skadapter__to_double(y);
-    __sklib_color __skreturn = __sklib__get_pixel__window__double__double(__skparam__wnd, __skparam__x, __skparam__y);
+    __sklib_color __skreturn = __sklib__get_pixel_from_bitmap__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
     return __skadapter__to_color(__skreturn);
 }
 color get_pixel_from_window(window destination, const point_2d &pt) {

--- a/generated/csharp/SplashKit.cs
+++ b/generated/csharp/SplashKit.cs
@@ -3576,23 +3576,17 @@ namespace SplashKitSDK
     [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__draw_pixel_on_window__window__color__double__double__drawing_options", CharSet=CharSet.Ansi)]
     private static extern void __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__sklib_ptr destination, __sklib_color clr, double x, double y, __sklib_drawing_options opts);
 
-    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__bitmap__point_2d_ref", CharSet=CharSet.Ansi)]
-    private static extern __sklib_color __sklib__get_pixel__bitmap__point_2d_ref(__sklib_ptr bmp, __sklib_point_2d pt);
-
-    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__bitmap__double__double", CharSet=CharSet.Ansi)]
-    private static extern __sklib_color __sklib__get_pixel__bitmap__double__double(__sklib_ptr bmp, double x, double y);
-
     [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__point_2d_ref", CharSet=CharSet.Ansi)]
     private static extern __sklib_color __sklib__get_pixel__point_2d_ref(__sklib_point_2d pt);
 
     [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__double__double", CharSet=CharSet.Ansi)]
     private static extern __sklib_color __sklib__get_pixel__double__double(double x, double y);
 
-    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__window__point_2d_ref", CharSet=CharSet.Ansi)]
-    private static extern __sklib_color __sklib__get_pixel__window__point_2d_ref(__sklib_ptr wnd, __sklib_point_2d pt);
+    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel_from_bitmap__bitmap__point_2d_ref", CharSet=CharSet.Ansi)]
+    private static extern __sklib_color __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__sklib_ptr bmp, __sklib_point_2d pt);
 
-    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel__window__double__double", CharSet=CharSet.Ansi)]
-    private static extern __sklib_color __sklib__get_pixel__window__double__double(__sklib_ptr wnd, double x, double y);
+    [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel_from_bitmap__bitmap__double__double", CharSet=CharSet.Ansi)]
+    private static extern __sklib_color __sklib__get_pixel_from_bitmap__bitmap__double__double(__sklib_ptr bmp, double x, double y);
 
     [DllImport("SplashKit", CallingConvention=CallingConvention.Cdecl, EntryPoint="__sklib__get_pixel_from_window__window__point_2d_ref", CharSet=CharSet.Ansi)]
     private static extern __sklib_color __sklib__get_pixel_from_window__window__point_2d_ref(__sklib_ptr destination, __sklib_point_2d pt);
@@ -17331,41 +17325,6 @@ namespace SplashKitSDK
       __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__skparam__destination, __skparam__clr, __skparam__x, __skparam__y, __skparam__opts);
     }
     /// <summary>
-    /// Returns the color of the pixel at the location on the supplied bitmap.
-    /// </summary>
-    /// <param name="bmp"> The bitmap to get the color from</param>
-    /// <param name="pt"> The position of the pixel</param>
-    /// <returns>The color of the pixel at the supplied location</returns>
-    public static Color GetPixel(Bitmap bmp, Point2D pt)
-    {
-      __sklib_ptr __skparam__bmp;
-      __sklib_point_2d __skparam__pt;
-      __sklib_color __skreturn;
-      __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
-      __skparam__pt = __skadapter__to_sklib_point_2d(pt);
-      __skreturn = __sklib__get_pixel__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
-      return __skadapter__to_color(__skreturn);
-    }
-    /// <summary>
-    /// Returns the color of the pixel at the x,y location on the supplied bitmap.
-    /// </summary>
-    /// <param name="bmp"> The bitmap to get the color from</param>
-    /// <param name="x"> The distance from the left edge of the bitmap to the pixel to read</param>
-    /// <param name="y"> The distance from the top of the bitmap to the pixel to read</param>
-    /// <returns>The color of the pixel at the supplied location</returns>
-    public static Color GetPixel(Bitmap bmp, double x, double y)
-    {
-      __sklib_ptr __skparam__bmp;
-      double __skparam__x;
-      double __skparam__y;
-      __sklib_color __skreturn;
-      __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
-      __skparam__x = __skadapter__to_sklib_double(x);
-      __skparam__y = __skadapter__to_sklib_double(y);
-      __skreturn = __sklib__get_pixel__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
-      return __skadapter__to_color(__skreturn);
-    }
-    /// <summary>
     /// Returns the color of the pixel at the x,y location on the current window.
     /// </summary>
     /// <param name="pt"> The position of the pixel</param>
@@ -17395,38 +17354,38 @@ namespace SplashKitSDK
       return __skadapter__to_color(__skreturn);
     }
     /// <summary>
-    /// Returns the color of the pixel at the location on the supplied window.
+    /// Returns the color of the pixel at the location on the supplied bitmap.
     /// </summary>
-    /// <param name="wnd"> The window to get the color from</param>
+    /// <param name="bmp"> The bitmap to get the color from</param>
     /// <param name="pt"> The position of the pixel</param>
     /// <returns>The color of the pixel at the supplied location</returns>
-    public static Color GetPixel(Window wnd, Point2D pt)
+    public static Color GetPixelFromBitmap(Bitmap bmp, Point2D pt)
     {
-      __sklib_ptr __skparam__wnd;
+      __sklib_ptr __skparam__bmp;
       __sklib_point_2d __skparam__pt;
       __sklib_color __skreturn;
-      __skparam__wnd = __skadapter__to_sklib_window(wnd);
+      __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
       __skparam__pt = __skadapter__to_sklib_point_2d(pt);
-      __skreturn = __sklib__get_pixel__window__point_2d_ref(__skparam__wnd, __skparam__pt);
+      __skreturn = __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
       return __skadapter__to_color(__skreturn);
     }
     /// <summary>
-    /// Returns the color of the pixel at the x,y location on the supplied window.
+    /// Returns the color of the pixel at the x,y location on the supplied bitmap.
     /// </summary>
-    /// <param name="wnd"> The window to get the color from</param>
-    /// <param name="x"> The distance from the left edge of the window to the pixel to read</param>
-    /// <param name="y"> The distance from the top of the window to the pixel to read</param>
+    /// <param name="bmp"> The bitmap to get the color from</param>
+    /// <param name="x"> The distance from the left edge of the bitmap to the pixel to read</param>
+    /// <param name="y"> The distance from the top of the bitmap to the pixel to read</param>
     /// <returns>The color of the pixel at the supplied location</returns>
-    public static Color GetPixel(Window wnd, double x, double y)
+    public static Color GetPixelFromBitmap(Bitmap bmp, double x, double y)
     {
-      __sklib_ptr __skparam__wnd;
+      __sklib_ptr __skparam__bmp;
       double __skparam__x;
       double __skparam__y;
       __sklib_color __skreturn;
-      __skparam__wnd = __skadapter__to_sklib_window(wnd);
+      __skparam__bmp = __skadapter__to_sklib_bitmap(bmp);
       __skparam__x = __skadapter__to_sklib_double(x);
       __skparam__y = __skadapter__to_sklib_double(y);
-      __skreturn = __sklib__get_pixel__window__double__double(__skparam__wnd, __skparam__x, __skparam__y);
+      __skreturn = __sklib__get_pixel_from_bitmap__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
       return __skadapter__to_color(__skreturn);
     }
     /// <summary>
@@ -30229,6 +30188,27 @@ public class Bitmap : PointerWrapper
     }
 
     /// <summary>
+    /// Returns the color of the pixel at the location on the supplied bitmap.
+    /// </summary>
+    /// <param name="pt"> The position of the pixel</param>
+    /// <returns>The color of the pixel at the supplied location</returns>
+    public Color GetPixel(Point2D pt)
+    {
+        return SplashKit.GetPixelFromBitmap(this, pt);
+    }
+
+    /// <summary>
+    /// Returns the color of the pixel at the x,y location on the supplied bitmap.
+    /// </summary>
+    /// <param name="x"> The distance from the left edge of the bitmap to the pixel to read</param>
+    /// <param name="y"> The distance from the top of the bitmap to the pixel to read</param>
+    /// <returns>The color of the pixel at the supplied location</returns>
+    public Color GetPixel(double x, double y)
+    {
+        return SplashKit.GetPixelFromBitmap(this, x, y);
+    }
+
+    /// <summary>
     /// Draw a quad on the supplied bitmap to the current bitmap.
     /// </summary>
     /// <param name="clr"> The color for the quad</param>
@@ -31361,6 +31341,27 @@ public class Window : PointerWrapper
     public void DrawLine(Color clr, double x1, double y1, double x2, double y2, DrawingOptions opts)
     {
         SplashKit.DrawLineOnWindow(this, clr, x1, y1, x2, y2, opts);
+    }
+
+    /// <summary>
+    /// Returns the color of the pixel at the x,y location on the given window.
+    /// </summary>
+    /// <param name="pt"> The position of the pixel</param>
+    /// <returns>The color of the pixel at the supplied location</returns>
+    public Color GetPixel(Point2D pt)
+    {
+        return SplashKit.GetPixelFromWindow(this, pt);
+    }
+
+    /// <summary>
+    /// Returns the color of the pixel at the x,y location on the given window.
+    /// </summary>
+    /// <param name="x"> The distance from the left edge of the window to the pixel to read</param>
+    /// <param name="y"> The distance from the top of the window to the pixel to read</param>
+    /// <returns>The color of the pixel at the supplied location</returns>
+    public Color GetPixel(double x, double y)
+    {
+        return SplashKit.GetPixelFromWindow(this, x, y);
     }
 
     /// <summary>

--- a/generated/docs/api.json
+++ b/generated/docs/api.json
@@ -34698,147 +34698,6 @@
         }
       },
       {
-        "signature": "color get_pixel(bitmap bmp,const point_2d &pt);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_bitmap_at_point",
-        "unique_method_name": null,
-        "suffix_name": null,
-        "description": "Returns the color of the pixel at the location on the supplied\nbitmap.",
-        "brief": null,
-        "return": {
-          "type": "color",
-          "description": "The color of the pixel at the supplied location",
-          "is_pointer": false,
-          "is_reference": false,
-          "is_vector": false,
-          "type_parameter": null
-        },
-        "parameters": {
-          "bmp": {
-            "type": "bitmap",
-            "description": "The bitmap to get the color from",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "pt": {
-            "type": "point_2d",
-            "description": "The position of the pixel",
-            "is_pointer": false,
-            "is_const": true,
-            "is_reference": true,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          }
-        },
-        "attributes": {
-          "suffix": "from_bitmap_at_point",
-          "group": "graphics"
-        },
-        "signatures": {
-          "cpp": [
-            "color get_pixel(bitmap bmp, const point_2d &pt)"
-          ],
-          "python": [
-            "def get_pixel_from_bitmap_at_point(bmp, pt):"
-          ],
-          "csharp": [
-            "public static Color SplashKit.GetPixel(Bitmap bmp, Point2D pt);"
-          ],
-          "pascal": [
-            "function GetPixel(bmp: Bitmap; const pt: Point2D): Color"
-          ]
-        }
-      },
-      {
-        "signature": "color get_pixel(bitmap bmp,double x,double y);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_bitmap",
-        "unique_method_name": null,
-        "suffix_name": null,
-        "description": "Returns the color of the pixel at the x,y location on the supplied\nbitmap.",
-        "brief": null,
-        "return": {
-          "type": "color",
-          "description": "The color of the pixel at the supplied location",
-          "is_pointer": false,
-          "is_reference": false,
-          "is_vector": false,
-          "type_parameter": null
-        },
-        "parameters": {
-          "bmp": {
-            "type": "bitmap",
-            "description": "The bitmap to get the color from",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "x": {
-            "type": "double",
-            "description": "The distance from the left edge of the bitmap to the pixel\nto read",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "y": {
-            "type": "double",
-            "description": "The distance from the top of the bitmap to the pixel to read",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          }
-        },
-        "attributes": {
-          "suffix": "from_bitmap",
-          "group": "graphics"
-        },
-        "signatures": {
-          "cpp": [
-            "color get_pixel(bitmap bmp, double x, double y)"
-          ],
-          "python": [
-            "def get_pixel_from_bitmap(bmp, x, y):"
-          ],
-          "csharp": [
-            "public static Color SplashKit.GetPixel(Bitmap bmp, double x, double y);"
-          ],
-          "pascal": [
-            "function GetPixel(bmp: Bitmap; x: Double; y: Double): Color"
-          ]
-        }
-      },
-      {
         "signature": "color get_pixel(const point_2d &pt);",
         "name": "get_pixel",
         "method_name": null,
@@ -34953,13 +34812,13 @@
         }
       },
       {
-        "signature": "color get_pixel(window wnd,const point_2d &pt);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_at_point",
-        "unique_method_name": null,
+        "signature": "color get_pixel_from_bitmap(bitmap bmp,const point_2d &pt);",
+        "name": "get_pixel_from_bitmap",
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_bitmap_at_point",
+        "unique_method_name": "bitmap.get_pixel_at_point",
         "suffix_name": null,
-        "description": "Returns the color of the pixel at the location on the supplied\nwindow.",
+        "description": "Returns the color of the pixel at the location on the supplied\nbitmap.",
         "brief": null,
         "return": {
           "type": "color",
@@ -34970,9 +34829,9 @@
           "type_parameter": null
         },
         "parameters": {
-          "wnd": {
-            "type": "window",
-            "description": "The window to get the color from",
+          "bmp": {
+            "type": "bitmap",
+            "description": "The bitmap to get the color from",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -34998,32 +34857,36 @@
           }
         },
         "attributes": {
-          "suffix": "from_window_at_point",
-          "group": "graphics"
+          "class": "bitmap",
+          "method": "get_pixel",
+          "suffix": "at_point",
+          "group": "graphics",
+          "self": "bmp"
         },
         "signatures": {
           "cpp": [
-            "color get_pixel(window wnd, const point_2d &pt)"
+            "color get_pixel_from_bitmap(bitmap bmp, const point_2d &pt)"
           ],
           "python": [
-            "def get_pixel_from_window_at_point(wnd, pt):"
+            "def get_pixel_from_bitmap_at_point(bmp, pt):"
           ],
           "csharp": [
-            "public static Color SplashKit.GetPixel(Window wnd, Point2D pt);"
+            "public Color Bitmap.GetPixel(Point2D pt);",
+            "public static Color SplashKit.GetPixelFromBitmap(Bitmap bmp, Point2D pt);"
           ],
           "pascal": [
-            "function GetPixel(wnd: Window; const pt: Point2D): Color"
+            "function GetPixelFromBitmap(bmp: Bitmap; const pt: Point2D): Color"
           ]
         }
       },
       {
-        "signature": "color get_pixel(window wnd,double x,double y);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window",
-        "unique_method_name": null,
+        "signature": "color get_pixel_from_bitmap(bitmap bmp,double x,double y);",
+        "name": "get_pixel_from_bitmap",
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_bitmap",
+        "unique_method_name": "bitmap.get_pixel",
         "suffix_name": null,
-        "description": "Returns the color of the pixel at the x,y location on the supplied\nwindow.",
+        "description": "Returns the color of the pixel at the x,y location on the supplied\nbitmap.",
         "brief": null,
         "return": {
           "type": "color",
@@ -35034,9 +34897,9 @@
           "type_parameter": null
         },
         "parameters": {
-          "wnd": {
-            "type": "window",
-            "description": "The window to get the color from",
+          "bmp": {
+            "type": "bitmap",
+            "description": "The bitmap to get the color from",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -35049,7 +34912,7 @@
           },
           "x": {
             "type": "double",
-            "description": "The distance from the left edge of the window to the pixel\nto read",
+            "description": "The distance from the left edge of the bitmap to the pixel\nto read",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -35062,7 +34925,7 @@
           },
           "y": {
             "type": "double",
-            "description": "The distance from the top of the window to the pixel to read",
+            "description": "The distance from the top of the bitmap to the pixel to read",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -35075,30 +34938,33 @@
           }
         },
         "attributes": {
-          "suffix": "from_window",
-          "group": "graphics"
+          "class": "bitmap",
+          "method": "get_pixel",
+          "group": "graphics",
+          "self": "bmp"
         },
         "signatures": {
           "cpp": [
-            "color get_pixel(window wnd, double x, double y)"
+            "color get_pixel_from_bitmap(bitmap bmp, double x, double y)"
           ],
           "python": [
-            "def get_pixel_from_window(wnd, x, y):"
+            "def get_pixel_from_bitmap(bmp, x, y):"
           ],
           "csharp": [
-            "public static Color SplashKit.GetPixel(Window wnd, double x, double y);"
+            "public Color Bitmap.GetPixel(double x, double y);",
+            "public static Color SplashKit.GetPixelFromBitmap(Bitmap bmp, double x, double y);"
           ],
           "pascal": [
-            "function GetPixel(wnd: Window; x: Double; y: Double): Color"
+            "function GetPixelFromBitmap(bmp: Bitmap; x: Double; y: Double): Color"
           ]
         }
       },
       {
         "signature": "color get_pixel_from_window(window destination,const point_2d &pt);",
         "name": "get_pixel_from_window",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_at_point_from_window",
-        "unique_method_name": null,
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_window_at_point",
+        "unique_method_name": "window.get_pixel_at_point",
         "suffix_name": null,
         "description": "Returns the color of the pixel at the x,y location on the given\nwindow.",
         "brief": null,
@@ -35139,17 +35005,21 @@
           }
         },
         "attributes": {
-          "suffix": "at_point_from_window",
-          "group": "graphics"
+          "class": "window",
+          "method": "get_pixel",
+          "suffix": "at_point",
+          "group": "graphics",
+          "self": "destination"
         },
         "signatures": {
           "cpp": [
             "color get_pixel_from_window(window destination, const point_2d &pt)"
           ],
           "python": [
-            "def get_pixel_from_window_at_point_from_window(destination, pt):"
+            "def get_pixel_from_window_at_point(destination, pt):"
           ],
           "csharp": [
+            "public Color Window.GetPixel(Point2D pt);",
             "public static Color SplashKit.GetPixelFromWindow(Window destination, Point2D pt);"
           ],
           "pascal": [
@@ -35160,9 +35030,9 @@
       {
         "signature": "color get_pixel_from_window(window destination,double x,double y);",
         "name": "get_pixel_from_window",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_from_window",
-        "unique_method_name": null,
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_window",
+        "unique_method_name": "window.get_pixel",
         "suffix_name": null,
         "description": "Returns the color of the pixel at the x,y location on the given\nwindow.",
         "brief": null,
@@ -35217,17 +35087,19 @@
         },
         "attributes": {
           "class": "window",
-          "suffix": "from_window",
-          "group": "graphics"
+          "method": "get_pixel",
+          "group": "graphics",
+          "self": "destination"
         },
         "signatures": {
           "cpp": [
             "color get_pixel_from_window(window destination, double x, double y)"
           ],
           "python": [
-            "def get_pixel_from_window_from_window(destination, x, y):"
+            "def get_pixel_from_window(destination, x, y):"
           ],
           "csharp": [
+            "public Color Window.GetPixel(double x, double y);",
             "public static Color SplashKit.GetPixelFromWindow(Window destination, double x, double y);"
           ],
           "pascal": [

--- a/generated/pascal/splashkit.pas
+++ b/generated/pascal/splashkit.pas
@@ -1278,12 +1278,10 @@ procedure DrawPixelOnWindow(destination: Window; clr: Color; const pt: Point2D);
 procedure DrawPixelOnWindow(destination: Window; clr: Color; const pt: Point2D; opts: DrawingOptions);
 procedure DrawPixelOnWindow(destination: Window; clr: Color; x: Double; y: Double);
 procedure DrawPixelOnWindow(destination: Window; clr: Color; x: Double; y: Double; opts: DrawingOptions);
-function GetPixel(bmp: Bitmap; const pt: Point2D): Color;
-function GetPixel(bmp: Bitmap; x: Double; y: Double): Color;
 function GetPixel(const pt: Point2D): Color;
 function GetPixel(x: Double; y: Double): Color;
-function GetPixel(wnd: Window; const pt: Point2D): Color;
-function GetPixel(wnd: Window; x: Double; y: Double): Color;
+function GetPixelFromBitmap(bmp: Bitmap; const pt: Point2D): Color;
+function GetPixelFromBitmap(bmp: Bitmap; x: Double; y: Double): Color;
 function GetPixelFromWindow(destination: Window; const pt: Point2D): Color;
 function GetPixelFromWindow(destination: Window; x: Double; y: Double): Color;
 function PointAt(x: Double; y: Double): Point2D;
@@ -3805,12 +3803,10 @@ procedure __sklib__draw_pixel_on_window__window__color__point_2d_ref(destination
 procedure __sklib__draw_pixel_on_window__window__color__point_2d_ref__drawing_options(destination: __sklib_ptr; clr: __sklib_color; const pt: __sklib_point_2d; opts: __sklib_drawing_options); cdecl; external;
 procedure __sklib__draw_pixel_on_window__window__color__double__double(destination: __sklib_ptr; clr: __sklib_color; x: Double; y: Double); cdecl; external;
 procedure __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(destination: __sklib_ptr; clr: __sklib_color; x: Double; y: Double; opts: __sklib_drawing_options); cdecl; external;
-function __sklib__get_pixel__bitmap__point_2d_ref(bmp: __sklib_ptr; const pt: __sklib_point_2d): __sklib_color; cdecl; external;
-function __sklib__get_pixel__bitmap__double__double(bmp: __sklib_ptr; x: Double; y: Double): __sklib_color; cdecl; external;
 function __sklib__get_pixel__point_2d_ref(const pt: __sklib_point_2d): __sklib_color; cdecl; external;
 function __sklib__get_pixel__double__double(x: Double; y: Double): __sklib_color; cdecl; external;
-function __sklib__get_pixel__window__point_2d_ref(wnd: __sklib_ptr; const pt: __sklib_point_2d): __sklib_color; cdecl; external;
-function __sklib__get_pixel__window__double__double(wnd: __sklib_ptr; x: Double; y: Double): __sklib_color; cdecl; external;
+function __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(bmp: __sklib_ptr; const pt: __sklib_point_2d): __sklib_color; cdecl; external;
+function __sklib__get_pixel_from_bitmap__bitmap__double__double(bmp: __sklib_ptr; x: Double; y: Double): __sklib_color; cdecl; external;
 function __sklib__get_pixel_from_window__window__point_2d_ref(destination: __sklib_ptr; const pt: __sklib_point_2d): __sklib_color; cdecl; external;
 function __sklib__get_pixel_from_window__window__double__double(destination: __sklib_ptr; x: Double; y: Double): __sklib_color; cdecl; external;
 function __sklib__point_at__double__double(x: Double; y: Double): __sklib_point_2d; cdecl; external;
@@ -12572,30 +12568,6 @@ begin
   __skparam__opts := __skadapter__to_sklib_drawing_options(opts);
   __sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__skparam__destination, __skparam__clr, __skparam__x, __skparam__y, __skparam__opts);
 end;
-function GetPixel(bmp: Bitmap; const pt: Point2D): Color;
-var
-  __skparam__bmp: __sklib_ptr;
-  __skparam__pt: __sklib_point_2d;
-  __skreturn: __sklib_color;
-begin
-  __skparam__bmp := __skadapter__to_sklib_bitmap(bmp);
-  __skparam__pt := __skadapter__to_sklib_point_2d(pt);
-  __skreturn := __sklib__get_pixel__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
-  result := __skadapter__to_color(__skreturn);
-end;
-function GetPixel(bmp: Bitmap; x: Double; y: Double): Color;
-var
-  __skparam__bmp: __sklib_ptr;
-  __skparam__x: Double;
-  __skparam__y: Double;
-  __skreturn: __sklib_color;
-begin
-  __skparam__bmp := __skadapter__to_sklib_bitmap(bmp);
-  __skparam__x := __skadapter__to_sklib_double(x);
-  __skparam__y := __skadapter__to_sklib_double(y);
-  __skreturn := __sklib__get_pixel__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
-  result := __skadapter__to_color(__skreturn);
-end;
 function GetPixel(const pt: Point2D): Color;
 var
   __skparam__pt: __sklib_point_2d;
@@ -12616,28 +12588,28 @@ begin
   __skreturn := __sklib__get_pixel__double__double(__skparam__x, __skparam__y);
   result := __skadapter__to_color(__skreturn);
 end;
-function GetPixel(wnd: Window; const pt: Point2D): Color;
+function GetPixelFromBitmap(bmp: Bitmap; const pt: Point2D): Color;
 var
-  __skparam__wnd: __sklib_ptr;
+  __skparam__bmp: __sklib_ptr;
   __skparam__pt: __sklib_point_2d;
   __skreturn: __sklib_color;
 begin
-  __skparam__wnd := __skadapter__to_sklib_window(wnd);
+  __skparam__bmp := __skadapter__to_sklib_bitmap(bmp);
   __skparam__pt := __skadapter__to_sklib_point_2d(pt);
-  __skreturn := __sklib__get_pixel__window__point_2d_ref(__skparam__wnd, __skparam__pt);
+  __skreturn := __sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt);
   result := __skadapter__to_color(__skreturn);
 end;
-function GetPixel(wnd: Window; x: Double; y: Double): Color;
+function GetPixelFromBitmap(bmp: Bitmap; x: Double; y: Double): Color;
 var
-  __skparam__wnd: __sklib_ptr;
+  __skparam__bmp: __sklib_ptr;
   __skparam__x: Double;
   __skparam__y: Double;
   __skreturn: __sklib_color;
 begin
-  __skparam__wnd := __skadapter__to_sklib_window(wnd);
+  __skparam__bmp := __skadapter__to_sklib_bitmap(bmp);
   __skparam__x := __skadapter__to_sklib_double(x);
   __skparam__y := __skadapter__to_sklib_double(y);
-  __skreturn := __sklib__get_pixel__window__double__double(__skparam__wnd, __skparam__x, __skparam__y);
+  __skreturn := __sklib__get_pixel_from_bitmap__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y);
   result := __skadapter__to_color(__skreturn);
 end;
 function GetPixelFromWindow(destination: Window; const pt: Point2D): Color;

--- a/generated/python/splashkit.py
+++ b/generated/python/splashkit.py
@@ -3273,18 +3273,14 @@ sklib.__sklib__draw_pixel_on_window__window__color__double__double.argtypes = [ 
 sklib.__sklib__draw_pixel_on_window__window__color__double__double.restype = None
 sklib.__sklib__draw_pixel_on_window__window__color__double__double__drawing_options.argtypes = [ c_void_p, _sklib_color, c_double, c_double, _sklib_drawing_options ]
 sklib.__sklib__draw_pixel_on_window__window__color__double__double__drawing_options.restype = None
-sklib.__sklib__get_pixel__bitmap__point_2d_ref.argtypes = [ c_void_p, _sklib_point_2d ]
-sklib.__sklib__get_pixel__bitmap__point_2d_ref.restype = _sklib_color
-sklib.__sklib__get_pixel__bitmap__double__double.argtypes = [ c_void_p, c_double, c_double ]
-sklib.__sklib__get_pixel__bitmap__double__double.restype = _sklib_color
 sklib.__sklib__get_pixel__point_2d_ref.argtypes = [ _sklib_point_2d ]
 sklib.__sklib__get_pixel__point_2d_ref.restype = _sklib_color
 sklib.__sklib__get_pixel__double__double.argtypes = [ c_double, c_double ]
 sklib.__sklib__get_pixel__double__double.restype = _sklib_color
-sklib.__sklib__get_pixel__window__point_2d_ref.argtypes = [ c_void_p, _sklib_point_2d ]
-sklib.__sklib__get_pixel__window__point_2d_ref.restype = _sklib_color
-sklib.__sklib__get_pixel__window__double__double.argtypes = [ c_void_p, c_double, c_double ]
-sklib.__sklib__get_pixel__window__double__double.restype = _sklib_color
+sklib.__sklib__get_pixel_from_bitmap__bitmap__point_2d_ref.argtypes = [ c_void_p, _sklib_point_2d ]
+sklib.__sklib__get_pixel_from_bitmap__bitmap__point_2d_ref.restype = _sklib_color
+sklib.__sklib__get_pixel_from_bitmap__bitmap__double__double.argtypes = [ c_void_p, c_double, c_double ]
+sklib.__sklib__get_pixel_from_bitmap__bitmap__double__double.restype = _sklib_color
 sklib.__sklib__get_pixel_from_window__window__point_2d_ref.argtypes = [ c_void_p, _sklib_point_2d ]
 sklib.__sklib__get_pixel_from_window__window__point_2d_ref.restype = _sklib_color
 sklib.__sklib__get_pixel_from_window__window__double__double.argtypes = [ c_void_p, c_double, c_double ]
@@ -8076,17 +8072,6 @@ def draw_pixel_on_window_with_options ( destination, clr, x, y, opts ):
     __skparam__y = __skadapter__to_sklib_double(y)
     __skparam__opts = __skadapter__to_sklib_drawing_options(opts)
     sklib.__sklib__draw_pixel_on_window__window__color__double__double__drawing_options(__skparam__destination, __skparam__clr, __skparam__x, __skparam__y, __skparam__opts)
-def get_pixel_from_bitmap_at_point ( bmp, pt ):
-    __skparam__bmp = __skadapter__to_sklib_bitmap(bmp)
-    __skparam__pt = __skadapter__to_sklib_point_2d(pt)
-    __skreturn = sklib.__sklib__get_pixel__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt)
-    return __skadapter__to_color(__skreturn)
-def get_pixel_from_bitmap ( bmp, x, y ):
-    __skparam__bmp = __skadapter__to_sklib_bitmap(bmp)
-    __skparam__x = __skadapter__to_sklib_double(x)
-    __skparam__y = __skadapter__to_sklib_double(y)
-    __skreturn = sklib.__sklib__get_pixel__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y)
-    return __skadapter__to_color(__skreturn)
 def get_pixel_at_point ( pt ):
     __skparam__pt = __skadapter__to_sklib_point_2d(pt)
     __skreturn = sklib.__sklib__get_pixel__point_2d_ref(__skparam__pt)
@@ -8096,23 +8081,23 @@ def get_pixel ( x, y ):
     __skparam__y = __skadapter__to_sklib_double(y)
     __skreturn = sklib.__sklib__get_pixel__double__double(__skparam__x, __skparam__y)
     return __skadapter__to_color(__skreturn)
-def get_pixel_from_window_at_point ( wnd, pt ):
-    __skparam__wnd = __skadapter__to_sklib_window(wnd)
+def get_pixel_from_bitmap_at_point ( bmp, pt ):
+    __skparam__bmp = __skadapter__to_sklib_bitmap(bmp)
     __skparam__pt = __skadapter__to_sklib_point_2d(pt)
-    __skreturn = sklib.__sklib__get_pixel__window__point_2d_ref(__skparam__wnd, __skparam__pt)
+    __skreturn = sklib.__sklib__get_pixel_from_bitmap__bitmap__point_2d_ref(__skparam__bmp, __skparam__pt)
     return __skadapter__to_color(__skreturn)
-def get_pixel_from_window ( wnd, x, y ):
-    __skparam__wnd = __skadapter__to_sklib_window(wnd)
+def get_pixel_from_bitmap ( bmp, x, y ):
+    __skparam__bmp = __skadapter__to_sklib_bitmap(bmp)
     __skparam__x = __skadapter__to_sklib_double(x)
     __skparam__y = __skadapter__to_sklib_double(y)
-    __skreturn = sklib.__sklib__get_pixel__window__double__double(__skparam__wnd, __skparam__x, __skparam__y)
+    __skreturn = sklib.__sklib__get_pixel_from_bitmap__bitmap__double__double(__skparam__bmp, __skparam__x, __skparam__y)
     return __skadapter__to_color(__skreturn)
-def get_pixel_from_window_at_point_from_window ( destination, pt ):
+def get_pixel_from_window_at_point ( destination, pt ):
     __skparam__destination = __skadapter__to_sklib_window(destination)
     __skparam__pt = __skadapter__to_sklib_point_2d(pt)
     __skreturn = sklib.__sklib__get_pixel_from_window__window__point_2d_ref(__skparam__destination, __skparam__pt)
     return __skadapter__to_color(__skreturn)
-def get_pixel_from_window_from_window ( destination, x, y ):
+def get_pixel_from_window ( destination, x, y ):
     __skparam__destination = __skadapter__to_sklib_window(destination)
     __skparam__x = __skadapter__to_sklib_double(x)
     __skparam__y = __skadapter__to_sklib_double(y)

--- a/generated/translator_cache.json
+++ b/generated/translator_cache.json
@@ -3,7 +3,7 @@
     "group": "animations",
     "brief": "Animations in SplashKit can be used to move between cells in\nbitmaps and sprites. Each animation generates a number sequence\nthat can then be used when drawing bitmaps.",
     "description": null,
-    "parsed_at": 1745561942,
+    "parsed_at": 1747096738,
     "path": "coresdk/src/coresdk/animations.h",
     "functions": [
       {
@@ -7255,7 +7255,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561945,
+    "parsed_at": 1747096738,
     "path": "coresdk/src/coresdk/clipping.h",
     "functions": [
       {
@@ -19702,7 +19702,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561950,
+    "parsed_at": 1747096739,
     "path": "coresdk/src/coresdk/drawing_options.h",
     "functions": [
       {
@@ -23293,7 +23293,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561952,
+    "parsed_at": 1747096740,
     "path": "coresdk/src/coresdk/graphics.h",
     "functions": [
       {
@@ -29929,7 +29929,7 @@
     "group": "json",
     "brief": "SplashKit Json allows you to create and read JSON objects.",
     "description": "Splashkit's JSON library allows you to easily create or read JSON objects and\nmanipulate them to/from a JSON string or from a file containing a JSON\nstring. Create a new JSON object with a call to `create_json()` and\nread or write data to it by calling methods like\n`json_add_string(json j, string key, string value)` and\n`json_read_string(json j, string key)`.",
-    "parsed_at": 1745561954,
+    "parsed_at": 1747096741,
     "path": "coresdk/src/coresdk/json.h",
     "functions": [
       {
@@ -36566,7 +36566,7 @@
     "group": "audio",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561957,
+    "parsed_at": 1747096742,
     "path": "coresdk/src/coresdk/music.h",
     "functions": [
       {
@@ -40910,7 +40910,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561959,
+    "parsed_at": 1747096743,
     "path": "coresdk/src/coresdk/point_drawing.h",
     "functions": [
       {
@@ -41787,119 +41787,6 @@
         }
       },
       {
-        "signature": "color get_pixel(bitmap bmp,const point_2d &pt);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_bitmap_at_point",
-        "unique_method_name": null,
-        "suffix_name": null,
-        "description": "Returns the color of the pixel at the location on the supplied\nbitmap.",
-        "brief": null,
-        "return": {
-          "type": "color",
-          "description": "The color of the pixel at the supplied location",
-          "is_pointer": false,
-          "is_reference": false,
-          "is_vector": false,
-          "type_parameter": null
-        },
-        "parameters": {
-          "bmp": {
-            "type": "bitmap",
-            "description": "The bitmap to get the color from",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "pt": {
-            "type": "point_2d",
-            "description": "The position of the pixel",
-            "is_pointer": false,
-            "is_const": true,
-            "is_reference": true,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          }
-        },
-        "attributes": {
-          "suffix": "from_bitmap_at_point",
-          "group": "graphics"
-        }
-      },
-      {
-        "signature": "color get_pixel(bitmap bmp,double x,double y);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_bitmap",
-        "unique_method_name": null,
-        "suffix_name": null,
-        "description": "Returns the color of the pixel at the x,y location on the supplied\nbitmap.",
-        "brief": null,
-        "return": {
-          "type": "color",
-          "description": "The color of the pixel at the supplied location",
-          "is_pointer": false,
-          "is_reference": false,
-          "is_vector": false,
-          "type_parameter": null
-        },
-        "parameters": {
-          "bmp": {
-            "type": "bitmap",
-            "description": "The bitmap to get the color from",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "x": {
-            "type": "double",
-            "description": "The distance from the left edge of the bitmap to the pixel\nto read",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          },
-          "y": {
-            "type": "double",
-            "description": "The distance from the top of the bitmap to the pixel to read",
-            "is_pointer": false,
-            "is_const": false,
-            "is_reference": false,
-            "is_array": false,
-            "array_dimension_sizes": [
-
-            ],
-            "is_vector": false,
-            "type_parameter": null
-          }
-        },
-        "attributes": {
-          "suffix": "from_bitmap",
-          "group": "graphics"
-        }
-      },
-      {
         "signature": "color get_pixel(const point_2d &pt);",
         "name": "get_pixel",
         "method_name": null,
@@ -41986,13 +41873,13 @@
         }
       },
       {
-        "signature": "color get_pixel(window wnd,const point_2d &pt);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_at_point",
-        "unique_method_name": null,
+        "signature": "color get_pixel_from_bitmap(bitmap bmp,const point_2d &pt);",
+        "name": "get_pixel_from_bitmap",
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_bitmap_at_point",
+        "unique_method_name": "bitmap.get_pixel_at_point",
         "suffix_name": null,
-        "description": "Returns the color of the pixel at the location on the supplied\nwindow.",
+        "description": "Returns the color of the pixel at the location on the supplied\nbitmap.",
         "brief": null,
         "return": {
           "type": "color",
@@ -42003,9 +41890,9 @@
           "type_parameter": null
         },
         "parameters": {
-          "wnd": {
-            "type": "window",
-            "description": "The window to get the color from",
+          "bmp": {
+            "type": "bitmap",
+            "description": "The bitmap to get the color from",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -42031,18 +41918,21 @@
           }
         },
         "attributes": {
-          "suffix": "from_window_at_point",
-          "group": "graphics"
+          "class": "bitmap",
+          "method": "get_pixel",
+          "suffix": "at_point",
+          "group": "graphics",
+          "self": "bmp"
         }
       },
       {
-        "signature": "color get_pixel(window wnd,double x,double y);",
-        "name": "get_pixel",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window",
-        "unique_method_name": null,
+        "signature": "color get_pixel_from_bitmap(bitmap bmp,double x,double y);",
+        "name": "get_pixel_from_bitmap",
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_bitmap",
+        "unique_method_name": "bitmap.get_pixel",
         "suffix_name": null,
-        "description": "Returns the color of the pixel at the x,y location on the supplied\nwindow.",
+        "description": "Returns the color of the pixel at the x,y location on the supplied\nbitmap.",
         "brief": null,
         "return": {
           "type": "color",
@@ -42053,9 +41943,9 @@
           "type_parameter": null
         },
         "parameters": {
-          "wnd": {
-            "type": "window",
-            "description": "The window to get the color from",
+          "bmp": {
+            "type": "bitmap",
+            "description": "The bitmap to get the color from",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -42068,7 +41958,7 @@
           },
           "x": {
             "type": "double",
-            "description": "The distance from the left edge of the window to the pixel\nto read",
+            "description": "The distance from the left edge of the bitmap to the pixel\nto read",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -42081,7 +41971,7 @@
           },
           "y": {
             "type": "double",
-            "description": "The distance from the top of the window to the pixel to read",
+            "description": "The distance from the top of the bitmap to the pixel to read",
             "is_pointer": false,
             "is_const": false,
             "is_reference": false,
@@ -42094,16 +41984,18 @@
           }
         },
         "attributes": {
-          "suffix": "from_window",
-          "group": "graphics"
+          "class": "bitmap",
+          "method": "get_pixel",
+          "group": "graphics",
+          "self": "bmp"
         }
       },
       {
         "signature": "color get_pixel_from_window(window destination,const point_2d &pt);",
         "name": "get_pixel_from_window",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_at_point_from_window",
-        "unique_method_name": null,
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_window_at_point",
+        "unique_method_name": "window.get_pixel_at_point",
         "suffix_name": null,
         "description": "Returns the color of the pixel at the x,y location on the given\nwindow.",
         "brief": null,
@@ -42144,16 +42036,19 @@
           }
         },
         "attributes": {
-          "suffix": "at_point_from_window",
-          "group": "graphics"
+          "class": "window",
+          "method": "get_pixel",
+          "suffix": "at_point",
+          "group": "graphics",
+          "self": "destination"
         }
       },
       {
         "signature": "color get_pixel_from_window(window destination,double x,double y);",
         "name": "get_pixel_from_window",
-        "method_name": null,
-        "unique_global_name": "get_pixel_from_window_from_window",
-        "unique_method_name": null,
+        "method_name": "get_pixel",
+        "unique_global_name": "get_pixel_from_window",
+        "unique_method_name": "window.get_pixel",
         "suffix_name": null,
         "description": "Returns the color of the pixel at the x,y location on the given\nwindow.",
         "brief": null,
@@ -42208,8 +42103,9 @@
         },
         "attributes": {
           "class": "window",
-          "suffix": "from_window",
-          "group": "graphics"
+          "method": "get_pixel",
+          "group": "graphics",
+          "self": "destination"
         }
       }
     ],
@@ -42230,7 +42126,7 @@
     "group": "geometry",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561960,
+    "parsed_at": 1747096744,
     "path": "coresdk/src/coresdk/point_geometry.h",
     "functions": [
       {
@@ -44070,7 +43966,7 @@
     "group": "raspberry",
     "brief": "Provides support for using an ADC device with the GPIO pins on the Raspberry Pi.",
     "description": null,
-    "parsed_at": 1745561960,
+    "parsed_at": 1747096744,
     "path": "coresdk/src/coresdk/raspi_adc.h",
     "functions": [
       {
@@ -44517,7 +44413,7 @@
     "group": "raspberry",
     "brief": "Splashkit allows you to read and write to the GPIO pins on the Raspberry Pi.",
     "description": null,
-    "parsed_at": 1745561961,
+    "parsed_at": 1747096745,
     "path": "coresdk/src/coresdk/raspi_gpio.h",
     "functions": [
       {
@@ -45738,7 +45634,7 @@
     "group": "graphics",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561962,
+    "parsed_at": 1747096747,
     "path": "coresdk/src/coresdk/rectangle_drawing.h",
     "functions": [
       {
@@ -61170,7 +61066,7 @@
     "group": "input",
     "brief": null,
     "description": null,
-    "parsed_at": 1745561966,
+    "parsed_at": 1747096748,
     "path": "coresdk/src/coresdk/text_input.h",
     "functions": [
       {
@@ -61705,7 +61601,7 @@
     "group": "timers",
     "brief": "Timers in SplashKit can be used to track the passing of time.",
     "description": null,
-    "parsed_at": 1745561967,
+    "parsed_at": 1747096749,
     "path": "coresdk/src/coresdk/timers.h",
     "functions": [
       {
@@ -65514,7 +65410,7 @@
     "group": "types",
     "brief": "SplashKit Types simplifies data type creation and management for streamlined programming.",
     "description": null,
-    "parsed_at": 1745561968,
+    "parsed_at": 1747096750,
     "path": "coresdk/src/coresdk/types.h",
     "functions": [
 


### PR DESCRIPTION
# Description

GetPixel is a Splashkit function that returns the color of a given pixel from a Window or Bitmap. At the moment, there are multiple overloads for GetPixel, some which take a Window as a parameter and others that take a Bitmap.

The problem is that some of these overloads either shouldn't exist or should be renamed to either get_pixel_from_window or get_pixel_from_bitmap.

This problem is currently causing some of the generated code to have funny names such as:
```py
def get_pixel_from_window_at_point_from_window(destination, pt)
```

# Fixes
### point_drawing.h
- Bitmap overloads for get_pixel need to be renamed to get_pixel_from_bitmap
- Since get_pixel_from_window already exists, delete the Window overloads for get_pixel
- Update the header docs for get_pixel_from_bitmap and get_pixel_from_window

### point_drawing.cpp
- Remove definitions for the Window overloads of get_pixel by moving to get_pixel_from_window
- Update all definitions that previously referenced the Window overload of get_pixel. Use get_pixel_from_window instead
- Rename Bitmap overload of get_pixel to get_pixel_from_bitmap
- Update all definitions that previously referenced the Bitmap overload of get_pixel. Use get_pixel_from_bitmap instead

### Translator
- Run the translator to generate the source code for all targeted programming languages

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [x] Documentation (update or new)

## How Has This Been Tested?

- point_drawing.h and point_drawing.cpp have been visually inspected for syntax errors
- After running the translator, api.json has been inspected to ensure that the functions/methods are being generated and that they have the correct names and signatures
- I have built the project binaries by running cmake followed by make. The project built successfully without errors.
- I ran sktest and skunit_tests

P.S. For those reviewing this Pull Request, I recommend reviewing each individual commit in succession rather than looking at the files changed tab. Don't worry too much about the generated files. Focus mainly on these two files: 
point_drawing.h and point_drawing.cpp

## Testing Checklist
- [x] Visual inspection of point_drawing.h and point_drawing.cpp
- [x] Check api.json
- [x] Build project from source
- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
