### PR TITLE
Add resource bundle unit tests and fix bug in free_resource_bundle

### DIFF
--- a/coresdk/src/coresdk/bundles.cpp
+++ b/coresdk/src/coresdk/bundles.cpp
@@ -141,7 +141,7 @@ namespace splashkit_lib
                     break;
                 case IMAGE_RESOURCE:
                     rb_load_bitmap(line_name, line_path);
-                    if ( ! has_resource_bundle(line_name) ) return;
+                    if ( ! has_bitmap(line_name) ) return;
                     break;
                 case FONT_RESOURCE:
                     load_font(line_name, line_path);

--- a/coresdk/src/test/unit_tests/unit_test_bundles.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bundles.cpp
@@ -1,0 +1,62 @@
+/**
+ * Bundle unit tests
+ */
+
+#include "catch.hpp"
+
+#include "bundles.h"
+#include "resources.h"
+#include "audio.h"
+#include "images.h"
+#include "timers.h"
+#include "text.h"
+
+using namespace splashkit_lib;
+
+// Log pointers of freed resources
+void free_notification(void *resource)
+{
+    UNSCOPED_INFO("Freeing: " << resource);
+}
+
+TEST_CASE("Load and free resource bundle", "[load_resource_bundle][free_resource_bundle]")
+{
+    register_free_notifier(&free_notification);
+
+    /**
+     * Load test resource bundle containing:
+     * ANIM,WalkingScript,kermit.txt
+     * BITMAP,FrogBmp,frog.png, 73, 105, 4, 4, 16
+     * FONT,hara,hara.ttf
+     * SOUND,error,error.wav
+     * MUSIC,background,energize_my_mind.mod
+     * TIMER,my timer
+     * BUNDLE,blah,blah.txt
+     */
+    load_resource_bundle("test", "test.txt");
+
+    // Confirm bundle and its resources are loaded
+    REQUIRE(has_resource_bundle("test"));
+    REQUIRE(has_animation_script("WalkingScript"));
+    REQUIRE(has_bitmap("FrogBmp"));
+    REQUIRE(has_font("hara"));
+    REQUIRE(has_sound_effect("error"));
+    REQUIRE(has_music("background"));
+    REQUIRE(has_timer("my timer"));
+    REQUIRE(has_resource_bundle("blah"));
+    REQUIRE(has_bitmap("ufo"));
+    REQUIRE(has_resource_bundle("test"));
+
+    // Free bundle and confirm resources are freed
+    free_resource_bundle("test");
+
+    REQUIRE_FALSE(has_resource_bundle("test"));
+    REQUIRE_FALSE(has_animation_script("WalkingScript"));
+    REQUIRE_FALSE(has_bitmap("FrogBmp"));
+    REQUIRE_FALSE(has_font("hara"));
+    REQUIRE_FALSE(has_sound_effect("error"));
+    REQUIRE_FALSE(has_music("background"));
+    REQUIRE_FALSE(has_timer("my timer"));
+    REQUIRE_FALSE(has_resource_bundle("blah"));
+    REQUIRE_FALSE(has_bitmap("ufo"));
+}


### PR DESCRIPTION
# Description

Adapts Andrew Cain's resource bundle tests from sktest for skunit_tests. They were a good candidate for unit tests since it's simple to confirm the loading and unloading of resources.

Also fixes an issue discovered when porting these tests over:
When loading, the `IMAGE_RESOURCE` case had the following check:
`if ( ! has_resource_bundle(line_name) ) return;`
This would always return (because it was checking resource bundles
rather than bitmaps), bitmaps to be loaded but never be added to
the list of bundled resources.
This in turn resulted in free_resource_bundle never freeing that resource.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

## Testing Checklist

Ran both test executables to ensure the tests functioned the same way and made sure the output was as expected after the bug fix (bitmaps successfully unloaded).

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review via the Planner board
