### PR TITLE
Fix remote GPIO hang on macOS

### DIFF
--- a/coresdk/src/backend/network_driver.cpp
+++ b/coresdk/src/backend/network_driver.cpp
@@ -22,6 +22,30 @@
 
 #include <string.h>
 #include <stdlib.h>
+
+// Platform-specific includes for non-blocking socket operations
+#ifdef _WIN32
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
+    #define SOCKET_ERRNO WSAGetLastError()
+    #define SOCKET_WOULDBLOCK WSAEWOULDBLOCK
+    #define SOCKET_INPROGRESS WSAEINPROGRESS
+#else
+    #include <fcntl.h>
+    #include <sys/socket.h>
+    #include <sys/select.h>
+    #include <netinet/in.h>
+    #include <arpa/inet.h>
+    #include <unistd.h>
+    #include <errno.h>
+    #define SOCKET_ERRNO errno
+    #define SOCKET_WOULDBLOCK EWOULDBLOCK
+    #define SOCKET_INPROGRESS EINPROGRESS
+#endif
+
+// Default connection timeout in seconds
+#define SK_CONNECTION_TIMEOUT_SECONDS 5
+
 namespace splashkit_lib
 {
     // This set keeps track of all of the sockets to see if there is activity
@@ -67,29 +91,191 @@ namespace splashkit_lib
         return result;
     }
 
