### PR TITLE
Out of range bugfix

### DIFF
--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -317,6 +317,11 @@ namespace splashkit_lib
 	  return std::numeric_limits<unsigned int>::max();
         }
 
+        if(octal_string.length() == 11 && octal_string.front() > '3')
+        {
+	  return std::numeric_limits<unsigned int>::max();
+        }
+
         try
         {
 	  return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -208,16 +208,16 @@ namespace splashkit_lib
 
         try
         {
-	  const unsigned long result = std::stoul(bin_str, nullptr, 2);
+            const unsigned long result = std::stoul(bin_str, nullptr, 2);
 
-	  if (result > std::numeric_limits<unsigned int>::max())
-	  {
-	      return std::numeric_limits<unsigned int>::max();
-	  }
-	  else
-	  {
-	      return static_cast<unsigned int>(result);
-	  }
+            if (result > std::numeric_limits<unsigned int>::max())
+            {
+                return std::numeric_limits<unsigned int>::max();
+            }
+            else
+            {
+                return static_cast<unsigned int>(result);
+            }
         }
         catch (const std::exception& error)
         {
@@ -319,21 +319,21 @@ namespace splashkit_lib
 
         try
         {
-	  const unsigned long result = std::stoul(octal_string, nullptr, 8);
+            const unsigned long result = std::stoul(octal_string, nullptr, 8);
 
-	  if (result > std::numeric_limits<unsigned int>::max())
-	  {
-	      return std::numeric_limits<unsigned int>::max();
-	  }
-	  else
-	  {
-	      return static_cast<unsigned int>(result);
-	  }
+            if (result > std::numeric_limits<unsigned int>::max())
+            {
+                return std::numeric_limits<unsigned int>::max();
+            }
+            else
+            {
+                return static_cast<unsigned int>(result);
+            }
         }
         catch (const std::exception& error)
         {
             LOG(ERROR) << "Invalid octal string \"" << octal_string << "\" passed to oct_to_dec. Returning 0.";
-	  return 0;
+            return 0;
         }
     }
 
@@ -351,11 +351,11 @@ namespace splashkit_lib
 
             if (result > std::numeric_limits<unsigned int>::max())
             {
-              return std::numeric_limits<unsigned int>::max();
+                return std::numeric_limits<unsigned int>::max();
             }
             else
             {
-              return static_cast<unsigned int>(result);
+                return static_cast<unsigned int>(result);
             }
         }
         catch (const std::exception& error)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -205,16 +205,21 @@ namespace splashkit_lib
             LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
             return 0;
         }
-        if(bin_str.length() > 32)
-        {
-	  return std::numeric_limits<unsigned int>::max();
-        }
 
         try
         {
-	  return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
+	  const unsigned long result = std::stoul(bin_str, nullptr, 2);
+
+	  if (result > std::numeric_limits<unsigned int>::max())
+	  {
+	      return std::numeric_limits<unsigned int>::max();
+	  }
+	  else
+	  {
+	      return static_cast<unsigned int>(result);
+	  }
         }
-        catch(const std::exception& error)
+        catch (const std::exception& error)
         {
             LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
             return 0;

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -347,21 +347,21 @@ namespace splashkit_lib
 
         try
         {
-	  const unsigned long result = std::stoul(hex_string, nullptr, 16);
+            const unsigned long result = std::stoul(hex_string, nullptr, 16);
 
-	  if (result > std::numeric_limits<unsigned int>::max())
-	  {
-	      return std::numeric_limits<unsigned int>::max();
-	  }
-	  else
-	  {
-	      return static_cast<unsigned int>(result);
-	  }
+            if (result > std::numeric_limits<unsigned int>::max())
+            {
+              return std::numeric_limits<unsigned int>::max();
+            }
+            else
+            {
+              return static_cast<unsigned int>(result);
+            }
         }
         catch (const std::exception& error)
         {
             LOG(ERROR) << "Invalid hex string \"" << hex_string << "\" passed to hex_to_dec. Returning 0.";
-	  return 0;
+            return 0;
         }
     }
 

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -341,7 +341,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        return stoi(hex_string, nullptr, 16);
+        return std::stoi(hex_string, nullptr, 16);
     }
 
     string oct_to_bin(const string &octal_str)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -143,6 +143,40 @@ namespace splashkit_lib
         return (*p == 0);
     }
 
