### PR TITLE
Restructure bitmap unit tests file

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -15,6 +15,7 @@ constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72,
               FROG_WIDTH = 294, FROG_HEIGHT = 422;
 
 
+
 // Load Bitmap & Free Bitmap
 TEST_CASE("bitmaps can be loaded and freed", "[load_bitmap][free_bitmap]")
 {
@@ -49,6 +50,23 @@ TEST_CASE("bitmaps can be loaded and freed", "[load_bitmap][free_bitmap]")
 
         free_bitmap(background_bmp);
         REQUIRE_FALSE(has_bitmap("background"));
+    }
+
+    SECTION("can load and free multiple bitmaps at a time")
+    {
+        bitmap rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
+        bitmap frog_bmp = load_bitmap("frog", "frog.png");
+        bitmap background_bmp = load_bitmap("background", "background.png");
+        
+        REQUIRE(bitmap_valid(rocket_bmp));
+        REQUIRE(bitmap_valid(frog_bmp));
+        REQUIRE(bitmap_valid(background_bmp));
+
+        free_all_bitmaps();
+
+        REQUIRE_FALSE(bitmap_valid(rocket_bmp));
+        REQUIRE_FALSE(bitmap_valid(frog_bmp));
+        REQUIRE_FALSE(bitmap_valid(background_bmp));
     }
 }
 
@@ -133,24 +151,6 @@ TEST_CASE("can detect non-existent bitmap")
     bitmap no_bmp = load_bitmap("non_existent", "non_existent.jpg");
     REQUIRE(no_bmp == nullptr);
     REQUIRE(has_bitmap("non_existent") == false);
-}
-
-// TODO: Merge with the test 'bitmaps can be loaded & freed'
-TEST_CASE("can load and free multiple bitmaps")
-{
-    bitmap rocket_bmp, frog_bmp, background_bmp;
-    rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
-    frog_bmp = load_bitmap("frog", "frog.png");
-    background_bmp = load_bitmap("background", "background.png");
-    REQUIRE(bitmap_valid(rocket_bmp));
-    REQUIRE(bitmap_valid(frog_bmp));
-    REQUIRE(bitmap_valid(background_bmp));
-
-    free_all_bitmaps();
-
-    REQUIRE_FALSE(bitmap_valid(rocket_bmp));
-    REQUIRE_FALSE(bitmap_valid(frog_bmp));
-    REQUIRE_FALSE(bitmap_valid(background_bmp));
 }
 
 // TODO: Refactor

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -146,6 +146,8 @@ TEST_CASE("can determine whether a bitmap exists from a name", "[has_bitmap]")
         REQUIRE_FALSE(has_bitmap("existent"));
         bitmap bmp = create_bitmap("existent", 32, 32);
         REQUIRE(has_bitmap("existent"));
+
+        free_bitmap(bmp);
     }
 
     SECTION("bitmap detected when the name is an empty string")
@@ -153,6 +155,8 @@ TEST_CASE("can determine whether a bitmap exists from a name", "[has_bitmap]")
         REQUIRE_FALSE(has_bitmap(""));
         bitmap bmp = create_bitmap("", 32, 32);
         REQUIRE(has_bitmap(""));
+
+        free_bitmap(bmp);
     }
     
     SECTION("no bitmap detected when supplying a non-existent bitmap name")
@@ -165,6 +169,8 @@ TEST_CASE("can determine whether a bitmap exists from a name", "[has_bitmap]")
         REQUIRE_FALSE(bitmap_valid(bmp));
         
         REQUIRE_FALSE(has_bitmap("non_existent"));
+
+        free_all_bitmaps();
     }
 }
 

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -110,13 +110,6 @@ TEST_CASE("width and height can be retrieved from bitmap", "[bitmap_width][bitma
         free_bitmap(bmp);
     }
 
-    SECTION("zero returned for width and height when passing empty bitmap")
-    {
-        bitmap bmp;
-        REQUIRE(bitmap_width(bmp) == 0);
-        REQUIRE(bitmap_height(bmp) == 0);
-    }
-
     SECTION("zero returned for width and height when passing freed bitmap")
     {
         int width = 256;

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -14,35 +14,119 @@ constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72,
               BACKGROUND_WIDTH = 864, BACKGROUND_HEIGHT = 769,
               FROG_WIDTH = 294, FROG_HEIGHT = 422;
 
-TEST_CASE("bitmaps can be created and freed", "[load_bitmap][bitmap_width][bitmap_height][free_bitmap]")
-{
-    // Creating bitmaps
-    bitmap rocket_bmp, frog_bmp, background_bmp;
-    rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
-    REQUIRE(bitmap_valid(rocket_bmp));
-    REQUIRE(rocket_bmp != nullptr);
-    REQUIRE(bitmap_width(rocket_bmp) == ROCKET_WIDTH);
-    REQUIRE(bitmap_height(rocket_bmp) == ROCKET_HEIGHT);
-    frog_bmp = load_bitmap("frog", "frog.png");
-    REQUIRE(bitmap_valid(frog_bmp));
-    REQUIRE(frog_bmp != nullptr);
-    REQUIRE(bitmap_width(frog_bmp) == FROG_WIDTH);
-    REQUIRE(bitmap_height(frog_bmp) == FROG_HEIGHT);
-    background_bmp = load_bitmap("background", "background.png");
-    REQUIRE(bitmap_valid(background_bmp));
-    REQUIRE(background_bmp != nullptr);
-    REQUIRE(bitmap_width(background_bmp) == BACKGROUND_WIDTH);
-    REQUIRE(bitmap_height(background_bmp) == BACKGROUND_HEIGHT);
 
-    // Freeing bitmaps
-    free_bitmap(rocket_bmp);
-    REQUIRE_FALSE(has_bitmap("rocket_sprt"));
-    free_bitmap(frog_bmp);
-    REQUIRE_FALSE(has_bitmap("frog"));
-    free_bitmap(background_bmp);
-    REQUIRE_FALSE(has_bitmap("background"));
+// Load Bitmap & Free Bitmap
+TEST_CASE("bitmaps can be loaded and freed", "[load_bitmap][free_bitmap]")
+{
+    SECTION("can load and free rocket bitmap")
+    {
+        bitmap rocket_bmp = load_bitmap("rocket_sprt", "rocket_sprt.png");
+        
+        REQUIRE_FALSE(rocket_bmp == nullptr);
+        REQUIRE(bitmap_valid(rocket_bmp));
+
+        free_bitmap(rocket_bmp);
+        REQUIRE_FALSE(has_bitmap("rocket_sprt"));
+    }
+
+    SECTION("can load and free frog bitmap")
+    {
+        bitmap frog_bmp = load_bitmap("frog", "frog.png");
+
+        REQUIRE_FALSE(frog_bmp == nullptr);
+        REQUIRE(bitmap_valid(frog_bmp));
+
+        free_bitmap(frog_bmp);
+        REQUIRE_FALSE(has_bitmap("frog"));
+    }
+
+    SECTION("can load and free background bitmap")
+    {
+        bitmap background_bmp = load_bitmap("background", "background.png");
+
+        REQUIRE_FALSE(background_bmp == nullptr);
+        REQUIRE(bitmap_valid(background_bmp));
+
+        free_bitmap(background_bmp);
+        REQUIRE_FALSE(has_bitmap("background"));
+    }
 }
 
+// Bitmap Width & Bitmap Height
+TEST_CASE("width and height can be retrieved from bitmap", "[bitmap_width][bitmap_height]")
+{
+    SECTION("can get width and height from bitmap")
+    {
+        int width = 256;
+        int height = 128;
+        bitmap bmp = create_bitmap("blank", width, height);
+
+        REQUIRE(bitmap_width(bmp) == width);
+        REQUIRE(bitmap_height(bmp) == height);
+
+        REQUIRE(bitmap_width("blank") == width);
+        REQUIRE(bitmap_height("blank") == height);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("can get width and height from bitmap when zero")
+    {
+        bitmap bmp = create_bitmap("blank", 0, 0);
+
+        REQUIRE(bitmap_width(bmp) == 0);
+        REQUIRE(bitmap_height(bmp) == 0);
+
+        REQUIRE(bitmap_width("blank") == 0);
+        REQUIRE(bitmap_height("blank") == 0);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("can get width and height from bitmap when negative")
+    {
+        int width = -1024;
+        int height = -512;
+        bitmap bmp = create_bitmap("blank", width, height);
+
+        REQUIRE(bitmap_width(bmp) == width);
+        REQUIRE(bitmap_height(bmp) == height);
+
+        REQUIRE(bitmap_width("blank") == width);
+        REQUIRE(bitmap_height("blank") == height);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("zero returned for width and height when passing empty bitmap")
+    {
+        bitmap bmp;
+        REQUIRE(bitmap_width(bmp) == 0);
+        REQUIRE(bitmap_height(bmp) == 0);
+    }
+
+    SECTION("zero returned for width and height when passing freed bitmap")
+    {
+        int width = 256;
+        int height = 64;
+        bitmap bmp = create_bitmap("blank", width, height);
+        free_bitmap(bmp);
+        
+        REQUIRE_FALSE(bitmap_width(bmp) == width);
+        REQUIRE_FALSE(bitmap_height(bmp) == height);
+
+        REQUIRE(bitmap_width(bmp) == 0);
+        REQUIRE(bitmap_height(bmp) == 0);
+    }
+
+    SECTION("zero returned for width and height when passing nullptr as bitmap")
+    {
+        REQUIRE(bitmap_width(nullptr) == 0);
+        REQUIRE(bitmap_height(nullptr) == 0);
+    }
+}
+
+// TODO: Refactor
 TEST_CASE("can detect non-existent bitmap")
 {
     REQUIRE(has_bitmap("non_existent") == false);
@@ -51,6 +135,7 @@ TEST_CASE("can detect non-existent bitmap")
     REQUIRE(has_bitmap("non_existent") == false);
 }
 
+// TODO: Merge with the test 'bitmaps can be loaded & freed'
 TEST_CASE("can load and free multiple bitmaps")
 {
     bitmap rocket_bmp, frog_bmp, background_bmp;
@@ -61,7 +146,6 @@ TEST_CASE("can load and free multiple bitmaps")
     REQUIRE(bitmap_valid(frog_bmp));
     REQUIRE(bitmap_valid(background_bmp));
 
-    // Freeing all bitmaps
     free_all_bitmaps();
 
     REQUIRE_FALSE(bitmap_valid(rocket_bmp));
@@ -69,6 +153,7 @@ TEST_CASE("can load and free multiple bitmaps")
     REQUIRE_FALSE(bitmap_valid(background_bmp));
 }
 
+// TODO: Refactor
 TEST_CASE("bitmap bounding details can be retrieved", "[bitmap]")
 {
     bitmap bmp = load_bitmap("rocket", "rocket_sprt.png");

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -185,8 +185,8 @@ TEST_CASE("can get bitmap center coordinates", "[bitmap_center]")
         bitmap bmp = create_bitmap("sample", width, height);
         
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == width / 2.0);
-        REQUIRE(center.y == height / 2.0);
+        REQUIRE(center.x == width / 2.0f);
+        REQUIRE(center.y == height / 2.0f);
 
         free_bitmap(bmp);
     }
@@ -199,8 +199,8 @@ TEST_CASE("can get bitmap center coordinates", "[bitmap_center]")
         bitmap bmp = create_bitmap("sample", width, height);
         
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == width / 2.0);
-        REQUIRE(center.y == height / 2.0);
+        REQUIRE(center.x == width / 2.0f);
+        REQUIRE(center.y == height / 2.0f);
 
         free_bitmap(bmp);
     }
@@ -210,8 +210,8 @@ TEST_CASE("can get bitmap center coordinates", "[bitmap_center]")
         bitmap bmp = create_bitmap("sample", 1, 1);
         
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == 0);
-        REQUIRE(center.y == 0);
+        REQUIRE(center.x == 0.5f);
+        REQUIRE(center.y == 0.5f);
 
         free_bitmap(bmp);
     }
