### PR TITLE
Fix bundle freeing: Bitmap resources not being freed

### DIFF
--- a/coresdk/src/coresdk/bundles.cpp
+++ b/coresdk/src/coresdk/bundles.cpp
@@ -141,7 +141,7 @@ namespace splashkit_lib
                     break;
                 case IMAGE_RESOURCE:
                     rb_load_bitmap(line_name, line_path);
-                    if ( ! has_resource_bundle(line_name) ) return;
+                    if ( ! has_bitmap(line_name) ) return;
                     break;
                 case FONT_RESOURCE:
                     load_font(line_name, line_path);


### PR DESCRIPTION
# Description

### Background
SplashKit bundles allow sets of resources to be loaded and freed as a group. For more information, see the [documentation](https://splashkit.io/guides/resources/loading-resources-with-bundles). The `free_resource_bundle` function is supposed to free every resource in the bundle at once.

### Problem
The `free_resource_bundle` function currently does not free bitmaps. This was shown in the "Bundles" test results - every other resource was freed successfully, except the bitmaps.

### Cause
When a bundle is loaded, each line of the bundle text file is analysed and run through a `SWITCH` in the `load_resource_bundle` function, loading the resource based on its type. Then the resources are added to a list (vector), which is stored as a field in the bundle. Meaning each bundle in memory has a list of corresponding resources. However, after the resources are loaded, their existence is checked to ensure the loading was successful. If it wasn't, the function returns early and the resource isn't added to the list.

In the case of a bitmap, we have:
```cpp
case IMAGE_RESOURCE:
    rb_load_bitmap(line_name, line_path);
    if ( ! has_resource_bundle(line_name) ) return;
    break;
```
Which means the condition checks for the bundle, not a bitmap. So the bitmap is loaded, but not added to the bundle's list of resources, and therefore not freed by `free_resource_bundle`.

### Fix
This is a very small and simple fix, changing the `IMAGE_RESOURCE` case so it checks `has_bitmap` rather than `has_resource_bundle`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the "Bundles" test in `sktest` in WSL and MSYS2. Also ran `skunit_tests`.

### Results of Bundles test

<img width="415" height="725" alt="bundle-test-results" src="https://github.com/user-attachments/assets/a9b8e84a-3429-4720-8272-1d323f73b9fb" />

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
