### PR TITLE
Fix CMake presets not working with versions older than 3.28

### DIFF
--- a/projects/cmake/CMakePresets.json
+++ b/projects/cmake/CMakePresets.json
@@ -14,7 +14,7 @@
         },
         {
             "name": "Windows",
-            "displayName": "Windows",
+            "displayName": "Windows (MSYS)",
             "description": "Windows mingw64 gcc",
             "generator": "MinGW Makefiles",
             "binaryDir": "${sourceDir}/build",

--- a/projects/cmake/CMakePresets.json
+++ b/projects/cmake/CMakePresets.json
@@ -3,7 +3,7 @@
     "configurePresets": [
         {
             "name": "Linux",
-            "displayName": "Linux without coverage",
+            "displayName": "Linux/WSL",
             "description": "Linux gcc g++",
             "binaryDir": "${sourceDir}/build",
             "cacheVariables": {

--- a/projects/cmake/CMakePresets.json
+++ b/projects/cmake/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 8,
+    "version": 3,
     "configurePresets": [
         {
             "name": "Linux",


### PR DESCRIPTION
# Description

Lowered the version in the presets file to 3. 

This fixes an issue I had while revising the unit testing guide where a high version number was preventing the presets from being used with older versions of CMake which they'd work with otherwise.

I also renamed the Linux preset to Linux/WSL to make it clear that it can also be used by WSL users, and renamed Windows to Windows (MSYS) to emphasise the difference.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Testing Checklist

The CMake build process runs as before, this just allows presets to be loaded with older versions of CMake (back to 3.21, [per documentation](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html))

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review on the planner board
