### PR TITLE
Fix inconsistent test output in MSYS2 and WSL

### DIFF
--- a/coresdk/src/test/test_animation.cpp
+++ b/coresdk/src/test/test_animation.cpp
@@ -23,11 +23,11 @@ void run_animation_test()
 {
     vector<string> sequence = { "Walkfront", "WalkLeft", "WalkRight", "WALKBACK", "dance" };
     
-    cout << "Script should not be loaded: " << has_animation_script("kermit");
+    cout << "Script should not be loaded: " << has_animation_script("kermit") << endl;
     
     animation_script kermit = load_animation_script("kermit", "kermit.txt");
     
-    cout << "Script should be loaded: " << has_animation_script("kermit");
+    cout << "Script should be loaded: " << has_animation_script("kermit") << endl;
     
     animation anim = create_animation(kermit, "MoonWalkBack");
     
@@ -57,7 +57,7 @@ void run_animation_test()
             it++;
         }
         
-        refresh_screen();
+        refresh_screen(60);
         
         if (quit_requested() ) break;
     }

--- a/coresdk/src/test/test_audio.cpp
+++ b/coresdk/src/test/test_audio.cpp
@@ -42,13 +42,16 @@ void run_audio_tests()
     
     cout << "    Downloading sound effect..." << endl;
     download_sound_effect("text message 2", "http://soundbible.com/grab.php?id=2155&type=wav", 80);
+    cout << "    Playing downloaded sound effect..." << endl;
     play_sound_effect("text message 2", 2, 0.8);
     delay(5000);
     
     cout << "    Downloading music..." << endl;
-    download_music("music", "http://www.royaltyfreemusic.com/music_clips/free/Heartland_1.mp3", 80);
+    download_music("music", "http://assets.mixkit.co/music/493/493.mp3", 80);
+    cout << "    Playing downloaded music..." << endl;
     play_music("music");
     delay(5000);
+    stop_music();
     
     play_sound_effect(s1, 1, 1.0f);
     

--- a/coresdk/src/test/test_camera.cpp
+++ b/coresdk/src/test/test_camera.cpp
@@ -26,17 +26,18 @@ void run_camera_test()
     sprite_set_anchor_point(s, bitmap_cell_center(sprite_layer(s, 0)));
 
     bool follow = true;
+    const int speed = 10;
 
     while ( ! window_close_requested(w1) )
     {
         process_events();
 
-        if ( key_down( LEFT_KEY) ) sprite_set_dx(s, -1);
-        else if ( key_down( RIGHT_KEY) ) sprite_set_dx(s, 1);
+        if ( key_down( LEFT_KEY) ) sprite_set_dx(s, -speed);
+        else if ( key_down( RIGHT_KEY) ) sprite_set_dx(s, speed);
         else sprite_set_dx(s, 0);
 
-        if ( key_down( UP_KEY) ) sprite_set_dy(s, -1);
-        else if ( key_down( DOWN_KEY) ) sprite_set_dy(s, 1);
+        if ( key_down( UP_KEY) ) sprite_set_dy(s, -speed);
+        else if ( key_down( DOWN_KEY) ) sprite_set_dy(s, speed);
         else sprite_set_dy(s, 0);
 
         if ( key_typed(F_KEY) )
@@ -66,7 +67,7 @@ void run_camera_test()
         draw_triangle(COLOR_AQUA, screen_width() / 2, 0, 0, screen_height(), screen_width(), screen_height());
 
         draw_sprite(s);
-        refresh_screen();
+        refresh_screen(30);
     }
 
     close_window(w1);

--- a/coresdk/src/test/test_geometry.cpp
+++ b/coresdk/src/test/test_geometry.cpp
@@ -13,6 +13,7 @@ using namespace std;
 #include "window_manager.h"
 #include "graphics.h"
 #include "input.h"
+#include "timers.h"
 
 using namespace splashkit_lib;
 
