### PR TITLE
Out of range bug fix

### DIFF
--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -206,7 +206,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        return stoi(bin_str, nullptr, 2);
+        return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
     }
 
     string hex_to_bin(const string &hex_str)
@@ -300,7 +300,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        return stoi(octal_string, nullptr, 8);
+        return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
     }
 
     unsigned int hex_to_dec(const string &hex_string)


### PR DESCRIPTION
# Description

Fixed the std::out_of_range exception that was happening in the unit tests for the functions:

- `bin_to_dec`
- `oct_to_dec`

This problem that was causing the exception to be thrown was the call to `std::stoi` in the functions above which were returning an `unsigned int`. This was resolved by changing `std::stoi` to `static_cast<unsigned int>(std::stoul(...))` to have the correct return type and avoid a `-Werror-conversion` flag. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can
reproduce. Please also list any relevant details for your test configuration_

Both sktest and skunit_tests were ran and no exceptions were thrown and no tests were failed for the two functions that were changed.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
