### PR TITLE
Unit testing timers

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_timers.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_timers.cpp
@@ -10,10 +10,23 @@
 
 using namespace splashkit_lib;
 
-TEST_CASE("timmy timer", "[timers]")
+TEST_CASE("test create and free timer", "[timers][free_timer][create_timer]")
 {
     timer t = create_timer("test_timer");
     REQUIRE(has_timer("test_timer"));
     free_timer(t);
     REQUIRE_FALSE(has_timer("test_timer"));
+}
+
+TEST_CASE("pause", "[timers][free_timer][create_timer]")
+{
+    timer t2 = create_timer("test_pause");
+    start_timer(t2);
+    while (timer_ticks(t2) <= 0)
+    {
+    }
+    REQUIRE(timer_ticks(t2) > 0);
+    pause_timer(t2);
+    unsigned int ticks = timer_ticks(t2);
+    REQUIRE(timer_ticks(t2) == ticks);
 }

--- a/coresdk/src/test/unit_tests/unit_test_timers.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_timers.cpp
@@ -5,31 +5,65 @@
 #include "catch.hpp"
 #include "timers.h"
 #include "logging_handling.h"
+#include "utils.h"
 
 using namespace splashkit_lib;
 
 TEST_CASE(
-    "timer can be created, started, paused, and freed",
-    "[timers][create_timer][free_timer][start_timer][pause_timer]")
+    "timer can be created",
+    "[timers][create_timer]")
 {
     timer t = create_timer("test");
     REQUIRE(has_timer("test"));
+    free_timer(t);
+}
 
-    REQUIRE(timer_ticks(t) == 0); // starts at 0
+TEST_CASE(
+    "timer starts at zero ticks",
+    "[timers][create_timer][timer_ticks]")
+{
+    timer t = create_timer("test");
+    REQUIRE(timer_ticks(t) == 0);
+    free_timer(t);
+}
 
-    int attempts = 0;
+TEST_CASE(
+    "timer advances after start",
+    "[timers][start_timer][timer_ticks]")
+{
+    timer t = create_timer("test");
     start_timer(t);
-    while (timer_ticks(t) == 0 || attempts < 1000)
-    {
-        attempts++;
-    };
 
-    REQUIRE(timer_ticks(t) > 0); // time has advanced
+    delay(200);
+
+    REQUIRE(timer_ticks(t) > 0);
+
+    free_timer(t);
+}
+
+TEST_CASE(
+    "timer does not advance while paused",
+    "[timers][pause_timer][timer_ticks]")
+{
+    timer t = create_timer("test");
+    start_timer(t);
+    delay(200);
 
     pause_timer(t);
     unsigned int ticks = timer_ticks(t);
-    REQUIRE(timer_ticks(t) == ticks); // ticks do not change while paused
+    delay(200);
+
+    REQUIRE(timer_ticks(t) == ticks);
 
     free_timer(t);
-    REQUIRE_FALSE(has_timer("test")); // check the same name we created
+}
+
+TEST_CASE(
+    "timer can be freed",
+    "[timers][free_timer]")
+{
+    timer t = create_timer("test");
+    free_timer(t);
+
+    REQUIRE_FALSE(has_timer("test"));
 }

--- a/coresdk/src/test/unit_tests/unit_test_timers.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_timers.cpp
@@ -3,30 +3,33 @@
  */
 
 #include "catch.hpp"
-
 #include "timers.h"
-
 #include "logging_handling.h"
 
 using namespace splashkit_lib;
 
-TEST_CASE("test create and free timer", "[timers][free_timer][create_timer]")
+TEST_CASE("create_timer and free_timer", "[timers][create_timer][free_timer]")
 {
     timer t = create_timer("test_timer");
     REQUIRE(has_timer("test_timer"));
+
     free_timer(t);
     REQUIRE_FALSE(has_timer("test_timer"));
 }
 
-TEST_CASE("pause", "[timers][free_timer][create_timer]")
+TEST_CASE("start_timer and pause_timer", "[timers][start_timer][pause_timer]")
 {
-    timer t2 = create_timer("test_pause");
-    start_timer(t2);
-    while (timer_ticks(t2) <= 0)
+    timer t = create_timer("test_pause");
+    REQUIRE(timer_ticks(t) == 0); // starts at 0
+
+    start_timer(t);
+    while (timer_ticks(t) == 0)
     {
+        // wait until some ticks have passed
     }
-    REQUIRE(timer_ticks(t2) > 0);
-    pause_timer(t2);
-    unsigned int ticks = timer_ticks(t2);
-    REQUIRE(timer_ticks(t2) == ticks);
+    REQUIRE(timer_ticks(t) > 0); // time has advanced
+
+    pause_timer(t);
+    unsigned int ticks = timer_ticks(t);
+    REQUIRE(timer_ticks(t) == ticks); // ticks do not change while paused
 }

--- a/coresdk/src/test/unit_tests/unit_test_timers.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_timers.cpp
@@ -8,28 +8,28 @@
 
 using namespace splashkit_lib;
 
-TEST_CASE("create_timer and free_timer", "[timers][create_timer][free_timer]")
+TEST_CASE(
+    "timer can be created, started, paused, and freed",
+    "[timers][create_timer][free_timer][start_timer][pause_timer]")
 {
-    timer t = create_timer("test_timer");
-    REQUIRE(has_timer("test_timer"));
+    timer t = create_timer("test");
+    REQUIRE(has_timer("test"));
 
-    free_timer(t);
-    REQUIRE_FALSE(has_timer("test_timer"));
-}
-
-TEST_CASE("start_timer and pause_timer", "[timers][start_timer][pause_timer]")
-{
-    timer t = create_timer("test_pause");
     REQUIRE(timer_ticks(t) == 0); // starts at 0
 
+    int attempts = 0;
     start_timer(t);
-    while (timer_ticks(t) == 0)
+    while (timer_ticks(t) == 0 || attempts < 1000)
     {
-        // wait until some ticks have passed
-    }
+        attempts++;
+    };
+
     REQUIRE(timer_ticks(t) > 0); // time has advanced
 
     pause_timer(t);
     unsigned int ticks = timer_ticks(t);
     REQUIRE(timer_ticks(t) == ticks); // ticks do not change while paused
+
+    free_timer(t);
+    REQUIRE_FALSE(has_timer("test")); // check the same name we created
 }

--- a/coresdk/src/test/unit_tests/unit_test_timers.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_timers.cpp
@@ -1,0 +1,19 @@
+/**
+ * Timer Unit Tests
+ */
+
+#include "catch.hpp"
+
+#include "timers.h"
+
+#include "logging_handling.h"
+
+using namespace splashkit_lib;
+
+TEST_CASE("timmy timer", "[timers]")
+{
+    timer t = create_timer("test_timer");
+    REQUIRE(has_timer("test_timer"));
+    free_timer(t);
+    REQUIRE_FALSE(has_timer("test_timer"));
+}


### PR DESCRIPTION
# Description

Added unit test for the `timer` function from _timers.cpp_ (documentation [here](https://splashkit.io/api/timers/)). The new tests are named _"create_timer and free_timer"_ and _"start_timer and pause_timer"_.

This test includes sections:
- create_timer
- free_timer
- start_timer
- pause_timer

Fixes # (issue)

## Type of change

- [x] Unit test addition

## How Has This Been Tested?
Built the test project as per [unit testing instructions](https://thoth-tech.netlify.app/products/splashkit/documentation/splashkit-expansion/01-unit-testing-guide/), running skunit_tests with all tests passed.

## Testing Checklist

- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
