### PR TITLE
Fix interface out of bounds error on MSYS2

### DIFF
--- a/coresdk/src/coresdk/interface.cpp
+++ b/coresdk/src/coresdk/interface.cpp
@@ -303,6 +303,7 @@ namespace splashkit_lib
     void _update_row_layout()
     {
         if (container_stack.size() == 0) return;
+        if (container_stack.back().layout_widths.empty()) return;
 
         sk_interface_set_layout(container_stack.back().layout_widths.size(), &container_stack.back().layout_widths[0], container_stack.back().layout_height);
     }


### PR DESCRIPTION
# Description

### Problem

Interfaces have a bug which can cause out-of-bounds errors in MSYS2. When running the UI test in MSYS2 via `sktest.exe`, the following error is received:

```shell
C:/msys64/mingw64/include/c++/15.2.0/bits/stl_vector.h:1263: constexpr std::vector<_Tp, _Alloc>::ref
erence std::vector<_Tp, _Alloc>::operator[](size_type) [with _Tp = int; _Alloc = std::allocator<int>
; reference = int&; size_type = long long unsigned int]: Assertion '__n < this->size()' failed.
```

### Cause

The error can be traced back to `interface.cpp`, line 308 in the `_update_row_layout` function, which has:
```cpp
sk_interface_set_layout(container_stack.back().layout_widths.size(), &container_stack.back().layout_widths[0], container_stack.back().layout_height);
```

This line attempts to access the `layout_widths` vector's first element (`container_stack.back().layout_widths[0]`), but many callers of `_update_row_layout` clear `layout_widths` beforehand, meaning the vector is empty and the out-of-bounds error occurs.

### Fix

A simple guard has been added to `_update_row_layout`, to check if `layout_widths` is empty before proceeding.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested primarily using the UI test in `sktest.exe` in MSYS2 and WSL. Interface displays as expected, with no errors received:

<img width="602" height="627" alt="image" src="https://github.com/user-attachments/assets/d5446009-d737-4013-ae99-351c5e1dd38e" />

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Note for Testers

There have been some reported issues running `sktest` (at all) on MSYS2. Specifically, the animation test was found to loop indefinitely, and some users found the test runner was freezing even before tests were launched. This has been addressed in #132.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