+    template<typename output>
+    output clamp_in_range(output number)
+    {
+        if (result > std::numeric_limits<output>::max())
+        {
+            return std::numeric_limits<output>::max();
+        }
+        else
+        {
+            return static_cast<output>(result);
+        }
+    }
+
+    template<typename output>
+    output convert_string(const string &input, int base = 10)
+    {
+        try
+        {
+            if constexpr (std::same_as<double, output>)
+            {
+                return clamp_in_range<output>(std::stod(input))
+            }
+            else
+            {
+                return clamp_in_range<output>(std::stoul(input, nullptr, base));
+            }
+        }
+        catch (const std::exception& error)
+        {
+            LOG(ERROR) << "Invalid string \"" << input << "\" passed to conversion function. Returning 0.";
+            return 0;
+        }
+    }
+
     int convert_to_integer(const string &text)
     {
         return std::stoi(text);
@@ -206,24 +240,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        try
-        {
-            const unsigned long result = std::stoul(bin_str, nullptr, 2);
-
-            if (result > std::numeric_limits<unsigned int>::max())
-            {
-                return std::numeric_limits<unsigned int>::max();
-            }
-            else
-            {
-                return static_cast<unsigned int>(result);
-            }
-        }
-        catch (const std::exception& error)
-        {
-            LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
-            return 0;
-        }
+        return convert_string<unsigned int>(bin_str, 2);
     }
 
     string hex_to_bin(const string &hex_str)
@@ -317,24 +334,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        try
-        {
-            const unsigned long result = std::stoul(octal_string, nullptr, 8);
-
-            if (result > std::numeric_limits<unsigned int>::max())
-            {
-                return std::numeric_limits<unsigned int>::max();
-            }
-            else
-            {
-                return static_cast<unsigned int>(result);
-            }
-        }
-        catch (const std::exception& error)
-        {
-            LOG(ERROR) << "Invalid octal string \"" << octal_string << "\" passed to oct_to_dec. Returning 0.";
-            return 0;
-        }
+        return convert_string<unsigned int>(octal_string, 8);
     }
 
     unsigned int hex_to_dec(const string &hex_string)
@@ -345,24 +345,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        try
-        {
-            const unsigned long result = std::stoul(hex_string, nullptr, 16);
-
-            if (result > std::numeric_limits<unsigned int>::max())
-            {
-                return std::numeric_limits<unsigned int>::max();
-            }
-            else
-            {
-                return static_cast<unsigned int>(result);
-            }
-        }
-        catch (const std::exception& error)
-        {
-            LOG(ERROR) << "Invalid hex string \"" << hex_string << "\" passed to hex_to_dec. Returning 0.";
-            return 0;
-        }
+        return convert_string<unsigned int>(hex_string, 16);
     }
 
     string oct_to_bin(const string &octal_str)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -9,6 +9,7 @@
 #include "basics.h"
 #include "easylogging++.h"
 
+#include <concepts>
 #include <algorithm>
 #include <cstdlib>
 

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -143,27 +143,30 @@ namespace splashkit_lib
         return (*p == 0);
     }
 
-    template<typename output>
-    output clamp_in_range(output number)
+    template<typename T>
+    concept Numeric = std::integral<T> || std::floating_point<T>;
+
+    template<Numeric output, Numeric input = unsigned long>
+    output clamp_in_range(input number)
     {
-        if (result > std::numeric_limits<output>::max())
+        if (number > std::numeric_limits<output>::max())
         {
             return std::numeric_limits<output>::max();
         }
         else
         {
-            return static_cast<output>(result);
+            return static_cast<output>(number);
         }
     }
 
