### PR TITLE
Fixed graphics bug for Graphics test

### DIFF
--- a/coresdk/src/backend/graphics_driver.cpp
+++ b/coresdk/src/backend/graphics_driver.cpp
@@ -526,6 +526,7 @@ namespace splashkit_lib
             SDL_DestroyTexture(window_be->backing);
         }
 
+        gfxPrimitivesSetFont(nullptr, 0, 0);
         SDL_DestroyRenderer(window_be->renderer);
         SDL_DestroyWindow(window_be->window);
 


### PR DESCRIPTION
Fixed an error where the text font cache wouldn't be cleared when windows were destroyed causing graphical issues when other windows would open

# Description

Msys2 has been having issues with the graphics test whilst WSL has been fine, this change is to fix that it is done by clearing out the global font data when a window is shut so its settings wont cause issues when a new window is opened up. Note to test if you are using Msys2 you may need to implement this PR(https://github.com/thoth-tech/splashkit-core/pull/132) to be able to test it as there have been issues, this info is also on the ticket.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
To test this I opened opened up the sktests and tested the graphics about thirty times, thirty might be excessive but it is important to not that I found this error that was fixed almost never appeared on the first run and would often not appear on the second so it is important to test it at least a few times. Additionally I ran the skunit_tests to make sure nothing in there got broken with this fix.

## Testing Checklist

- [x] Tested with sktest
- [x] Tested with skunit_tests

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings