### PR TITLE
Create unit test for function bitmap_name

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -133,9 +133,11 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 {   
     SECTION("can get bitmap name")
     {
-        bitmap bmp = create_bitmap("rocket", 128, 512);
+        bitmap bmp = create_bitmap("rock", 28, 28);
         string name = bitmap_name(bmp);
-        REQUIRE(name == "rocket");
+        REQUIRE(name == "rock");
+
+        free_bitmap(bmp);
     }
 
     SECTION("empty string returned for bitmap name when passing nullptr")
@@ -146,7 +148,7 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 
     SECTION("empty string returned for bitmap when passing freed bitmap")
     {
-        bitmap bmp = create_bitmap("treasure", 256, 256);
+        bitmap bmp = create_bitmap("treasure", 32, 24);
         free_bitmap(bmp);
         string name = bitmap_name(bmp);
         
@@ -157,14 +159,22 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 
     SECTION("can get unique names from bitmaps when names are reused")
     {
-        bitmap bmp_1 = create_bitmap("blank", 300, 200);
-        bitmap bmp_2 = create_bitmap("blank", 800, 600);
+        bitmap bmp_1 = create_bitmap("blank", 100, 200);
+        bitmap bmp_2 = create_bitmap("blank", 300, 400);
+        bitmap bmp_3 = create_bitmap("blank", 500, 600);
+        bitmap bmp_4 = create_bitmap("blank", 700, 800);
 
         string name_1 = bitmap_name(bmp_1);
         string name_2 = bitmap_name(bmp_2);
+        string name_3 = bitmap_name(bmp_3);
+        string name_4 = bitmap_name(bmp_4);
 
         REQUIRE(name_1 == "blank");
         REQUIRE(name_2 == "blank0");
+        REQUIRE(name_3 == "blank1");
+        REQUIRE(name_4 == "blank2");
+
+        free_all_bitmaps();
     }
 
     SECTION("can get name of bitmap when name is empty string")
@@ -173,6 +183,8 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
         string name = bitmap_name(bmp);
 
         REQUIRE(name == "");
+
+        free_bitmap(bmp);
     }
 
     SECTION("can get name of bitmap when name includes special characters")
@@ -182,5 +194,7 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 
         string returned_name = bitmap_name(bmp);
         REQUIRE(returned_name == silly_name);
+
+        free_bitmap(bmp);
     }
 }

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -133,9 +133,7 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 {   
     SECTION("can get bitmap name")
     {
-        bitmap bmp = load_bitmap("rocket", "rocket_sprt.png");
-        REQUIRE(bitmap_valid(bmp));
-        
+        bitmap bmp = create_bitmap("rocket", 128, 512);
         string name = bitmap_name(bmp);
         REQUIRE(name == "rocket");
     }
@@ -148,13 +146,12 @@ TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
 
     SECTION("empty string returned for bitmap when passing freed bitmap")
     {
-        bitmap bmp = load_bitmap("frog", "frog.png");
-        REQUIRE(bitmap_valid(bmp));
-        
+        bitmap bmp = create_bitmap("treasure", 256, 256);
         free_bitmap(bmp);
-
         string name = bitmap_name(bmp);
-        REQUIRE_FALSE(name == "frog");
+        
+        REQUIRE_FALSE(bitmap_valid(bmp));
+        REQUIRE_FALSE(name == "treasure");
         REQUIRE(name == "");
     }
 

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -128,3 +128,62 @@ TEST_CASE("bitmap bounding details can be retrieved", "[bitmap]")
     }
     free_bitmap(bmp);
 }
+
+TEST_CASE("name can be retrieved from bitmap", "[bitmap][bitmap_name]")
+{   
+    SECTION("can get bitmap name")
+    {
+        bitmap bmp = load_bitmap("rocket", "rocket_sprt.png");
+        REQUIRE(bitmap_valid(bmp));
+        
+        string name = bitmap_name(bmp);
+        REQUIRE(name == "rocket");
+    }
+
+    SECTION("empty string returned for bitmap name when passing nullptr")
+    {
+        string name = bitmap_name(nullptr);
+        REQUIRE(name == "");
+    }
+
+    SECTION("empty string returned for bitmap when passing freed bitmap")
+    {
+        bitmap bmp = load_bitmap("frog", "frog.png");
+        REQUIRE(bitmap_valid(bmp));
+        
+        free_bitmap(bmp);
+
+        string name = bitmap_name(bmp);
+        REQUIRE_FALSE(name == "frog");
+        REQUIRE(name == "");
+    }
+
+    SECTION("can get unique names from bitmaps when names are reused")
+    {
+        bitmap bmp_1 = create_bitmap("blank", 300, 200);
+        bitmap bmp_2 = create_bitmap("blank", 800, 600);
+
+        string name_1 = bitmap_name(bmp_1);
+        string name_2 = bitmap_name(bmp_2);
+
+        REQUIRE(name_1 == "blank");
+        REQUIRE(name_2 == "blank0");
+    }
+
+    SECTION("can get name of bitmap when name is empty string")
+    {
+        bitmap bmp = create_bitmap("", 64, 64);
+        string name = bitmap_name(bmp);
+
+        REQUIRE(name == "");
+    }
+
+    SECTION("can get name of bitmap when name includes special characters")
+    {
+        string silly_name = "AbCdEf 2+3=5 !@#$% \n";
+        bitmap bmp = create_bitmap(silly_name, 128, 128);
+
+        string returned_name = bitmap_name(bmp);
+        REQUIRE(returned_name == silly_name);
+    }
+}


### PR DESCRIPTION
# Description

This PR includes unit tests for the Splashkit function bitmap_name. Tests include making sure that the returned name matches the name of the bitmap and checking if bitmap_name returns an empty string when an invalid bitmap reference is passed as a parameter.

## Type of change

- [x] New unit test added, with multiple sections

## How Has This Been Tested?

To test, build the project and run the skunit_tests executable. Steps are provided on the Splashkit Documentation website if you are uncertain.

The test is named "name can be retrieved from bitmap" and should pass. If the test fails, let me know and we can track down the problem together.

## Testing Checklist

- [x] Tested with skunit_tests

<img width="3655" height="1180" alt="Screenshot from 2025-08-28 16-03-57" src="https://github.com/user-attachments/assets/7a609509-c3a2-4998-8958-ce96a0b7bff4" />


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