-    template<typename output>
+    template<Numeric output>
     output convert_string(const string &input, int base = 10)
     {
         try
         {
-            if constexpr (std::same_as<double, output>)
+            if constexpr (std::floating_point<output>)
             {
-                return clamp_in_range<output>(std::stod(input))
+                return clamp_in_range<output, double>(std::stod(input));
             }
             else
             {

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -205,7 +205,7 @@ namespace splashkit_lib
             LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
             return 0;
         }
-        if(bin_str.length() > 32)
+        if (bin_str.length() > 32)
         {
 	  return std::numeric_limits<unsigned int>::max();
         }
@@ -214,7 +214,7 @@ namespace splashkit_lib
         {
 	  return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
         }
-        catch(const std::exception& error)
+        catch (const std::exception& error)
         {
             LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
             return 0;
@@ -312,12 +312,12 @@ namespace splashkit_lib
             return 0;
         }
 
-        if(octal_string.length() > 11)
+        if (octal_string.length() > 11)
         {
 	  return std::numeric_limits<unsigned int>::max();
         }
 
-        if(octal_string.length() == 11 && octal_string.front() > '3')
+        if (octal_string.length() == 11 && octal_string.front() > '3')
         {
 	  return std::numeric_limits<unsigned int>::max();
         }
@@ -326,7 +326,7 @@ namespace splashkit_lib
         {
 	  return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
         }
-        catch(const std::exception& error)
+        catch (const std::exception& error)
         {
             LOG(ERROR) << "Invalid octal string \"" << octal_string << "\" passed to oct_to_dec. Returning 0.";
 	  return 0;

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -206,7 +206,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        return stoi(bin_str, nullptr, 2);
+        return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
     }
 
     string hex_to_bin(const string &hex_str)
@@ -300,7 +300,7 @@ namespace splashkit_lib
             return 0;
         }
 
-        return stoi(octal_string, nullptr, 8);
+        return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
     }
 
     unsigned int hex_to_dec(const string &hex_string)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -205,8 +205,20 @@ namespace splashkit_lib
             LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
             return 0;
         }
+        if(bin_str.length() > 32)
+        {
+	  return std::numeric_limits<unsigned int>::max();
+        }
 
-        return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
+        try
+        {
+	  return static_cast<unsigned int>(std::stoul(bin_str, nullptr, 2));
+        }
+        catch(const std::exception& error)
+        {
+            LOG(ERROR) << "Invalid binary string \"" << bin_str << "\" passed to bin_to_dec. Returning 0.";
+            return 0;
+        }
     }
 
     string hex_to_bin(const string &hex_str)
@@ -300,7 +312,20 @@ namespace splashkit_lib
             return 0;
         }
 
-        return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
+        if(octal_string.length() > 11)
+        {
+	  return std::numeric_limits<unsigned int>::max();
+        }
+
+        try
+        {
+	  return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
+        }
+        catch(const std::exception& error)
+        {
+            LOG(ERROR) << "Invalid octal string \"" << octal_string << "\" passed to oct_to_dec. Returning 0.";
+	  return 0;
+        }
     }
 
     unsigned int hex_to_dec(const string &hex_string)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -341,11 +341,28 @@ namespace splashkit_lib
     {
         if (!is_hex(hex_string))
         {
-            LOG(ERROR) << "Invalid octal string \"" << hex_string << "\" passed to hex_to_dec. Returning 0.";
+            LOG(ERROR) << "Invalid hex string \"" << hex_string << "\" passed to hex_to_dec. Returning 0.";
             return 0;
         }
 
-        return std::stoi(hex_string, nullptr, 16);
+        try
+        {
+	  const unsigned long result = std::stoul(hex_string, nullptr, 16);
+
+	  if (result > std::numeric_limits<unsigned int>::max())
+	  {
+	      return std::numeric_limits<unsigned int>::max();
+	  }
+	  else
+	  {
+	      return static_cast<unsigned int>(result);
+	  }
+        }
+        catch (const std::exception& error)
+        {
+            LOG(ERROR) << "Invalid hex string \"" << hex_string << "\" passed to hex_to_dec. Returning 0.";
+	  return 0;
+        }
     }
 
     string oct_to_bin(const string &octal_str)