+    /**
+     * Helper function to connect with timeout using native sockets.
+     * Returns the connected socket fd on success, -1 on failure.
+     */
+    static int _connect_with_timeout(const char *host, unsigned short port, int timeout_seconds)
+    {
+        struct sockaddr_in server_addr;
+        int sock_fd;
+        
+        // Create socket
+        sock_fd = socket(AF_INET, SOCK_STREAM, 0);
+        if (sock_fd < 0)
+        {
+            LOG(ERROR) << "Failed to create socket: " << SOCKET_ERRNO;
+            return -1;
+        }
+        
+        // Set up server address
+        memset(&server_addr, 0, sizeof(server_addr));
+        server_addr.sin_family = AF_INET;
+        server_addr.sin_port = htons(port);
+        
+        // Convert host to IP address
+        if (inet_pton(AF_INET, host, &server_addr.sin_addr) <= 0)
+        {
+            // Try to resolve hostname using SDLNet
+            IPaddress addr;
+            if (SDLNet_ResolveHost(&addr, host, port) < 0)
+            {
+                LOG(ERROR) << "Failed to resolve host: " << host;
+#ifdef _WIN32
+                closesocket(sock_fd);
+#else
+                close(sock_fd);
+#endif
+                return -1;
+            }
+            server_addr.sin_addr.s_addr = addr.host;
+        }
+        
+        // Set socket to non-blocking mode
+#ifdef _WIN32
+        unsigned long mode = 1;
+        ioctlsocket(sock_fd, FIONBIO, &mode);
+#else
+        int flags = fcntl(sock_fd, F_GETFL, 0);
+        fcntl(sock_fd, F_SETFL, flags | O_NONBLOCK);
+#endif
+        
+        // Initiate connection (returns immediately for non-blocking socket)
+        int connect_result = connect(sock_fd, (struct sockaddr*)&server_addr, sizeof(server_addr));
+        
+        if (connect_result < 0)
+        {
+            int err = SOCKET_ERRNO;
+            // Check if connection is in progress (expected for non-blocking)
+            if (err != SOCKET_INPROGRESS && err != SOCKET_WOULDBLOCK)
+            {
+                LOG(ERROR) << "Connect failed immediately: " << err;
+#ifdef _WIN32
+                closesocket(sock_fd);
+#else
+                close(sock_fd);
+#endif
+                return -1;
+            }
+            
+            // Wait for connection with timeout using select()
+            fd_set write_fds, except_fds;
+            struct timeval timeout;
+            
+            FD_ZERO(&write_fds);
+            FD_ZERO(&except_fds);
+            FD_SET(sock_fd, &write_fds);
+            FD_SET(sock_fd, &except_fds);
+            
+            timeout.tv_sec = timeout_seconds;
+            timeout.tv_usec = 0;
+            
+            int select_result = select(sock_fd + 1, NULL, &write_fds, &except_fds, &timeout);
+            
+            if (select_result <= 0)
+            {
+                if (select_result == 0)
+                {
+                    LOG(ERROR) << "Connection timeout after " << timeout_seconds << " seconds";
+                }
+                else
+                {
+                    LOG(ERROR) << "Select failed: " << SOCKET_ERRNO;
+                }
+#ifdef _WIN32
+                closesocket(sock_fd);
+#else
+                close(sock_fd);
+#endif
+                return -1;
+            }
+            
+            // Check if connection was successful
+            int so_error = 0;
+            socklen_t len = sizeof(so_error);
+            if (getsockopt(sock_fd, SOL_SOCKET, SO_ERROR, (char*)&so_error, &len) < 0 || so_error != 0)
+            {
+                LOG(ERROR) << "Connection failed: " << (so_error ? so_error : SOCKET_ERRNO);
+#ifdef _WIN32
+                closesocket(sock_fd);
+#else
+                close(sock_fd);
+#endif
+                return -1;
+            }
+        }
+        
+        // Set socket back to blocking mode for normal operation
+#ifdef _WIN32
+        mode = 0;
+        ioctlsocket(sock_fd, FIONBIO, &mode);
+#else
+        int flags_blocking = fcntl(sock_fd, F_GETFL, 0);
+        fcntl(sock_fd, F_SETFL, flags_blocking & ~O_NONBLOCK);
+#endif
+        
+        return sock_fd;
+    }
+
     sk_network_connection sk_open_tcp_connection(const char *host, unsigned short port)
     {
         internal_sk_init();
-
-        IPaddress addr;
-        TCPsocket client;
 
         sk_network_connection result;
         result.id = NETWORK_CONNECTION_PTR;
         result.kind = UNKNOWN;
         result._socket = nullptr;
 
+        // If host is null, we're creating a server socket - use the original blocking method
+        if (host == nullptr)
+        {
+            IPaddress addr;
+            if (SDLNet_ResolveHost(&addr, nullptr, port) < 0)
+                return result;
+
+            TCPsocket server = SDLNet_TCP_Open(&addr);
+            if (server)
+            {
+                result.kind = TCP;
+                result._socket = server;
+            }
+            else
+            {
+                LOG(ERROR) << "SDLNet_TCP_Open (server): " << SDLNet_GetError();
+            }
+            return result;
+        }
+
+        // For client connections, use non-blocking connect with timeout
+        int sock_fd = _connect_with_timeout(host, port, SK_CONNECTION_TIMEOUT_SECONDS);
+        
+        if (sock_fd < 0)
+        {
+            return result;  // Connection failed
+        }
+
+        // Successfully connected! Now we need to wrap this in SDL_net's TCPsocket
+        // Unfortunately, SDL_net doesn't provide a way to create a TCPsocket from a raw fd.
+        // So we close the test connection and use SDL_net for the actual connection.
+        // Since we verified the connection works, SDLNet_TCP_Open should succeed quickly.
+#ifdef _WIN32
+        closesocket(sock_fd);
+#else
+        close(sock_fd);
+#endif
+
+        // Now use SDL_net - the connection should succeed immediately since we verified connectivity
+        IPaddress addr;
         if (SDLNet_ResolveHost(&addr, host, port) < 0)
             return result;
 
-        client = SDLNet_TCP_Open(&addr);
+        TCPsocket client = SDLNet_TCP_Open(&addr);
 
         if (client)
         {
             result.kind = TCP;
             result._socket = client;
-            if (host)
-                SDLNet_TCP_AddSocket(_sockets, client);
+            SDLNet_TCP_AddSocket(_sockets, client);
         }
         else
         {


### PR DESCRIPTION
## Description
Fixes the issue where `remote_raspi_init` hangs indefinitely on macOS when trying to connect to a remote Raspberry Pi.

**Root Cause:** `SDLNet_TCP_Open` is a blocking function with no timeout. On macOS, when the host is unreachable, it hangs indefinitely (potentially for minutes due to OS-level TCP timeout settings).

**Solution:** Implement a non-blocking TCP connection with a 5-second timeout using native socket calls:
1. Create a non-blocking socket using `fcntl()`/`ioctlsocket()`
2. Initiate connection (returns immediately with `EINPROGRESS`)
3. Use `select()` with timeout to wait for connection
4. Check connection result with `getsockopt(SO_ERROR)`
5. If successful, close the test socket and use `SDLNet_TCP_Open` (which now succeeds immediately)

**Changes to `network_driver.cpp`:**
- Added platform-specific includes for socket operations (`fcntl.h`, `winsock2.h`, etc.)
- Added `SK_CONNECTION_TIMEOUT_SECONDS` constant (5 seconds)
- Added `_connect_with_timeout()` helper function
- Modified `sk_open_tcp_connection()` to use timeout for client connections
- Server socket creation (host=null) still uses the original blocking method

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Built and tested on macOS using CMake:

```bash
cd projects/cmake
cmake --preset macOS
cmake --build build/

cd ../../bin
./skunit_tests --order rand
# Result: All tests passed (1263 assertions in 79 test cases)

./skunit_tests "[networking]"
# Result: All tests passed (31 assertions in 2 test cases)
```

## Testing Checklist
- [x] Code compiles without errors on macOS
- [x] All existing unit tests pass (79 test cases)
- [x] All networking tests pass (31 assertions)
- [x] Connection timeout works correctly (5 second limit)
- [ ] Tested on Linux/WSL (not available on this machine)
- [ ] Tested on Windows/MSYS2 (not available on this machine)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Existing tests continue to pass
- [x] The fix is backward compatible with existing code