@@ -221,8 +221,8 @@ TEST_CASE("can get bitmap center coordinates", "[bitmap_center]")
         bitmap bmp = create_bitmap("sample", 0, 0);
         
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == 0);
-        REQUIRE(center.y == 0);
+        REQUIRE(center.x == 0.0f);
+        REQUIRE(center.y == 0.0f);
 
         free_bitmap(bmp);
     }

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -10,11 +10,6 @@
 
 using namespace splashkit_lib;
 
-constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72,
-              BACKGROUND_WIDTH = 864, BACKGROUND_HEIGHT = 769,
-              FROG_WIDTH = 294, FROG_HEIGHT = 422;
-
-
 // Load Bitmap & Free Bitmap
 TEST_CASE("bitmaps can be loaded and freed", "[load_bitmap][free_bitmap]")
 {
@@ -173,63 +168,158 @@ TEST_CASE("can determine whether a bitmap exists from a name", "[has_bitmap]")
     }
 }
 
-// TODO: Refactor
-TEST_CASE("bitmap bounding details can be retrieved", "[bitmap]")
+// Bitmap Center
+TEST_CASE("can get bitmap center coordinates", "[bitmap_center]")
 {
-    bitmap bmp = load_bitmap("rocket", "rocket_sprt.png");
-    REQUIRE(bmp != nullptr);
-    REQUIRE(bitmap_valid(bmp));
-    SECTION("can get bitmap width")
+    SECTION("can get bitmap center when width and height are even")
     {
-        REQUIRE(bitmap_width(bmp) == ROCKET_WIDTH);
-    }
-    SECTION("can get bitmap height")
-    {
-        REQUIRE(bitmap_height(bmp) == ROCKET_HEIGHT);
-    }
-    SECTION("can get bitmap center")
-    {
+        const int width = 128;
+        const int height = 64;
+        
+        bitmap bmp = create_bitmap("sample", width, height);
+        
         point_2d center = bitmap_center(bmp);
-        REQUIRE(center.x == ROCKET_WIDTH / 2.0);
-        REQUIRE(center.y == ROCKET_HEIGHT / 2.0);
+        REQUIRE(center.x == width / 2.0);
+        REQUIRE(center.y == height / 2.0);
+
+        free_bitmap(bmp);
     }
-    SECTION("can get bitmap bounding rectangle")
+
+    SECTION("can get bitmap center when width and height are odd")
     {
+        const int width = 129;
+        const int height = 65;
+        
+        bitmap bmp = create_bitmap("sample", width, height);
+        
+        point_2d center = bitmap_center(bmp);
+        REQUIRE(center.x == width / 2.0);
+        REQUIRE(center.y == height / 2.0);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("can get bitmap center when width and height are 1")
+    {
+        bitmap bmp = create_bitmap("sample", 1, 1);
+        
+        point_2d center = bitmap_center(bmp);
+        REQUIRE(center.x == 0);
+        REQUIRE(center.y == 0);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("can get bitmap center when width and height are 0")
+    {
+        bitmap bmp = create_bitmap("sample", 0, 0);
+        
+        point_2d center = bitmap_center(bmp);
+        REQUIRE(center.x == 0);
+        REQUIRE(center.y == 0);
+
+        free_bitmap(bmp);
+    }
+}
+
+// Bitmap Bounding Rectangle
+TEST_CASE("can get bitmap bounding rectangle", "[bitmap_bounding_rectangle]")
+{
+    SECTION("can get bitmap bounding rectangle when width and height are non-zero")
+    {
+        const int width = 43;
+        const int height = 28;
+        bitmap bmp = create_bitmap("blank", width, height);
+        
         rectangle rect = bitmap_bounding_rectangle(bmp);
         REQUIRE(rect.x == 0.0);
         REQUIRE(rect.y == 0.0);
-        REQUIRE(rect.width == ROCKET_WIDTH);
-        REQUIRE(rect.height == ROCKET_HEIGHT);
-    }
-    double center_corner_dist = sqrt(pow(ROCKET_WIDTH / 2.0, 2.0) + pow(ROCKET_HEIGHT / 2.0, 2.0));
+        REQUIRE(rect.width == width);
+        REQUIRE(rect.height == height);
 
-    SECTION("can get bitmap bounding circle")
-    {
-        circle circ = bitmap_bounding_circle(bmp, point_at(100.0, 100.0));
-        REQUIRE(circ.center.x == 100.0);
-        REQUIRE(circ.center.y == 100.0);
-        REQUIRE(circ.radius == center_corner_dist);
+        free_bitmap(bmp);
     }
-    SECTION("can get bitmap cell circle")
+
+    SECTION("can get bitmap bounding rectangle when width and height are 1")
     {
-        point_2d pt = point_at(100.0, 100.0);
+        bitmap bmp = create_bitmap("blank", 1, 1);
+        
+        rectangle rect = bitmap_bounding_rectangle(bmp);
+        REQUIRE(rect.x == 0.0);
+        REQUIRE(rect.y == 0.0);
+        REQUIRE(rect.width == 1);
+        REQUIRE(rect.height == 1);
+
+        free_bitmap(bmp);
+    }
+
+    SECTION("can get bitmap bounding rectangle when width and height are 0")
+    {
+        bitmap bmp = create_bitmap("blank", 0, 0);
+        
+        rectangle rect = bitmap_bounding_rectangle(bmp);
+        REQUIRE(rect.x == 0.0);
+        REQUIRE(rect.y == 0.0);
+        REQUIRE(rect.width == 0);
+        REQUIRE(rect.height == 0);
+
+        free_bitmap(bmp);
+    }
+}
+
+// Bitmap Bounding Circle
+TEST_CASE("can get bitmap bounding circle", "[bitmap_bounding_circle]")
+{
+    const int width = 127;
+    const int height = 30;
+    
+    bitmap bmp = create_bitmap("sample", width, height);
+    
+    double center_corner_dist = sqrt(pow(width / 2.0, 2.0) + pow(height / 2.0, 2.0));
+    
+    circle circ = bitmap_bounding_circle(bmp, point_at(100.0, 200.0));
+    REQUIRE(circ.center.x == 100.0);
+    REQUIRE(circ.center.y == 200.0);
+    REQUIRE(circ.radius == center_corner_dist);
+
+    free_bitmap(bmp);
+}
+
+// Bitmap Cell Circle
+TEST_CASE("can get bitmap cell circle", "[bitmap_cell_circle]")
+{
+    bitmap bmp = create_bitmap("blank", 256, 256);
+    
+    bitmap_set_cell_details(bmp, 128, 128, 2, 2, 4);
+    
+    const double center_corner_dist = sqrt(pow(128 / 2.0, 2.0) + pow(128 / 2.0, 2.0));
+    
+    point_2d pt = point_at(100.0, 200.0);
+
+    SECTION("can get bitmap cell circle without scale")
+    {
         circle circ = bitmap_cell_circle(bmp, pt);
+        circle circ2 = bitmap_cell_circle(bmp, pt.x, pt.y);
+
         REQUIRE(circ.center.x == pt.x);
         REQUIRE(circ.center.y == pt.y);
         REQUIRE(circ.radius == center_corner_dist);
-        circle circ2 = bitmap_cell_circle(bmp, pt.x, pt.y);
+
         REQUIRE(circ2.center.x == pt.x);
         REQUIRE(circ2.center.y == pt.y);
         REQUIRE(circ2.radius == center_corner_dist);
-
-        SECTION("can get bitmap cell circle with scale")
-        {
-            double scale = 2.0;
-            circle circ2 = bitmap_cell_circle(bmp, pt, scale);
-            REQUIRE(circ2.center.x == pt.x);
-            REQUIRE(circ2.center.y == pt.y);
-            REQUIRE(circ2.radius == center_corner_dist * scale);
-        }
     }
+
+    SECTION("can get bitmap cell circle with scale")
+    {
+        const double scale = 2.0;
+        
+        circle circ = bitmap_cell_circle(bmp, pt, scale);
+
+        REQUIRE(circ.center.x == pt.x);
+        REQUIRE(circ.center.y == pt.y);
+        REQUIRE(circ.radius == center_corner_dist * scale);
+    }
+
     free_bitmap(bmp);
 }

--- a/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_bitmap.cpp
@@ -15,7 +15,6 @@ constexpr int ROCKET_WIDTH = 36, ROCKET_HEIGHT = 72,
               FROG_WIDTH = 294, FROG_HEIGHT = 422;
 
 
-
 // Load Bitmap & Free Bitmap
 TEST_CASE("bitmaps can be loaded and freed", "[load_bitmap][free_bitmap]")
 {
@@ -144,13 +143,34 @@ TEST_CASE("width and height can be retrieved from bitmap", "[bitmap_width][bitma
     }
 }
 
-// TODO: Refactor
-TEST_CASE("can detect non-existent bitmap")
+// Has Bitmap
+TEST_CASE("can determine whether a bitmap exists from a name", "[has_bitmap]")
 {
-    REQUIRE(has_bitmap("non_existent") == false);
-    bitmap no_bmp = load_bitmap("non_existent", "non_existent.jpg");
-    REQUIRE(no_bmp == nullptr);
-    REQUIRE(has_bitmap("non_existent") == false);
+    SECTION("bitmap detected when supplying a valid bitmap name")
+    {
+        REQUIRE_FALSE(has_bitmap("existent"));
+        bitmap bmp = create_bitmap("existent", 32, 32);
+        REQUIRE(has_bitmap("existent"));
+    }
+
+    SECTION("bitmap detected when the name is an empty string")
+    {
+        REQUIRE_FALSE(has_bitmap(""));
+        bitmap bmp = create_bitmap("", 32, 32);
+        REQUIRE(has_bitmap(""));
+    }
+    
+    SECTION("no bitmap detected when supplying a non-existent bitmap name")
+    {
+        REQUIRE_FALSE(has_bitmap("non_existent"));
+        
+        bitmap bmp = load_bitmap("non_existent", "non_existent.png");
+        
+        REQUIRE(bmp == nullptr);
+        REQUIRE_FALSE(bitmap_valid(bmp));
+        
+        REQUIRE_FALSE(has_bitmap("non_existent"));
+    }
 }
 
 // TODO: Refactor


### PR DESCRIPTION
# Description

According to the Thoth Tech guide for writing unit tests, you should aim to isolate functionality as much as possible when creating a test. The unit testing for bitmap functions doesn't follow this convention, as many unit tests are testing multiple functions at the same time and some functions are getting tested repeatedly by separate tests. This isn't ideal so what I have done is try to restructure the bitmap unit tests file such that each test only tests the fewest number of bitmap functions at a time and each test is mutually exclusive, meaning that they are isolated as much as possible.

## Type of change

- [x] Code Refactor
- [x] Added Unit Tests

## How Has This Been Tested?

This has been tested by running all unit tests in a randomized order and ensuring that all tests pass.

Tests can be run from either the terminal or directly from VS Code using Cmake Tools. For more information, please consult the Thoth Tech documentation.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
