### PR TITLE
Fix/msys2 test issue (original PR #132)

### DIFF
--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -283,6 +283,10 @@ add_custom_command(TARGET sktest
 add_custom_command(TARGET sktest
     PRE_BUILD COMMAND
     ${CMAKE_COMMAND} -E copy_directory "${SK_SRC}/test/Resources/" $<TARGET_FILE_DIR:sktest>)
+#Note this is what has been changed for test fix
+if (MSYS)
+	target_link_options(sktest PRIVATE -mconsole)
+endif()
 
 # if (MSYS)
 #     add_custom_command(TARGET sktest

--- a/projects/cmake/CMakeLists.txt
+++ b/projects/cmake/CMakeLists.txt
@@ -283,7 +283,7 @@ add_custom_command(TARGET sktest
 add_custom_command(TARGET sktest
     PRE_BUILD COMMAND
     ${CMAKE_COMMAND} -E copy_directory "${SK_SRC}/test/Resources/" $<TARGET_FILE_DIR:sktest>)
-#Note this is what has been changed for test fix
+#If MSYS is being used force sktest to be a console executable
 if (MSYS)
 	target_link_options(sktest PRIVATE -mconsole)
 endif()


### PR DESCRIPTION
# Description

This PR is a copy of [#132](https://github.com/thoth-tech/splashkit-core/pull/132), created by former contributor @ConnorClancyDeakin. The fix resolves an important bug when running tests in MSYS2.

The original PR had 2 approvals, however the user has deleted their account, which closed the PR (hence the need to re-raise).

## Original Description (#132)

The sktest.exe has been unable to work on the MSYS2/MINGW64 it was getting stuck in one test and wasnt giving any feedback the terminal would freeze up (if you want to simulate the error you should be able to just run the sktest in you msys2 mingW64) The change that has been provided here changes the way the test is built to be a console exectuable which has made it work on my machine.

Fixes sktest.exe not working in MSYS2/MINGW64

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

First you must be using MYSYS2/WINGW64 although it could be beneficial to check with others as well to make sure it doesnt stop anything else from working

This change can be tested by simply building and testing the program using the sktest.exe file when you do this it should let you choose any test and run them as well as exit the program. The tests should complete and bring you back to the main terminal to choose another test. Essentially you should get a terminal menu when you run the sktest.exe that you can use.

## Testing Checklist

- [x] Tested with sktest

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have requested a review from ... on the Pull Request

### Extra note

This change changes the way the sktest is built as far as I've been able to find there has been no uninteded consequences of this but I havent done a change like this before, it should only effect the sktest.exe when msys is being used but if you know more than me and think this should be different please put that in your peer review as I do not want to break things on accident. essentially please dont be afraid to be harsh.