### PR TITLE
Add TCP and UDP network unit tests

### DIFF
--- a/coresdk/src/test/unit_tests/unit_test_network.cpp
+++ b/coresdk/src/test/unit_tests/unit_test_network.cpp
@@ -1,10 +1,29 @@
 #include "catch.hpp"
 
+#include <functional>
+
 #include "networking.h"
+#include "utils.h"
 
 #include "logging_handling.h"
 
 using namespace splashkit_lib;
+
+namespace
+{
+bool wait_for_network_condition(const std::function<bool()> &condition, int timeout_ms = 1000)
+{
+    unsigned int start = current_ticks();
+    while (current_ticks() - start < static_cast<unsigned int>(timeout_ms))
+    {
+        check_network_activity();
+        if (condition())
+            return true;
+        delay(1);
+    }
+    return condition();
+}
+}
 
 TEST_CASE("can create a server", "[networking]")
 {
@@ -234,4 +253,89 @@ TEST_CASE("can convert network data")
         REQUIRE_FALSE(is_valid_ipv4("abc.def.ghi.jkl")); // Letters
         REQUIRE_FALSE(is_valid_ipv4("192,168,1,1"));     // Wrong separator
     }
+}
+
+TEST_CASE("tcp messages can flow both ways", "[networking][tcp]")
+{
+    close_all_servers();
+    close_all_connections();
+
+    constexpr unsigned short int PORT = 3010;
+    const string SERVER_NAME = "unit_test_tcp_server";
+    const string CLIENT_NAME = "unit_test_tcp_client";
+    const string CLIENT_TO_SERVER_MSG = "To server --> from client";
+    const string SERVER_TO_CLIENT_MSG = "To client --> from server";
+
+    server_socket server = create_server(SERVER_NAME, PORT, TCP);
+    REQUIRE(server != nullptr);
+
+    connection client = open_connection(CLIENT_NAME, "127.0.0.1", PORT, TCP);
+    REQUIRE(client != nullptr);
+    REQUIRE(wait_for_network_condition([&]() { return server_has_new_connection(server); }));
+    REQUIRE(accept_new_connection(server));
+
+    connection server_side_client = last_connection(server);
+    REQUIRE(server_side_client != nullptr);
+    REQUIRE(connection_count(server) == 1);
+
+    REQUIRE(send_message_to(CLIENT_TO_SERVER_MSG, client));
+    REQUIRE(wait_for_network_condition([&]() { return has_messages(server); }));
+
+    message to_server = read_message(server);
+    REQUIRE(to_server != nullptr);
+    REQUIRE(message_data(to_server) == CLIENT_TO_SERVER_MSG);
+    close_message(to_server);
+
+    REQUIRE(send_message_to(SERVER_TO_CLIENT_MSG, server_side_client));
+    REQUIRE(wait_for_network_condition([&]() { return has_messages(client); }));
+
+    message to_client = read_message(client);
+    REQUIRE(to_client != nullptr);
+    REQUIRE(message_data(to_client) == SERVER_TO_CLIENT_MSG);
+    close_message(to_client);
+
+    REQUIRE(close_server(server));
+    close_all_connections();
+    close_all_servers();
+}
+
+
+TEST_CASE("udp messages can flow both ways", "[networking][udp]")
+{
+    close_all_servers();
+    close_all_connections();
+
+    constexpr unsigned short int PORT = 3011;
+    const string SERVER_NAME = "unit_test_udp_server";
+    const string TO_SERVER_NAME = "unit_test_to_server";
+    const string TO_CLIENT_NAME = "unit_test_to_client";
+    const string UDP_TO_SERVER_MSG = "Hello UDP";
+    const string UDP_TO_CLIENT_MSG = "Hello Client";
+
+    server_socket server = create_server(SERVER_NAME, PORT, UDP);
+    REQUIRE(server != nullptr);
+
+    connection to_server = open_connection(TO_SERVER_NAME, "127.0.0.1", PORT, UDP);
+    REQUIRE(to_server != nullptr);
+
+    REQUIRE(send_message_to(UDP_TO_SERVER_MSG, to_server));
+    REQUIRE(wait_for_network_condition([&]() { return has_messages(server); }));
+
+    message msg = read_message(server);
+    REQUIRE(msg != nullptr);
+    REQUIRE(message_data(msg) == UDP_TO_SERVER_MSG);
+
+    connection to_client = open_connection(TO_CLIENT_NAME, message_host(msg), message_port(msg), UDP);
+    REQUIRE(to_client != nullptr);
+    REQUIRE(send_message_to(UDP_TO_CLIENT_MSG, to_client));
+
+    REQUIRE(wait_for_network_condition([&]() { return has_messages(to_server); }));
+    REQUIRE(read_message_data(to_server) == UDP_TO_CLIENT_MSG);
+
+    close_message(msg);
+    REQUIRE(close_connection(to_server));
+    REQUIRE(close_server(server));
+
+    close_all_connections();
+    close_all_servers();
 }

--- a/projects/cmake/build-ninja/Testing/Temporary/CTestCostData.txt
+++ b/projects/cmake/build-ninja/Testing/Temporary/CTestCostData.txt
@@ -1,0 +1,11 @@
+can create a server 0 0
+can communicate with server 0 0
+can convert network data 0 0
+tcp messages can flow both ways 0 0
+udp messages can flow both ways 0 0
+---
+can create a server
+can communicate with server
+can convert network data
+tcp messages can flow both ways
+udp messages can flow both ways