--- a/coresdk/src/coresdk/basics.cpp
+++ b/coresdk/src/coresdk/basics.cpp
@@ -317,19 +317,16 @@ namespace splashkit_lib
             return 0;
         }
 
-        if(octal_string.length() > 11)
-        {
-	  return std::numeric_limits<unsigned int>::max();
-        }
-
-        if(octal_string.length() == 11 && octal_string.front() > '3')
-        {
-	  return std::numeric_limits<unsigned int>::max();
-        }
-
         try
         {
-	  return static_cast<unsigned int>(std::stoul(octal_string, nullptr, 8));
+	  const unsigned long result = std::stoul(octal_string, nullptr, 8);
+
+	  if (result > std::numeric_limits<unsigned int>::max())
+	  {
+	      return std::numeric_limits<unsigned int>::max();
+	  }
+
+	  return static_cast<unsigned int>(result);
         }
         catch(const std::exception& error)
         {

--- a/coresdk/src/coresdk/basics.h
+++ b/coresdk/src/coresdk/basics.h
@@ -19,7 +19,7 @@ using std::vector;
 
 namespace splashkit_lib
 {
-    
+
     /**
      * Return a new string that removes the spaces from the start and end of
      * the input string.
@@ -101,7 +101,7 @@ namespace splashkit_lib
 
     /**
      * Returns true if the string contains the substring.
-     * 
+     *
      * @param text      The text to search
      * @param subtext   The substring to search for
      * @returns         True if the substring is found in the text.
@@ -110,7 +110,7 @@ namespace splashkit_lib
 
     /**
      * Returns the index of the first occurrence of the substring in the text.
-     * 
+     *
      * @param text      The text to search
      * @param subtext   The substring to search for
      * @returns         The index of the first occurrence of the substring in the text, or -1 if the substring is not found.
@@ -119,7 +119,7 @@ namespace splashkit_lib
 
     /**
      * Replace all occurrences of a substring in a string with another string.
-     * 
+     *
      * @param text      The text to search
      * @param substr    The substring to find and replace
      * @param new_text  The string to replace the substring with
@@ -129,7 +129,7 @@ namespace splashkit_lib
 
     /**
      * Split a string into an array of strings based on a delimiter.
-     * 
+     *
      * @param text      The text to split
      * @param delimiter The character to split the text on
      * @returns         An array of strings
@@ -169,7 +169,7 @@ namespace splashkit_lib
      * @returns True if the string is a valid octal string, false otherwise
      */
     bool is_octal(const string &octal_str);
-    
+
     /**
      * @brief Converts a decimal (unsigned integer) to a binary string
      *
@@ -187,6 +187,8 @@ namespace splashkit_lib
      *
      * Converts the provided binary string into an unsigned integer.
      * For example, "1010" will be converted to 10.
+     * Any input that exceedes the max value of unsigned integer will silently truncate and not be treated as an error.
+     * Any out of range error that occurs will result in the value being returned being 0.
      *
      * @param bin Binary string to convert
      *
@@ -235,6 +237,8 @@ namespace splashkit_lib
      *
      * Converts the provided octal string into its decimal representation.
      * For example, "100" will be converted to 64.
+     * Any input that exceedes the max value of unsigned integer will silently truncate and not be treated as an error.
+     * Any out of range error that occurs will result in the value being returned being 0.
      *
      * @param octal_string Octal string to convert
      *
@@ -280,9 +284,9 @@ namespace splashkit_lib
 
     /**
      * @brief Convert a hexadecimal string to its numeric value.
-     * 
+     *
      * @param hex_string the data to convert
-     * 
+     *
      * @return unsigned int the numeric value of the hex string
      */
     unsigned int hex_to_dec(const string &hex_string);

--- a/coresdk/src/coresdk/basics.h
+++ b/coresdk/src/coresdk/basics.h
@@ -284,6 +284,9 @@ namespace splashkit_lib
 
     /**
      * @brief Convert a hexadecimal string to its numeric value.
+     * For example, "A" will be converted to 10.
+     * Any input that exceedes the max value of unsigned integer will silently truncate and not be treated as an error.
+     * Any out of range error that occurs will result in the value being returned being 0.
      *
      * @param hex_string the data to convert
      *

--- a/coresdk/src/test/test_terminal.cpp
+++ b/coresdk/src/test/test_terminal.cpp
@@ -6,6 +6,7 @@
 *  Copyright © 2016 Andrew Cain. All rights reserved.
 */
 
+#include <limits>
 #include "terminal.h"
 #include "utils.h"
 #include <iostream>
@@ -142,6 +143,12 @@ void bin_to_dec()
     assert(bin_to_dec("10000000000000000000000000000000") != 2147483649);
     assert(bin_to_dec("abcde") != 2147483647);
     assert(bin_to_dec("a1b2b3i4f02") != 1234);
+
+    // Test for over 32-bits
+    assert(bin_to_dec("111111111111111111111111111111111") == std::numeric_limits<unsigned int>::max());
+
+    // Test over 64-bit limit
+    assert(bin_to_dec("11111111111111111111111111111111111111111111111111111111111111111") == std::numeric_limits<unsigned int>::max());
 
     string bin_input1 = "1111011";
     int result1 = bin_to_dec(bin_input1);
@@ -340,6 +347,12 @@ void test_oct_to_dec()
     assert(oct_to_dec("20000000000") != 2147483649);
     assert(oct_to_dec("abcde") != 2147483647);
     assert(oct_to_dec("a1b2b3i4f02") != 1234);
+
+    // Test for over 32-bit limit
+    assert(oct_to_dec("377777777777") == std::numeric_limits<unsigned int>::max());
+
+    // Test over 64-bit limit
+    assert(oct_to_dec("3777777777777777777777") == std::numeric_limits<unsigned int>::max());
 
     string oct_input1 = "173";
     int result1 = oct_to_dec(oct_input1);

--- a/coresdk/src/test/test_terminal.cpp
+++ b/coresdk/src/test/test_terminal.cpp
@@ -346,12 +346,8 @@ void test_oct_to_dec()
     assert(oct_to_dec("abcde") != 2147483647);
     assert(oct_to_dec("a1b2b3i4f02") != 1234);
 
-    // Test for over 32-bit limit
-    assert(oct_to_dec("47777777777") == std::numeric_limits<unsigned int>::max());
-    assert(oct_to_dec("40000000000") == std::numeric_limits<unsigned int>::max());
-
-    // Test over 64-bit limit
-    assert(oct_to_dec("3777777777777777777777") == std::numeric_limits<unsigned int>::max());
+    // Test over unsigned int max
+    assert(oct_to_dec("1777777777777777777777") == std::numeric_limits<unsigned int>::max());
 
     string oct_input1 = "173";
     int result1 = oct_to_dec(oct_input1);

--- a/coresdk/src/test/test_terminal.cpp
+++ b/coresdk/src/test/test_terminal.cpp
@@ -208,6 +208,59 @@ void hex_to_bin()
     write_line("-------------------------------------");
 }
 
+void hex_to_dec_tests()
+{
+    write_line("Testing hexadecimal to decimal conversion");
+
+    // Basic cases
+    assert(hex_to_dec("0") == 0);
+    assert(hex_to_dec("1") == 1);
+    assert(hex_to_dec("A") == 10);
+    assert(hex_to_dec("F") == 15);
+    assert(hex_to_dec("10") == 16);
+    assert(hex_to_dec("FF") == 255);
+    assert(hex_to_dec("100") == 256);
+    assert(hex_to_dec("ABC") == 2748);
+    assert(hex_to_dec("1234") == 4660);
+
+    // Larger hexadecimal values
+    assert(hex_to_dec("FFFF") == 65535);
+    assert(hex_to_dec("FFFFFFFF") == 4294967295);
+    assert(hex_to_dec("1FFFFFF") == 33554431);
+    assert(hex_to_dec("ABCDEF") == 11259375);
+
+    // Tests for inequality
+    assert(hex_to_dec("0") != 1);
+    assert(hex_to_dec("1") != 0);
+    assert(hex_to_dec("A") != 11);
+    assert(hex_to_dec("F") != 16);
+    assert(hex_to_dec("10") != 10);
+    assert(hex_to_dec("FF") != 256);
+    assert(hex_to_dec("100") != 255);
+    assert(hex_to_dec("ABC") != 2749);
+    assert(hex_to_dec("1234") != 4670);
+    assert(hex_to_dec("FFFF") != 100);
+    assert(hex_to_dec("FFFFFFFF") != 200);
+    assert(hex_to_dec("1FFFFFF") != 300);
+    assert(hex_to_dec("GGGGGG") != 400);
+
+	// Test over unsigned int
+    assert(hex_to_dec("100000000") == 4294967295);
+	// Test over unsigned long
+    assert(hex_to_dec("10000000000000000") == 0);
+
+    const string hex_input1 = "ABCDEF";
+    const unsigned int result1 = hex_to_dec(hex_input1);
+    write_line("ABCDEF in decimal is " + to_string(result1));
+
+    const string hex_input2 = "1234";
+    const unsigned int result2 = hex_to_dec(hex_input2);
+    write_line("1234 in decimal is " + to_string(result2));
+
+    write_line("All hexadecimal to decimal tests passed!");
+    write_line("-------------------------------------");
+}
+
 void bin_to_hex()
 {
     write_line("Testing binary to hexadecimal conversion");
@@ -893,6 +946,7 @@ void run_terminal_test()
     dec_to_bin();
     bin_to_dec();
     hex_to_bin();
+	hex_to_dec_tests();
     bin_to_hex();
     test_dec_to_oct();
     test_oct_to_dec();

--- a/coresdk/src/test/test_terminal.cpp
+++ b/coresdk/src/test/test_terminal.cpp
@@ -125,6 +125,9 @@ void bin_to_dec()
     // High values (32-bit boundaries)
     assert(bin_to_dec("10000000000000000000000000000000") == 2147483648);
 
+    // Test for over unsigned int max
+    assert(bin_to_dec("1111111111111111111111111111111111111111111111111111111111111111") == std::numeric_limits<unsigned int>::max());
+
     // Mixed bits
     assert(bin_to_dec("1111011") == 123);
     assert(bin_to_dec("10000000001") == 1025);
@@ -144,11 +147,6 @@ void bin_to_dec()
     assert(bin_to_dec("abcde") != 2147483647);
     assert(bin_to_dec("a1b2b3i4f02") != 1234);
 
-    // Test for over 32-bits
-    assert(bin_to_dec("111111111111111111111111111111111") == std::numeric_limits<unsigned int>::max());
-
-    // Test over 64-bit limit
-    assert(bin_to_dec("11111111111111111111111111111111111111111111111111111111111111111") == std::numeric_limits<unsigned int>::max());
 
     string bin_input1 = "1111011";
     int result1 = bin_to_dec(bin_input1);

--- a/coresdk/src/test/test_terminal.cpp
+++ b/coresdk/src/test/test_terminal.cpp
@@ -349,7 +349,8 @@ void test_oct_to_dec()
     assert(oct_to_dec("a1b2b3i4f02") != 1234);
 
     // Test for over 32-bit limit
-    assert(oct_to_dec("377777777777") == std::numeric_limits<unsigned int>::max());
+    assert(oct_to_dec("47777777777") == std::numeric_limits<unsigned int>::max());
+    assert(oct_to_dec("40000000000") == std::numeric_limits<unsigned int>::max());
 
     // Test over 64-bit limit
     assert(oct_to_dec("3777777777777777777777") == std::numeric_limits<unsigned int>::max());


### PR DESCRIPTION
# Description

Fixed the std::out_of_range exception that was happening in the unit tests for the functions:

- `bin_to_dec`
- `oct_to_dec`

This problem that was causing the exception to be thrown was the call to `std::stoi` in the functions above which were returning an `unsigned int`. This was resolved by changing `std::stoi` to `static_cast<unsigned int>(std::stoul(...))` to have the correct return type and avoid a `-Werror-conversion` flag. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Both sktest and skunit_tests were ran and no exceptions were thrown and no tests were failed for the two functions that were changed.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request