@@ -470,6 +471,7 @@ void test_bitmap_ray_collision()
     point_2d bmp_3_center = point_offset_by(bmp_3_position, vector_to(bitmap_center(bmp_3)));
     point_2d ray_origin = point_at(100, 100);
     vector_2d ray_heading = vector_to(200, 200);
+    const double RAY_STEP = 5.0;
     
     while ( !window_close_requested(w1) ) {
         process_events();
@@ -477,13 +479,13 @@ void test_bitmap_ray_collision()
         clear_screen(COLOR_WHITE);
 
         if (key_down(UP_KEY))
-            ray_origin.y -= 1.0;
+            ray_origin.y -= RAY_STEP;
         if (key_down(DOWN_KEY))
-            ray_origin.y += 1.0;
+            ray_origin.y += RAY_STEP;
         if (key_down(LEFT_KEY))
-            ray_origin.x -= 1.0;
+            ray_origin.x -= RAY_STEP;
         if (key_down(RIGHT_KEY))
-            ray_origin.x += 1.0;
+            ray_origin.x += RAY_STEP;
         
         bool collision_1 = bitmap_ray_collision(bmp_1, 0, bmp_1_position, ray_origin, ray_heading);
         bool collision_2 = bitmap_ray_collision(bmp_2, 0, bmp_2_position, ray_origin, ray_heading);
@@ -517,7 +519,7 @@ void test_bitmap_ray_collision()
         circle ray_origin_circle = circle_at(ray_origin, 3.0);
         draw_circle(COLOR_BLUE, ray_origin_circle);
 
-        refresh_screen();
+        refresh_screen(30);
     }
     close_window(w1);
 }

--- a/coresdk/src/test/test_sprites.cpp
+++ b/coresdk/src/test/test_sprites.cpp
@@ -991,6 +991,7 @@ void test_sprite_ray_collision()
     sprite_set_rotation(s3, 10.0f);
     point_2d ray_origin = point_at(100, 100);
     vector_2d ray_heading = vector_to(200, 200);
+    const double RAY_STEP = 5.0;
     
     while ( !window_close_requested(w1) ) {
         process_events();
@@ -998,13 +999,13 @@ void test_sprite_ray_collision()
         clear_screen(COLOR_WHITE);
 
         if (key_down(UP_KEY))
-            ray_origin.y -= 1.0;
+            ray_origin.y -= RAY_STEP;
         if (key_down(DOWN_KEY))
-            ray_origin.y += 1.0;
+            ray_origin.y += RAY_STEP;
         if (key_down(LEFT_KEY))
-            ray_origin.x -= 1.0;
+            ray_origin.x -= RAY_STEP;
         if (key_down(RIGHT_KEY))
-            ray_origin.x += 1.0;
+            ray_origin.x += RAY_STEP;
         
         bool collision_1 = sprite_ray_collision(s1, ray_origin, ray_heading);
         bool collision_2 = sprite_ray_collision(s2, ray_origin, ray_heading);
@@ -1038,7 +1039,7 @@ void test_sprite_ray_collision()
         circle ray_origin_circle = circle_at(ray_origin, 3.0);
         draw_circle(COLOR_BLUE, ray_origin_circle);
         
-        refresh_screen();
+        refresh_screen(30);
     }
     close_window(w1);
 }

--- a/coresdk/src/test/test_tcp_networking.cpp
+++ b/coresdk/src/test/test_tcp_networking.cpp
@@ -129,7 +129,7 @@ void run_tcp_networking_test()
     pause_test();
 
     cout << "Client still:  " << lConA << endl;
-    cout << "Test message send (to closed client):  " << send_message_to(string("A", 876), lConB);
+    cout << "Test message send (to closed client):  " << send_message_to(string("A", 876), lConB) << endl;
 
     pause_test();
     cout << "Test message send (expect false):  " << send_message_to(string("A", 876), lConB) << endl;