--- a/projects/cmake/build-ninja/Testing/Temporary/LastTest.log
+++ b/projects/cmake/build-ninja/Testing/Temporary/LastTest.log
@@ -1,0 +1,78 @@
+Start testing: Apr 26 20:08 Sri Lanka Standard Time
+----------------------------------------------------------
+64/85 Testing: can create a server
+64/85 Test: can create a server
+Command: "C:/Users/USER/Documents/Projects/splashkit-core/bin/skunit_tests.exe" "can create a server"
+Directory: C:/Users/USER/Documents/Projects/splashkit-core/projects/cmake/build-ninja
+"can create a server" start time: Apr 26 20:08 Sri Lanka Standard Time
+Output:
+----------------------------------------------------------
+<end of output>
+Test time =   0.01 sec
+----------------------------------------------------------
+Test Failed.
+"can create a server" end time: Apr 26 20:08 Sri Lanka Standard Time
+"can create a server" time elapsed: 00:00:00
+----------------------------------------------------------
+
+65/85 Testing: can communicate with server
+65/85 Test: can communicate with server
+Command: "C:/Users/USER/Documents/Projects/splashkit-core/bin/skunit_tests.exe" "can communicate with server"
+Directory: C:/Users/USER/Documents/Projects/splashkit-core/projects/cmake/build-ninja
+"can communicate with server" start time: Apr 26 20:08 Sri Lanka Standard Time
+Output:
+----------------------------------------------------------
+<end of output>
+Test time =   0.01 sec
+----------------------------------------------------------
+Test Failed.
+"can communicate with server" end time: Apr 26 20:08 Sri Lanka Standard Time
+"can communicate with server" time elapsed: 00:00:00
+----------------------------------------------------------
+
+66/85 Testing: can convert network data
+66/85 Test: can convert network data
+Command: "C:/Users/USER/Documents/Projects/splashkit-core/bin/skunit_tests.exe" "can convert network data"
+Directory: C:/Users/USER/Documents/Projects/splashkit-core/projects/cmake/build-ninja
+"can convert network data" start time: Apr 26 20:08 Sri Lanka Standard Time
+Output:
+----------------------------------------------------------
+<end of output>
+Test time =   0.01 sec
+----------------------------------------------------------
+Test Failed.
+"can convert network data" end time: Apr 26 20:08 Sri Lanka Standard Time
+"can convert network data" time elapsed: 00:00:00
+----------------------------------------------------------
+
+67/85 Testing: tcp messages can flow both ways
+67/85 Test: tcp messages can flow both ways
+Command: "C:/Users/USER/Documents/Projects/splashkit-core/bin/skunit_tests.exe" "tcp messages can flow both ways"
+Directory: C:/Users/USER/Documents/Projects/splashkit-core/projects/cmake/build-ninja
+"tcp messages can flow both ways" start time: Apr 26 20:08 Sri Lanka Standard Time
+Output:
+----------------------------------------------------------
+<end of output>
+Test time =   0.01 sec
+----------------------------------------------------------
+Test Failed.
+"tcp messages can flow both ways" end time: Apr 26 20:08 Sri Lanka Standard Time
+"tcp messages can flow both ways" time elapsed: 00:00:00
+----------------------------------------------------------
+
+68/85 Testing: udp messages can flow both ways
+68/85 Test: udp messages can flow both ways
+Command: "C:/Users/USER/Documents/Projects/splashkit-core/bin/skunit_tests.exe" "udp messages can flow both ways"
+Directory: C:/Users/USER/Documents/Projects/splashkit-core/projects/cmake/build-ninja
+"udp messages can flow both ways" start time: Apr 26 20:08 Sri Lanka Standard Time
+Output:
+----------------------------------------------------------
+<end of output>
+Test time =   0.01 sec
+----------------------------------------------------------
+Test Failed.
+"udp messages can flow both ways" end time: Apr 26 20:08 Sri Lanka Standard Time
+"udp messages can flow both ways" time elapsed: 00:00:00
+----------------------------------------------------------
+
+End testing: Apr 26 20:08 Sri Lanka Standard Time

--- a/projects/cmake/build-ninja/Testing/Temporary/LastTestsFailed.log
+++ b/projects/cmake/build-ninja/Testing/Temporary/LastTestsFailed.log
@@ -1,0 +1,5 @@
+64:can create a server
+65:can communicate with server
+66:can convert network data
+67:tcp messages can flow both ways
+68:udp messages can flow both ways


### PR DESCRIPTION
## Description

This PR expands networking unit test coverage by porting core TCP and UDP message-flow checks from sktest into the Catch2 unit test suite.

Changes included:
- Added TCP message round-trip test in unit_test_network.cpp
- Added UDP message round-trip test in unit_test_network.cpp
- Added a small polling helper for async network activity to reduce timing flakiness in unit tests
- Added missing functional header/namespace usage required by the helper in unit_test_network.cpp

Motivation:
- Existing sktest had TCP/UDP message tests, but equivalent coverage was missing in skunit_tests.
- This brings automated unit coverage closer to behavior already manually verified in sktest.

Dependencies:
- No new project dependencies added.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

Build and discovery:
1. Configure CMake Ninja build for tests
2. Build skunit_tests target
3. Verify test discovery with ctest -N

Networking test execution:
1. Run filtered networking tests through CTest:
   ctest --test-dir projects/cmake/build-ninja -R "network|server|communicate|tcp messages|udp messages" --output-on-failure
2. Confirmed new test cases are discovered:
   - tcp messages can flow both ways
   - udp messages can flow both ways

Current environment result:
- Test execution in this Windows environment fails at process startup with exit code 0xc0000139 across networking cases (runtime DLL/entrypoint issue), including pre-existing networking tests.
- This indicates an environment/runtime problem rather than an assertion failure specific to the newly added tests.

## Testing Checklist

- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request