### PR TITLE
Add Unit tests for clipping functions

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_clipping.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_clipping.cpp
@@ -1,0 +1,102 @@
+/**
+ * Clipping Unit Tests
+ * 
+ * 
+ * Created by Matthew Sutrisno
+ */
+
+#include "graphics.h"
+#include "color.h"
+#include "catch.hpp"
+
+using namespace splashkit_lib;
+
+
+static bool pixel_is(bitmap bmp, int x, int y, color expected)
+{
+    color c = get_pixel(bmp, x, y);
+    
+    return (red_of(c) == red_of(expected) &&
+            green_of(c) == green_of(expected) &&
+            blue_of(c) == blue_of(expected) &&
+            alpha_of(c) == alpha_of(expected));
+}
+
+TEST_CASE("set_clip restricts drawing to area", "[graphics][clipping]")
+{
+    bitmap bmp = create_bitmap("clip_test1", 40, 40);
+    clear_bitmap(bmp, COLOR_WHITE);
+
+    set_clip(bmp, rectangle_from(10, 10, 20, 20));
+
+    fill_rectangle(COLOR_RED, 0, 0, 40, 40, option_draw_to(bmp));
+
+    REQUIRE(pixel_is(bmp, 15, 15, COLOR_RED));
+
+    REQUIRE(pixel_is(bmp, 5, 5, COLOR_WHITE));
+    REQUIRE(pixel_is(bmp, 35, 35, COLOR_WHITE));
+
+    free_bitmap(bmp);
+}
+
+TEST_CASE("push_clip intersects clipping regions", "[graphics][clipping]")
+{
+    bitmap bmp = create_bitmap("clip_test2", 40, 40);
+    clear_bitmap(bmp, COLOR_WHITE);
+
+    set_clip(bmp, rectangle_from(10, 10, 20, 20));
+
+    push_clip(bmp, rectangle_from(20, 0, 10, 40));
+
+    fill_rectangle(COLOR_BLUE, 0, 0, 40, 40, option_draw_to(bmp));
+
+    REQUIRE(pixel_is(bmp, 25, 15, COLOR_BLUE));
+
+    REQUIRE(pixel_is(bmp, 15, 15, COLOR_WHITE));
+
+    REQUIRE(pixel_is(bmp, 5, 5, COLOR_WHITE));
+
+    free_bitmap(bmp);
+}
+
+TEST_CASE("pop_clip restores previous clipping region", "[graphics][clipping]")
+{
+    bitmap bmp = create_bitmap("clip_test3", 40, 40);
+    clear_bitmap(bmp, COLOR_WHITE);
+
+    set_clip(bmp, rectangle_from(5, 5, 20, 20));
+
+    push_clip(bmp, rectangle_from(10, 10, 20, 20));
+
+    fill_rectangle(COLOR_GREEN, 0, 0, 40, 40, option_draw_to(bmp));
+
+    REQUIRE(pixel_is(bmp, 12, 12, COLOR_GREEN));
+    REQUIRE(pixel_is(bmp, 6, 6, COLOR_WHITE));
+
+    pop_clip(bmp);
+
+    fill_rectangle(COLOR_RED, 0, 0, 40, 40, option_draw_to(bmp));
+
+    REQUIRE(pixel_is(bmp, 6, 6, COLOR_RED));
+
+    REQUIRE(pixel_is(bmp, 30, 30, COLOR_WHITE));
+
+    free_bitmap(bmp);
+}
+
+TEST_CASE("reset_clip removes clipping", "[graphics][clipping]")
+{
+    bitmap bmp = create_bitmap("clip_test4", 40, 40);
+    clear_bitmap(bmp, COLOR_WHITE);
+
+    set_clip(bmp, rectangle_from(10, 10, 10, 10));
+
+    reset_clip(bmp);
+
+    fill_rectangle(COLOR_GOLD, 0, 0, 40, 40, option_draw_to(bmp));
+
+    REQUIRE(pixel_is(bmp, 0, 0, COLOR_GOLD));
+    REQUIRE(pixel_is(bmp, 39, 39, COLOR_GOLD));
+
+    free_bitmap(bmp);
+}


### PR DESCRIPTION
# Description

This PR adds new unit tests for SplashKit’s clipping functionality.
These tests cover creating and removing clipping rectangles, handling multiple nested clipping regions, and verifying that drawing functions only affect the expected clipped area.

This work addresses the current gap in our test suite, as `sktest` performs visual tests for clipping but `skunit_tests` does not yet define test cases yet.

## Type of change

- [✓] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The new tests create an off-screen bitmap, apply clipping rectangles, draw shapes, and then use `get_pixel` to confirm that only the clipped region was modified. Tests include:

- Creating and removing a single clipping rectangle
- Stacking multiple clipping rectangles (nested clips)
- Ensuring that drawing operations affect only the active clipped area
- Resetting the clip restores full drawing range

Tests were run locally to verify succesful operations

## Testing Checklist

- [✓] Tested with sktest
- [✓] Tested with skunit_tests

## Checklist

- [✓] My code follows the style guidelines of this project
- [✓] I have performed a self-review of my own code
- [✓] I have made corresponding changes to the documentation
- [✓] My changes generate no new warnings