--- a/coresdk/src/test/test_text.cpp
+++ b/coresdk/src/test/test_text.cpp
@@ -145,7 +145,7 @@ void run_text_test()
     load_font("kochi", "kochi-gothic-subst.ttf");
     draw_text("スプラッシュ・キット", COLOR_BLACK, "kochi", 30, 0, 280);
 
-    download_font("brawler", "https://github.com/google/fonts/raw/master/ofl/brawler/Brawler-Regular.ttf", 443);
+    download_font("brawler", "https://raw.githubusercontent.com/google/fonts/main/ofl/brawler/Brawler-Regular.ttf", 443);
     draw_text("Hello World: Brawler!", COLOR_BLACK, "brawler", 30, 0, 350);
     
     refresh_screen();

--- a/coresdk/src/test/test_ui.cpp
+++ b/coresdk/src/test/test_ui.cpp
@@ -20,8 +20,7 @@ using namespace splashkit_lib;
 void run_ui_test()
 {
     open_window("Test UI", 600, 600);
-
-    font fontA = load_font("interface font 1", "arial.ttf");
+    font fontA = load_font("interface font 1", "hara.ttf");
     font fontB = load_font("interface font 2", "kochi-gothic-subst.ttf");
     set_interface_font(fontA);
     set_interface_font_size(12);


### PR DESCRIPTION
# Description

### Problems

Integration tests run by `sktest.exe` sometimes produce inconsistent results between WSL and MSYS2 environments. 

- Animation test runs at a much faster speed in MSYS2, to the point where it's not even observable
- Camera movement in the camera test is much faster in MSYS2 than WSL
- Ray movement in the geometry test is much faster in MSYS2 than WSL
- Sprite movement in the sprite test is much faster in MSYS2 than WSL
- UI test fails to load `Arial.ttf` on WSL (A windows default font not included in the `Resources` directory)

### Summary of changes

Fixes have been applied where possible _without editing core SplashKit functions_. There are some critical issues affecting MSYS2 which cause some tests to fail, but these bugs are not caused by the tests themselves, and will be updated in separate PRs. This PR also includes some minor changes unrelated to environment consistency (such as broken URLs and output messages). These have been addressed to allow the tests to run clearly.

- **Animation:** Added frame rate cap to fix MSYS2 animation playing too fast
- **Animation:** Minor `cout` adjustments for readability
- **Audio:** Updated music URL to valid path
- **Audio:** Adjusted `cout` messages to improve result clarity
- **Audio:** Stopped music after 5 seconds to improve result clarity
- **Camera:** Added frame cap and camera move speed for cross-platform consistency
- **Geometry:** Added frame cap and ray move speed for cross-platform consistency
- **Sprites:** Added frame cap and sprite move speed for cross-platform consistency
- **TCP Networking:** Added endl to improve readability
- **Text:** Updated font URL to valid path
- **UI:** Changed font from Arial to Hara to avoid missing font in WSL/Linux

### Known issues not addressed by this PR

- Issues with running `sktest.exe` in MSYS2 environment
   There have been some reported issues running `sktest` (at all) on MSYS2. Specifically, the animation test was found to loop indefinitely, and some users found the test runner was freezing even before tests were launched. This has been addressed in #132.

- Graphical bugs
   There are inconsistent results when running graphics, input, and text tests in MSYS2, with graphical output displaying unexpected results. An example is shown [here](https://github.com/user-attachments/assets/7ce4b8a0-b251-401b-9eca-15a373689437). This is likely related to drawing text in MSYS2, and cannot be addressed by updating the tests themselves.

- Issues with download paths in MSYS2
 Some download functions are buggy in MSYS2, most likely due to path differences in Windows vs Linux. This affects:
  - Audio test: `download_music`
  - Text test: `download_font`
  - Window test: `download_bitmap`

- Terminal test fails
 Fails on both WSL and MSYS2. Not yet investigated.

- UI test fails on MSYS2
 Due to an issue with `interface.cpp` - addressed in #155.

- Bundle test fails bitmap freeing
 Addressed in #131.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran `sktest` in WSL and MSYS2 environments

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
