### PR TITLE
Add resources unit tests; remove old test hook

### DIFF
--- a/coresdk/src/test/test_main.cpp
+++ b/coresdk/src/test/test_main.cpp
@@ -45,7 +45,6 @@ void setup_tests()
     add_test("Input", run_input_test);
     add_test("Logging", run_logging_test);
     add_test("Physics", run_physics_test);
-    add_test("Resources", run_resources_tests);
     add_test("Shape drawing", run_shape_drawing_test);
     add_test("Sprite tests", run_sprite_test);
     add_test("Terminal", run_terminal_test);

--- a/coresdk/src/test/test_main.h
+++ b/coresdk/src/test/test_main.h
@@ -15,7 +15,6 @@ void run_shape_drawing_test();
 void run_animation_test();
 void run_text_test();
 void run_audio_tests();
-void run_resources_tests();
 void run_windows_tests();
 void run_graphics_test();
 

--- a/coresdk/src/test/unit_tests/unit_test_resources.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_resources.cpp
@@ -1,0 +1,96 @@
+#include "catch.hpp"
+
+#include "resources.h"
+
+using namespace splashkit_lib;
+using std::string;
+
+namespace
+{
+    struct resources_path_guard
+    {
+        string original;
+
+        resources_path_guard()
+            : original(path_to_resources())
+        {
+        }
+
+        ~resources_path_guard()
+        {
+            set_resources_path(original);
+        }
+    };
+
+#ifdef WINDOWS
+    const string PATH_SEP = "\\";
+#else
+    const string PATH_SEP = "/";
+#endif
+
+    string dir_path(const string &base, const string &folder)
+    {
+        return base + PATH_SEP + folder + PATH_SEP;
+    }
+
+    string file_path(const string &base, const string &filename)
+    {
+        return base + PATH_SEP + filename;
+    }
+}
+
+TEST_CASE("configured resources path is returned", "[resources][path_to_resources]")
+{
+    resources_path_guard guard;
+    const string test_path = "resources-base";
+
+    set_resources_path(test_path);
+
+    REQUIRE(path_to_resources() == test_path);
+}
+
+TEST_CASE("resource kind paths map to expected folders", "[resources][path_to_resources_kind]")
+{
+    resources_path_guard guard;
+    const string base_path = "resources-base";
+
+    set_resources_path(base_path);
+
+    REQUIRE(path_to_resources(ANIMATION_RESOURCE) == dir_path(base_path, "animations"));
+    REQUIRE(path_to_resources(BUNDLE_RESOURCE) == dir_path(base_path, "bundles"));
+    REQUIRE(path_to_resources(FONT_RESOURCE) == dir_path(base_path, "fonts"));
+    REQUIRE(path_to_resources(IMAGE_RESOURCE) == dir_path(base_path, "images"));
+    REQUIRE(path_to_resources(JSON_RESOURCE) == dir_path(base_path, "json"));
+    REQUIRE(path_to_resources(MUSIC_RESOURCE) == dir_path(base_path, "sounds"));
+    REQUIRE(path_to_resources(SERVER_RESOURCE) == dir_path(base_path, "server"));
+    REQUIRE(path_to_resources(SOUND_RESOURCE) == dir_path(base_path, "sounds"));
+    REQUIRE(path_to_resources(TIMER_RESOURCE) == base_path);
+    REQUIRE(path_to_resources(OTHER_RESOURCE) == base_path);
+}
+
+TEST_CASE("resources path can be updated", "[resources][set_resources_path]")
+{
+    resources_path_guard guard;
+    const string first_path = "resources-path-one";
+    const string second_path = "resources-path-two";
+
+    set_resources_path(first_path);
+    REQUIRE(path_to_resources() == first_path);
+
+    set_resources_path(second_path);
+    REQUIRE(path_to_resources() == second_path);
+    REQUIRE(path_to_resources(IMAGE_RESOURCE) == dir_path(second_path, "images"));
+}
+
+TEST_CASE("path_to_resource combines folder and filename", "[resources][path_to_resource]")
+{
+    resources_path_guard guard;
+    const string base_path = "resources-base";
+
+    set_resources_path(base_path);
+
+    REQUIRE(path_to_resource("ufo.png", IMAGE_RESOURCE) == dir_path(base_path, "images") + "ufo.png");
+    REQUIRE(path_to_resource("beep.wav", SOUND_RESOURCE) == dir_path(base_path, "sounds") + "beep.wav");
+    REQUIRE(path_to_resource("config.json", JSON_RESOURCE) == dir_path(base_path, "json") + "config.json");
+    REQUIRE(path_to_resource("root.txt", OTHER_RESOURCE) == file_path(base_path, "root.txt"));
+}


### PR DESCRIPTION
# Description

This PR adds dedicated Catch2 coverage for resources path utilities and removes the legacy manual Resources test registration from the old sktest runner.

Summary of changes:
- Added unit_test_resources.cpp with tests for:
- path_to_resources
- path_to_resources(kind) for all resource kinds
- set_resources_path
- path_to_resource
- Added platform separator helpers in the new test file for stable path assertions.
- Added an RAII guard in the new test file to restore the original resources path after each test case.
- Removed old run_resources_tests registration from test_main.cpp.
- Removed old run_resources_tests declaration from test_main.h.

Motivation and context:
- The previous resources test path was a legacy manual print-based check in sktest.
- This change migrates resources verification into automated unit tests so behavior is asserted and regressions are caught by CI/test runs.
- The RAII guard prevents global resource path state leakage across tests.

Dependencies required for this change:
- No new runtime dependencies.
- Uses existing Catch2 unit test setup already present in the project.

Fixes #<issue-number>

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Current status:
- Not executed in this shell due local CMake/toolchain mismatch in the current PowerShell environment.

Reproduction steps:
1. Open an environment with the project’s expected build toolchain (MSYS2/MinGW as configured for this repo).
2. From cmake, run: cmake --preset Windows
3. From cmake, run: cmake --build build --target skunit_tests
4. Run the unit tests binary with resources filter, for example: skunit_tests [resources]
5. Optionally run full suite: skunit_tests

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request